### PR TITLE
feat(dns): Cloudflare-managed DNS for futo.cloud

### DIFF
--- a/ansible/ceph/docs/s3-integration.md
+++ b/ansible/ceph/docs/s3-integration.md
@@ -214,10 +214,13 @@ s3.dev.austin.int.futo.cloud.        A  10.10.10.92
 *.s3.dev.austin.int.futo.cloud.      A  10.10.10.92
 ```
 
-Round-robin A records across all three nodes. Without these records,
-use path-style addressing or connect directly via IP.
+Round-robin A records across all three nodes.
 
-Note: this repo does not manage DNS. Coordinate with the network/DNS team.
+These records are live and managed in this repo: `tf/deployment/dev/dns/`
+(Cloudflare, futo.cloud zone). They resolve publicly but point at the
+management VLAN, so they are only routable from networks that reach
+10.10.10.0/24. To change them, edit `records.auto.tfvars` and
+`TF_STACK_DIR=tf/deployment/dev/dns mise run tf:apply`.
 
 ## Performance characteristics
 

--- a/tf/.env
+++ b/tf/.env
@@ -10,3 +10,9 @@ export OP_SERVICE_ACCOUNT_TOKEN="op://yucca_tf_dev/yucca_futo_1pass_superuser_se
 # Consumed by OpenTofu's S3 backend via standard AWS env vars.
 export AWS_ACCESS_KEY_ID="op://yucca_tf/TF_STATE_S3_ACCESS_KEY/password"
 export AWS_SECRET_ACCESS_KEY="op://yucca_tf/TF_STATE_S3_SECRET_KEY/password"
+
+# Cloudflare API token for the dns stack (futo.cloud zone; Zone:Read +
+# DNS:Edit). The cloudflare provider reads this env var directly. Lives in
+# the *_manual vault: it is a human-created token, and the yucca_tf copies
+# are duplicated (one archived) which breaks op:// title resolution.
+export CLOUDFLARE_API_TOKEN="op://yucca_tf_manual/CLOUDFLARE_API_TOKEN/password"

--- a/tf/README.md
+++ b/tf/README.md
@@ -32,14 +32,22 @@ tf/
         │   ├── versions.tf, variables.tf, main.tf
         │   ├── clusters.auto.tfvars  ← declarative cluster list (edit here to add/modify)
         │   └── .terraform.lock.hcl
-        └── talos/
+        ├── talos/
+        │   ├── terragrunt.hcl, versions.tf, variables.tf, main.tf
+        │   └── clusters.auto.tfvars  ← declarative Talos cluster list (nodes[], profile, VLANs)
+        └── dns/
             ├── terragrunt.hcl, versions.tf, variables.tf, main.tf
-            └── clusters.auto.tfvars  ← declarative Talos cluster list (nodes[], profile, VLANs)
+            └── records.auto.tfvars   ← declarative DNS records (Cloudflare, futo.cloud zone)
 ```
 
 Future envs land as siblings: `deployment/staging/ceph/`, `deployment/prod/ceph/`.
-Additional stacks land as siblings within an env — `dev/talos/` is one;
-`dev/monitoring/` could be next.
+Additional stacks land as siblings within an env — `dev/talos/` and
+`dev/dns/` are two; `dev/monitoring/` could be next.
+
+The dns stack manages infrastructure names in the futo.cloud Cloudflare
+zone (today: the Sietch RGW S3 endpoint + virtual-hosted wildcard).
+Records are declarative in `records.auto.tfvars`; the API token resolves
+from `op://yucca_tf_manual/CLOUDFLARE_API_TOKEN` via `tf/.env`.
 
 The talos stack is documented in `ansible/talos/README.md` and
 `ansible/talos/docs/runbooks/cluster-bring-up.md` (the TF + Ansible flow

--- a/tf/deployment/dev/dns/.terraform.lock.hcl
+++ b/tf/deployment/dev/dns/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:mopYISyLkUVUwMjJbuPenxIUVDrna1/7ACB1hfMfciU=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/tf/deployment/dev/dns/main.tf
+++ b/tf/deployment/dev/dns/main.tf
@@ -1,0 +1,42 @@
+# Cloudflare-managed DNS for infrastructure names under futo.cloud.
+# The provider reads CLOUDFLARE_API_TOKEN from the environment (injected
+# from 1P via tf/.env by the mise tf:* tasks); no provider arguments.
+provider "cloudflare" {}
+
+locals {
+  # One resource instance per (name, value) pair. The for_each key carries
+  # the value so adding or removing a node IP touches only that instance,
+  # never its siblings under the same name.
+  record_instances = merge([
+    for name, r in var.records : {
+      for v in r.values : "${name}/${r.type}/${v}" => {
+        name    = name
+        type    = r.type
+        content = v
+        ttl     = r.ttl
+        proxied = r.proxied
+        comment = r.comment
+      }
+    }
+  ]...)
+}
+
+resource "cloudflare_dns_record" "this" {
+  for_each = local.record_instances
+
+  zone_id = var.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  content = each.value.content
+  ttl     = each.value.ttl
+  proxied = each.value.proxied
+  comment = each.value.comment
+}
+
+output "records" {
+  description = "Managed records as name => sorted values, for quick inspection after apply."
+  value = {
+    for name, r in var.records :
+    name => sort([for k, inst in local.record_instances : inst.content if inst.name == name])
+  }
+}

--- a/tf/deployment/dev/dns/records.auto.tfvars
+++ b/tf/deployment/dev/dns/records.auto.tfvars
@@ -1,0 +1,24 @@
+# futo.cloud zone (FUTO Account).
+zone_id = "474fbfd96bf49879054a493f126c4071"
+
+# Sietch RGW S3 endpoint: round-robin A records across the 3 ceph nodes'
+# bond IPs. The addresses are RFC1918 (10.10.10.0/24 management VLAN) —
+# resolvable from anywhere, routable only from networks that reach the
+# mgmt VLAN. proxied stays false everywhere here: Cloudflare cannot proxy
+# private addresses, and these names are internal infrastructure.
+#
+# The wildcard serves S3 virtual-hosted bucket addressing
+# (<bucket>.s3.dev.austin.int.futo.cloud); the cluster's rgw_dns_name and
+# TLS SANs already expect it. See ansible/ceph/docs/s3-integration.md.
+records = {
+  "s3.dev.austin.int.futo.cloud" = {
+    type    = "A"
+    values  = ["10.10.10.90", "10.10.10.91", "10.10.10.92"]
+    comment = "Sietch RGW S3 endpoint (tf/deployment/dev/dns)"
+  }
+  "*.s3.dev.austin.int.futo.cloud" = {
+    type    = "A"
+    values  = ["10.10.10.90", "10.10.10.91", "10.10.10.92"]
+    comment = "Sietch RGW S3 virtual-hosted buckets (tf/deployment/dev/dns)"
+  }
+}

--- a/tf/deployment/dev/dns/terragrunt.hcl
+++ b/tf/deployment/dev/dns/terragrunt.hcl
@@ -1,0 +1,6 @@
+include "root" {
+  path = find_in_parent_folders("terragrunt.hcl")
+}
+
+# records.auto.tfvars is loaded automatically by OpenTofu in this directory.
+# No stack-specific inputs.

--- a/tf/deployment/dev/dns/variables.tf
+++ b/tf/deployment/dev/dns/variables.tf
@@ -1,0 +1,20 @@
+variable "zone_id" {
+  description = "Cloudflare zone ID for futo.cloud. Stable and non-secret; the API token in tf/.env authorizes access to it."
+  type        = string
+}
+
+variable "records" {
+  description = "DNS records keyed by FQDN. Each entry fans out to one cloudflare_dns_record per value, so round-robin A records are N values under one name."
+  type = map(object({
+    type    = string
+    values  = list(string)
+    ttl     = optional(number, 300)
+    proxied = optional(bool, false)
+    comment = optional(string)
+  }))
+
+  validation {
+    condition     = alltrue([for name, r in var.records : length(r.values) > 0])
+    error_message = "Every record needs at least one value."
+  }
+}

--- a/tf/deployment/dev/dns/versions.tf
+++ b/tf/deployment/dev/dns/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.11"
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
DNS records for Sietch's S3 endpoint, managed by Terraform in
tf/deployment/dev/dns. s3.dev.austin.int.futo.cloud and its wildcard
resolve to the three ceph nodes; no more /etc/hosts entries.

The cluster already expected these names, so nothing changed on the
ceph side. Verified working: public resolution, HTTP 200 from RGW
through the name, clean re-plan after apply.

Notes:

- The Cloudflare token comes from the yucca\_tf\_manual vault via tf/.env
  (the yucca\_tf copies are duplicated and fail to resolve).
- The IPs are on the management VLAN: the names resolve anywhere but
  only route from networks that can reach 10.10.10.0/24.

Docs: tf/README.md and ansible/ceph/docs/s3-integration.md.

- `main` <!-- branch-stack -->
  - \#121 :point\_left:
