### PR TITLE
fix(ceph): enforce dashboard admin password on every converge

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/tasks/bootstrap.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/bootstrap.yml
@@ -68,3 +68,44 @@
     # cephadm automatically distributes ceph.conf, admin keyring, and
     # its SSH key to managed hosts during `ceph orch host add`. No
     # manual capture or distribution needed.
+
+# --- Idempotent dashboard password enforcement ---
+# The bootstrap task above only sets the dashboard password on the very first
+# `cephadm bootstrap` (guarded by `not ceph_conf.stat.exists`), and
+# `--dashboard-password-noupdate` means it is never re-applied afterwards. If a
+# cluster was ever bootstrapped out-of-band (or before this var existed),
+# cephadm generated a *random* admin password and no playbook run would ever
+# correct it — the vaulted password stays aspirational. These tasks reconcile
+# the running cluster to `ceph_dashboard_password` on every converge, so the
+# vault is the single source of truth for both initial set and rotation.
+- name: Write dashboard password to temp file (reconcile)
+  ansible.builtin.copy:
+    content: "{{ ceph_dashboard_password }}"
+    dest: /tmp/.ceph-dash-reconcile-pw
+    owner: root
+    group: root
+    mode: '0600'
+  when: inventory_hostname in groups['ceph_bootstrap']
+  no_log: true
+
+- name: Enforce dashboard admin password (idempotent)
+  ansible.builtin.shell: |
+    set -o pipefail
+    ceph dashboard ac-user-set-password {{ ceph_dashboard_user }} \
+      -i /tmp/.ceph-dash-reconcile-pw --force-password-policy >/dev/null
+    rc=$?
+    shred -u /tmp/.ceph-dash-reconcile-pw 2>/dev/null || rm -f /tmp/.ceph-dash-reconcile-pw
+    exit $rc
+  args:
+    executable: /bin/bash
+  when: inventory_hostname in groups['ceph_bootstrap']
+  # ac-user-set-password always re-hashes (random bcrypt salt), so we cannot
+  # cheaply detect a real change; treat enforcement as a converge, not a change.
+  changed_when: false
+  no_log: true
+
+- name: Ensure reconcile password temp file is gone
+  ansible.builtin.file:
+    path: /tmp/.ceph-dash-reconcile-pw
+    state: absent
+  when: inventory_hostname in groups['ceph_bootstrap']

--- a/ansible/ceph/roles/ceph_deploy/tasks/verify.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/verify.yml
@@ -42,3 +42,45 @@
   ansible.builtin.debug:
     msg: "{{ cluster_status.stdout_lines }}"
   when: inventory_hostname in groups['ceph_bootstrap']
+
+# --- Drift guard: assert the live dashboard credential matches the vault ---
+# Functional check (dependency-free: no bcrypt needed). We discover the
+# dashboard URL from `ceph mgr services` and attempt an API login with the
+# vaulted credential; HTTP 201 means the cluster password matches IaC. If the
+# bootstrap reconcile task is ever removed or fails, this fails the play loudly
+# instead of letting the credential silently drift.
+- name: Probe dashboard login with the vaulted credential
+  ansible.builtin.shell: |
+    set -o pipefail
+    url=$(ceph mgr services 2>/dev/null \
+      | python3 -c 'import sys,json; print(json.load(sys.stdin).get("dashboard","").rstrip("/"))')
+    if [ -z "$url" ]; then echo "no-dashboard-url"; exit 0; fi
+    # Password travels via env + stdin only — never on the process argv.
+    code=$(python3 -c 'import json,os; print(json.dumps({"username": os.environ["DASH_U"], "password": os.environ["DASH_P"]}))' \
+      | curl -sk -m 15 -o /dev/null -w '%{http_code}' \
+          -H 'Accept: application/vnd.ceph.api.v1.0+json' \
+          -H 'Content-Type: application/json' \
+          -X POST "$url/api/auth" --data-binary @-)
+    echo "$code"
+  args:
+    executable: /bin/bash
+  environment:
+    DASH_U: "{{ ceph_dashboard_user }}"
+    DASH_P: "{{ ceph_dashboard_password }}"
+  when: inventory_hostname in groups['ceph_bootstrap']
+  register: dashboard_cred_probe
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: Assert dashboard admin credential matches the vault
+  ansible.builtin.assert:
+    that:
+      - (dashboard_cred_probe.stdout_lines | default(['']) | last) == '201'
+    success_msg: "Dashboard admin login matches the vaulted password."
+    fail_msg: >-
+      Dashboard admin credential has DRIFTED from IaC (got HTTP
+      '{{ dashboard_cred_probe.stdout_lines | default(['']) | last }}', expected 201).
+      The running cluster's password does not match ceph_dashboard_password.
+      Re-run the ceph_deploy role to reconcile, or investigate an out-of-band change.
+  when: inventory_hostname in groups['ceph_bootstrap']


### PR DESCRIPTION
## Problem

The Ceph dashboard admin password was only set during the one-time cephadm
bootstrap, guarded by `not ceph_conf.stat.exists`, with no idempotent reconcile.
A cluster bootstrapped out of band (or before this var existed) kept a random
admin password that no later playbook run would correct, so the vaulted password
drifted silently from the live cluster.

## Change

- `bootstrap.yml`: add an enforce task that sets the dashboard password from
  `ceph_dashboard_password` on every converge (`ceph dashboard
  ac-user-set-password`, password via a 0600 temp file, shred after). Runs
  outside the bootstrap guard, so it heals clusters bootstrapped out of band.
- `verify.yml`: add a drift assertion that discovers the dashboard URL from
  `ceph mgr services`, logs in with the vaulted credential, and fails the play
  on anything other than HTTP 201. Password travels via env and stdin only.

## Validation

- ansible-lint clean (production profile); `ansible-playbook --syntax-check`
  passes for deploy-ceph.yml and site.yml.
- Ran `scripts/ansible-play.sh deploy-ceph.yml --tags verify --limit laurel`
  against dev (sietch): assertion passed ("Dashboard admin login matches the
  vaulted password"), play recap ok=5 changed=0 failed=0.

Generated with Claude Code (<https://claude.com/claude-code>)

- `main` <!-- branch-stack -->
  - \#154 :point\_left:
