### PR TITLE
chore: update ansible/ceph/inventories/sietch[...]/group_vars/all/var…

### DIFF
--- a/ansible/ceph/inventories/sietch-ceph.dev.austin.int/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/sietch-ceph.dev.austin.int/group_vars/all/vars.yml
@@ -11,8 +11,8 @@ gateway: 10.10.10.1
 dns_server: 10.10.10.1
 bond_mode: active-backup
 bond_interfaces:
-  - eno1
-  - eno2
+  - eno1np0
+  - eno2np1
 networkd_enabled: true
 
 # === Ceph ===


### PR DESCRIPTION
Updated Sietch-Ceph bond\_interfaces to match the new 25G network link names:

- eno1 -> eno1np0
- eno2 -> eno2np1

* `main` <!-- branch-stack -->
  - \#140 :point\_left:
