### PR TITLE
fix(ceph): harden deploy-ceph for from-scratch reimage

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/tasks/crush-rules.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/crush-rules.yml
@@ -8,12 +8,23 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
+# Only create a device-class rule for classes that actually exist -- otherwise
+# `create-replicated ... host <class>` fails with "device class does not
+# exist". This makes the role robust to HDD-only clusters (no SSD OSDs) as well
+# as SSD-inclusive ones.
+- name: List CRUSH device classes
+  ansible.builtin.command: ceph osd crush class ls
+  register: crush_classes
+  when: inventory_hostname in groups['ceph_bootstrap']
+  changed_when: false
+
 - name: Create replicated_hdd CRUSH rule
   ansible.builtin.command: >
     ceph osd crush rule create-replicated replicated_hdd default host hdd
   when:
     - inventory_hostname in groups['ceph_bootstrap']
     - "'replicated_hdd' not in crush_rules.stdout"
+    - "'hdd' in (crush_classes.stdout | default(''))"
   changed_when: true
 
 - name: Create replicated_ssd CRUSH rule
@@ -22,6 +33,7 @@
   when:
     - inventory_hostname in groups['ceph_bootstrap']
     - "'replicated_ssd' not in crush_rules.stdout"
+    - "'ssd' in (crush_classes.stdout | default(''))"
   changed_when: true
 
 - name: Show CRUSH rules

--- a/ansible/ceph/roles/ceph_deploy/tasks/join.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/join.yml
@@ -13,6 +13,27 @@
          | list }}
   when: inventory_hostname in groups['ceph_bootstrap']
 
+# cephadm adds hosts by SSHing to root@<addr> with the cluster key it generated
+# at bootstrap (/etc/ceph/ceph.pub). On a fresh install that key is not yet in
+# the join nodes' root authorized_keys, so `ceph orch host add` fails with
+# "Permission denied". Distribute it here (ansible connects as ansible-iac and
+# becomes root) before adding the hosts.
+- name: Get cephadm cluster SSH pubkey from the bootstrap node
+  ansible.builtin.command: ceph cephadm get-pub-key
+  delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+  run_once: true
+  become: true
+  register: cephadm_cluster_pubkey
+  changed_when: false
+
+- name: Authorize the cephadm pubkey for root on the join nodes
+  ansible.posix.authorized_key:
+    user: root
+    key: "{{ cephadm_cluster_pubkey.stdout }}"
+    state: present
+  become: true
+  when: inventory_hostname in groups['ceph_join']
+
 - name: Verify cephadm SSH to join nodes
   ansible.builtin.shell: |
     set -euo pipefail

--- a/ansible/ceph/roles/ceph_deploy/tasks/osds.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/osds.yml
@@ -63,7 +63,7 @@
         | map('length') | sum
     }}
     echo "Expecting $EXPECTED OSDs total across the cluster"
-    for i in $(seq 1 90); do
+    for i in $(seq 1 180); do
       ACTUAL=$(ceph osd stat --format json 2>/dev/null \
         | python3 -c "import sys, json; print(json.load(sys.stdin).get('num_osds', 0))" \
         2>/dev/null || echo 0)
@@ -74,19 +74,19 @@
       fi
       sleep 10
     done
-    echo "WARNING: only $ACTUAL of $EXPECTED OSDs provisioned after 15 minutes"
+    echo "WARNING: only $ACTUAL of $EXPECTED OSDs provisioned after 30 minutes"
     exit 1
   args:
     executable: /bin/bash
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
   run_once: true
   changed_when: false
-  timeout: 960
+  timeout: 1920
 
 - name: Wait for OSDs to come up
   ansible.builtin.shell: |
     set -o pipefail
-    for i in $(seq 1 90); do
+    for i in $(seq 1 180); do
       up=$(ceph osd stat --format json 2>/dev/null |
         python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('num_up_osds',0))" \
         2>/dev/null || echo 0)
@@ -99,14 +99,14 @@
       fi
       sleep 10
     done
-    echo "WARNING: Not all OSDs up after 15 minutes"
+    echo "WARNING: Not all OSDs up after 30 minutes"
     exit 1
   args:
     executable: /bin/bash
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
   run_once: true
   changed_when: false
-  timeout: 960
+  timeout: 1920
 
 # Safety net: if any OSD comes up with reweight=0 (rare with orch apply,
 # but possible if a noin flag was set externally before this run), fix it.


### PR DESCRIPTION
deploy-ceph.yml carried three latent assumptions that only surface on a clean from-scratch reimage (the dev cluster was assembled incrementally over time), all found bringing up the rebuilt staging cluster:

- join.yml: distribute the cephadm cluster pubkey (/etc/ceph/ceph.pub) to root's authorized\_keys on the join nodes before `ceph orch host add`. cephadm SSHes to root\@node with that key; on a fresh install it isn't there yet, so host-add failed "Permission denied" and the OSD apply then hit "Unknown hosts".
- crush-rules.yml: gate the replicated\_hdd / replicated\_ssd rule creation on the device class actually existing (ceph osd crush class ls). An HDD-only cluster otherwise fails with "device class ssd does not exist".
- osds.yml: raise the OSD provision + up waits from 15 to 30 minutes. A cold 36-OSD dmcrypt build can exceed 15 min; the timeout cascaded to skip RGW.

Validated end to end by a clean staging deploy: HEALTH\_OK, 36 OSDs up, RGW staging-z1, all pools active+clean. The dashboard --force-password flag (the fourth such fix) landed separately in #178.

- `main` <!-- branch-stack -->
  - \#183 :point\_left:
