### PR TITLE
fix(ceph): enforce Grafana admin login password from the vault

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -93,13 +93,49 @@
 
 # --- Step 4: Set Grafana admin credentials ---
 
+# The Grafana admin LOGIN password is seeded by cephadm only at first deploy,
+# and nothing reconciled it, so it drifted from the vault. That broke both
+# direct login at :3000 and the dashboard Grafana API calls below (which
+# authenticate as this same admin user). Enforce it from the vault on every
+# converge. reset-admin-password writes Grafana's sqlite DB on the host volume,
+# so the change persists across container restarts and redeploys.
+- name: Find Grafana container
+  ansible.builtin.shell: >
+    set -o pipefail;
+    podman ps --filter name=-grafana- {% raw %}--format '{{ .Names }}'{% endraw %} | head -1
+  args:
+    executable: /bin/bash
+  register: grafana_container
+  changed_when: false
+  when: inventory_hostname in groups['ceph_bootstrap']
+  tags: [grafana_admin_password]
+
+- name: Enforce Grafana admin login password
+  ansible.builtin.shell: |
+    set -o pipefail
+    printf '%s' "$GF_ADMIN_PW" \
+      | podman exec -i "$GF_CONTAINER" \
+          grafana cli --homepath /usr/share/grafana --config /etc/grafana/grafana.ini \
+          admin reset-admin-password --password-from-stdin
+  args:
+    executable: /bin/bash
+  environment:
+    GF_ADMIN_PW: "{{ ceph_grafana_admin_password }}"
+    GF_CONTAINER: "{{ grafana_container.stdout }}"
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - grafana_container.stdout | default('') | length > 0
+  changed_when: false
+  no_log: true
+  tags: [grafana_admin_password]
+
 - name: Set Grafana admin user
   ansible.builtin.command: >
     ceph dashboard set-grafana-api-username {{ ceph_grafana_admin_user }}
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-- name: Set Grafana admin password
+- name: Set dashboard Grafana API password
   ansible.builtin.shell: |
     set -o pipefail
     echo '{{ ceph_grafana_admin_password }}' \


### PR DESCRIPTION
## Problem

Login at <https://10.10.10.90:3000/login> failed for `admin` with the vaulted
password (HTTP 401). Grafana itself was healthy (/api/health 200).

cephadm seeds the Grafana admin login password only at first deploy. The role
never reconciled it, so the live password drifted from
`SIETCH_CEPH_GRAFANA_PASSWORD`. The existing "Set Grafana admin password" task
was misleading: it only ran `ceph dashboard set-grafana-api-password`, which
sets the credential the ceph dashboard uses to call Grafana's API, not the
Grafana admin login. The 1Password copies in Yucca and yucca\_tf\_dev were
identical, so this was drift between the cluster and the vault, not a vault
problem.

## Change

- Add an idempotent reconcile that resets the Grafana admin password to
  `ceph_grafana_admin_password` on every converge, via `grafana cli
  reset-admin-password --password-from-stdin` inside the grafana container. It
  writes Grafana's sqlite DB on the host volume, so it persists across container
  restarts and redeploys. Password travels via env and stdin, never on argv.
- Rename the existing task to "Set dashboard Grafana API password" to reflect
  what it actually does.

## Fixed and verified on sietch (dev)

- Reset the live password to the vault value; `POST /login` now returns 200.
- Ran the new tasks through the playbook
  (`deploy-ceph.yml --tags grafana_admin_password`): found the container,
  enforced the password, 0 failed. Login still 200 afterward.
- ansible-lint clean (production profile), syntax-check passes.

Generated with Claude Code (<https://claude.com/claude-code>)

- `main` <!-- branch-stack -->
  - \#157 :point\_left:
