### PR TITLE
fix: include `python3` in Nix flake, needed for Tilt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,7 @@ in pkgs.mkShell {
     lsof
     pkg-config
     openssl.dev
+    python3
     (writeShellScriptBin "fish" ''
       exec ${pkgs.fish}/bin/fish -C 'mise activate fish | source' "$@"
     '')


### PR DESCRIPTION
- `main` <!-- branch-stack -->
  - \#122 :point\_left:
