### PR TITLE
fix(ceph): open cephadm service discovery port 8765 in firewall

### DIFF
--- a/ansible/ceph/roles/security/defaults/main.yml
+++ b/ansible/ceph/roles/security/defaults/main.yml
@@ -23,6 +23,11 @@ ceph_firewall_alertmanager_port: "{{ ceph_alertmanager_port | default(9093) }}"
 ceph_firewall_node_exporter_port: 9100
 ceph_firewall_mgr_exporter_port: 9283
 ceph_firewall_ceph_exporter_port: 9926
+# cephadm service discovery (mgr). Prometheus fetches its scrape target list
+# from this endpoint on the active mgr via http_sd. If it is not reachable from
+# the Prometheus host, Prometheus discovers zero targets and Grafana shows no
+# data. The active mgr can be any node, so this must be open on all of them.
+ceph_firewall_service_discovery_port: 8765
 
 # --- Optional service gateways (disabled by default) ---
 

--- a/ansible/ceph/roles/security/templates/nftables.conf.j2
+++ b/ansible/ceph/roles/security/templates/nftables.conf.j2
@@ -52,6 +52,7 @@ table inet filter {
         ip saddr {{ net }} tcp dport {{ ceph_firewall_node_exporter_port }} accept
         ip saddr {{ net }} tcp dport {{ ceph_firewall_mgr_exporter_port }} accept
         ip saddr {{ net }} tcp dport {{ ceph_firewall_ceph_exporter_port }} accept
+        ip saddr {{ net }} tcp dport {{ ceph_firewall_service_discovery_port }} accept
 {% if ceph_firewall_iscsi_enabled | bool %}
 
         # iSCSI gateway


### PR DESCRIPTION
## Problem

Grafana at <https://10.10.10.90:3000> showed no data. The cause was upstream of
Grafana: Prometheus had zero scrape targets.

cephadm wires Prometheus to discover its targets via http\_sd against the mgr
service discovery endpoint (`http://<active-mgr>:8765/sd/prometheus/...`). The
security role's nftables allowlist opened every monitoring port (9095, 3000,
9093, 9100, 9283, 9926, 8443) but not 8765, and the chain policy is drop. So
Prometheus on laurel could not reach the SD endpoint on the active mgr
(returned http\_code 000), discovered zero targets, and Grafana had nothing to
query.

## Change

- Add `ceph_firewall_service_discovery_port` (8765) to the security role
  defaults.
- Open it in the nftables template alongside the other monitoring ports.

The active mgr can be any node, so the port is opened on all of them.

## Applied and verified on sietch (dev)

Ran `harden.yml` on all three nodes (nftables changed and reloaded, SSH
unchanged, 0 failed). After the change:

- SD endpoint from the Prometheus host: `10.10.10.91:8765 -> 200` (was 000).
- Prometheus active targets: 7, all up (was 0).
- `ceph_health_status` returns data (value 0, HEALTH\_OK).

Generated with Claude Code (<https://claude.com/claude-code>)

- `main` <!-- branch-stack -->
  - \#156 :point\_left:
