### PR TITLE
feat(k8s): cut michael over to the staging RGW endpoint

### DIFF
--- a/kubernetes/apps/base/michael/helmrelease.yaml
+++ b/kubernetes/apps/base/michael/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
     hostAliases:
       - ip: ${RGW_HAPROXY_CLUSTER_IP}
         hostnames:
-          - s3.dev.austin.int.futo.cloud
+          - s3.staging.austin.int.futo.cloud
     # Full replacement of the chart's dev env: no Rook secretKeyRefs (S3 creds
     # arrive via envFrom from the TF Secret), real RGW endpoint, OTLP to the
     # in-cluster agents (vmagent metrics, Vector logs).
@@ -44,7 +44,7 @@ spec:
       - name: LOG_LEVEL
         value: info
       - name: S3_ENDPOINT
-        value: http://s3.dev.austin.int.futo.cloud
+        value: http://s3.staging.austin.int.futo.cloud
       - name: S3_REGION
         value: us-east-1
       - name: S3_FORCE_PATH_STYLE

--- a/kubernetes/apps/base/rgw-haproxy/configmap.yaml
+++ b/kubernetes/apps/base/rgw-haproxy/configmap.yaml
@@ -9,7 +9,7 @@
 #
 # Why the Host header is preserved: RGW validates the S3 signature against the
 # request Host and rejects any host not in its zonegroup hostnames list. michael
-# signs with `s3.dev.austin.int.futo.cloud` (which IS in that list) and reaches
+# signs with `s3.staging.austin.int.futo.cloud` (which IS in that list) and reaches
 # this proxy via a hostAlias (see the michael HelmRelease), so the original Host
 # flows through unchanged and signatures validate.
 apiVersion: v1

--- a/kubernetes/apps/base/rgw-haproxy/service.yaml
+++ b/kubernetes/apps/base/rgw-haproxy/service.yaml
@@ -1,6 +1,6 @@
 ---
 # Pinned ClusterIP so michael's pod can pin a hostAlias
-# (s3.dev.austin.int.futo.cloud -> this IP) and keep signing with the real RGW
+# (s3.staging.austin.int.futo.cloud -> this IP) and keep signing with the real RGW
 # hostname. The value is set per-env in cluster-settings (RGW_HAPROXY_CLUSTER_IP)
 # and MUST fall inside the cluster's Service CIDR and be otherwise unallocated.
 apiVersion: v1

--- a/kubernetes/clusters/staging/cluster-settings.yaml
+++ b/kubernetes/clusters/staging/cluster-settings.yaml
@@ -29,7 +29,7 @@ data:
 
   # ─── RGW (object storage via in-cluster HAProxy) ─────────────────────
   # Pinned ClusterIP for the rgw-haproxy Service; michael pins a hostAlias
-  # (s3.dev.austin.int.futo.cloud -> this IP). MUST be inside the Service CIDR
+  # (s3.staging.austin.int.futo.cloud -> this IP). MUST be inside the Service CIDR
   # and otherwise unallocated. Talos default Service CIDR is 10.96.0.0/12.
   RGW_HAPROXY_CLUSTER_IP: 10.96.0.253
 


### PR DESCRIPTION
DRAFT -- do not merge until the staging sietch cluster is deployed and s3.staging.austin.int.futo.cloud resolves (PR #167). Merging earlier points michael at an endpoint that does not exist yet.

michael (restic backup) reaches the sietch RGW at s3.staging.austin.int.futo.cloud instead of s3.dev: the hostAlias hostname and S3\_ENDPOINT move to the staging name, which the rebuilt RGW advertises in its zonegroup hostnames (rgw\_dns\_name) so SigV4 signatures still validate. The in-cluster HAProxy and its backends (10.10.10.90-92) are unchanged -- only the signing/endpoint hostname moves. The three comment-only references are updated to match. See ansible/ceph/docs/s3-integration.md.

- `main` <!-- branch-stack -->
  - \#168 :point\_left:
