### PR TITLE
fix(ceph): use --force-password for dashboard password on Tentacle

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/tasks/bootstrap.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/bootstrap.yml
@@ -92,7 +92,7 @@
   ansible.builtin.shell: |
     set -o pipefail
     ceph dashboard ac-user-set-password {{ ceph_dashboard_user }} \
-      -i /tmp/.ceph-dash-reconcile-pw --force-password-policy >/dev/null
+      -i /tmp/.ceph-dash-reconcile-pw --force-password >/dev/null
     rc=$?
     shred -u /tmp/.ceph-dash-reconcile-pw 2>/dev/null || rm -f /tmp/.ceph-dash-reconcile-pw
     exit $rc


### PR DESCRIPTION
The dashboard password reconcile in bootstrap.yml used `ceph dashboard ac-user-set-password ... --force-password-policy`, which Tentacle (v20) rejects with "Unexpected argument" -- the flag is `--force-password`. The task runs only on the bootstrap node, so its failure marked that host failed and knocked out the subsequent host-join step, leaving lawson/samara out of cephadm and failing OSD apply with "Unknown hosts". This was latent because earlier testing exercised the verify-side HTTP assertion, not this bootstrap CLI task. Fixed the flag.

- `main` <!-- branch-stack -->
  - \#178 :point\_left:
