### PR TITLE
feat(ceph): support per-cluster baseline packages

### DIFF
--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/group_vars/all/vars.yml
@@ -24,6 +24,17 @@ ceph_repo_key_url: "https://download.ceph.com/keys/release.asc"
 admin_user: ansible-iac
 timezone: UTC
 
+# Cluster-specific packages, merged with the baseline role's universal
+# baseline_diag_packages. These match sietch's hardware: Mellanox ConnectX 25G
+# NICs (eno1np0/eno2np1) and SAS-expander drive enclosures. A different cluster
+# declares its own set (or none).
+baseline_extra_packages:
+  - lldpd       # LLDP neighbor/switch discovery on the 25G fabric
+  - mstflint    # Mellanox ConnectX firmware query/update
+  - tcpdump     # packet capture for network debugging
+  - ledmon      # SAS enclosure drive-fault LEDs (ledctl)
+  - sg3-utils   # SCSI enclosure management (sg_ses)
+
 # Deploy keypair path on the controller. Both {path} and {path}.pub must
 # exist before running provision.yml (the preflight play in provision.yml
 # enforces this). ansible-iac's authorized_keys on every node is populated

--- a/ansible/ceph/roles/baseline/defaults/main.yml
+++ b/ansible/ceph/roles/baseline/defaults/main.yml
@@ -42,6 +42,13 @@ baseline_diag_packages:
   - bsdmainutils
   - python3-boto3
 
+# Per-cluster hardware/site-specific packages, merged with baseline_diag_packages
+# at install time. Default empty so the role stays hardware-agnostic; each
+# cluster declares its own set in inventories/<cluster>/group_vars/all/vars.yml
+# (e.g. sietch's Mellanox + SAS-enclosure tools). A different cluster (spice,
+# ...) sets its own list or leaves it empty.
+baseline_extra_packages: []
+
 # --- Services ---
 baseline_enable_services:
   - dbus

--- a/ansible/ceph/roles/baseline/tasks/packages.yml
+++ b/ansible/ceph/roles/baseline/tasks/packages.yml
@@ -12,7 +12,7 @@
     name: "{{ baseline_podman_packages }}"
     state: present
 
-- name: Install diagnostic and ops packages
+- name: Install diagnostic and ops packages (universal + per-cluster)
   ansible.builtin.apt:
-    name: "{{ baseline_diag_packages }}"
+    name: "{{ baseline_diag_packages + baseline_extra_packages }}"
     state: present


### PR DESCRIPTION
The baseline role now installs a universal diag/ops set plus a per-cluster baseline\_extra\_packages list (default empty), so cluster-specific hardware tooling no longer leaks into the role. sietch's staging inventory declares its own: lldpd, mstflint, tcpdump (Mellanox ConnectX 25G fabric) and ledmon, sg3-utils (SAS-expander drive enclosures) -- packages that were hand-installed on the live dev nodes and would otherwise be lost on the reimage. A different cluster (spice, ...) sets its own list or leaves it empty. See ansible/ceph/inventories/<cluster>/group\_vars/all/vars.yml and roles/baseline/defaults/main.yml.

- `main` <!-- branch-stack -->
  - \#169 :point\_left:
