### PR TITLE
chore(ceph): record sietch node Dell service tags

### DIFF
--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-laurel.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-laurel.yml
@@ -2,6 +2,12 @@
 hostname_short: sietch-ceph-laurel
 bond_ip: 10.10.10.90
 
+# Dell service tag (PowerEdge R730xd chassis identity). chassis-asset-tag is
+# unset in BIOS, so the service tag is the durable per-box identifier. Captured
+# 2026-06-25; cross-check before a (re)image alongside sas_path_prefix + SSD
+# serials: `ssh sietch-ceph-laurel-idrac` or `dmidecode -s system-serial-number`.
+dell_service_tag: 1LPFJH2
+
 # SAS expander base path (unique per chassis — different backplane address per node)
 sas_path_prefix: "pci-0000:02:00.0-sas-exp0x500056b3fcf498ff"
 

--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-lawson.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-lawson.yml
@@ -2,6 +2,10 @@
 hostname_short: sietch-ceph-lawson
 bond_ip: 10.10.10.91
 
+# Dell service tag (PowerEdge R730xd chassis identity; chassis-asset-tag unset
+# in BIOS). Captured 2026-06-25; cross-check before a (re)image.
+dell_service_tag: 4KBFJH2
+
 # SAS expander base path (unique per chassis — different backplane address per node)
 sas_path_prefix: "pci-0000:02:00.0-sas-exp0x500056b35be6b4ff"
 

--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-samara.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-samara.yml
@@ -2,6 +2,10 @@
 hostname_short: sietch-ceph-samara
 bond_ip: 10.10.10.92
 
+# Dell service tag (PowerEdge R730xd chassis identity; chassis-asset-tag unset
+# in BIOS). Captured 2026-06-25; cross-check before a (re)image.
+dell_service_tag: 6YHQXK2
+
 # SAS expander base path (unique per chassis — different backplane address per node)
 sas_path_prefix: "pci-0000:02:00.0-sas-exp0x500056b3393ba1ff"
 


### PR DESCRIPTION
Recorded the sietch nodes' Dell service tags (captured during the 2026-06-25 staging reimage) as a host\_vars field, so future reprovisions can validate the physical box directly instead of inferring from SAS expander + SSD serials. chassis-asset-tag is unset in BIOS on all three, so the service tag is the durable per-box identifier.

- sietch-ceph-laurel: 1LPFJH2
- sietch-ceph-lawson: 4KBFJH2
- sietch-ceph-samara: 6YHQXK2

* `main` <!-- branch-stack -->
  - \#175 :point\_left:
