### PR TITLE
feat(ceph): add LV-based SSD OSD tier for sietch

### DIFF
--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-laurel.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-laurel.yml
@@ -18,6 +18,8 @@ ssd2_phy: 13    # serial 17321A07CFEE
 # LVM VGs on SSD partition 5
 ceph_db_vg1: ceph-db-rear12   # VG on SSD1 (phy12) partition 5
 ceph_db_vg2: ceph-db-rear13   # VG on SSD2 (phy13) partition 5
+ceph_ssd_vg1: ceph-ssd-rear12  # VG on SSD1 (phy12) partition 6 -- SSD OSD data
+ceph_ssd_vg2: ceph-ssd-rear13  # VG on SSD2 (phy13) partition 6 -- SSD OSD data
 
 # HDD OSD mappings: PHY slot -> block.db LV
 # PHY 0-5 -> SSD1 (ceph-db-rear12/db-slot0..5)
@@ -52,7 +54,5 @@ ceph_hdd_osds:
 
 # SSD OSD partitions (partition 6 on each rear SSD, no separate block.db)
 ceph_ssd_osds:
-  - path_phy: phy12
-    partition: 6
-  - path_phy: phy13
-    partition: 6
+  - lv: ceph-ssd-rear12/osd-ssd   # SSD1 part6 (phy12) -> ceph_ssd_vg1
+  - lv: ceph-ssd-rear13/osd-ssd   # SSD2 part6 (phy13) -> ceph_ssd_vg2

--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-lawson.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-lawson.yml
@@ -16,6 +16,8 @@ ssd2_phy: 13    # serial 17251B44C4D8
 # LVM VGs on SSD partition 5
 ceph_db_vg1: ceph-db-rear12   # VG on SSD1 (phy12) partition 5
 ceph_db_vg2: ceph-db-rear13   # VG on SSD2 (phy13) partition 5
+ceph_ssd_vg1: ceph-ssd-rear12  # VG on SSD1 (phy12) partition 6 -- SSD OSD data
+ceph_ssd_vg2: ceph-ssd-rear13  # VG on SSD2 (phy13) partition 6 -- SSD OSD data
 
 # HDD OSD mappings: PHY slot -> block.db LV
 # PHY 0-5 -> SSD1 (ceph-db-rear12/db-slot0..5)
@@ -50,7 +52,5 @@ ceph_hdd_osds:
 
 # SSD OSD partitions (partition 6 on each rear SSD, no separate block.db)
 ceph_ssd_osds:
-  - path_phy: phy12
-    partition: 6
-  - path_phy: phy13
-    partition: 6
+  - lv: ceph-ssd-rear12/osd-ssd   # SSD1 part6 (phy12) -> ceph_ssd_vg1
+  - lv: ceph-ssd-rear13/osd-ssd   # SSD2 part6 (phy13) -> ceph_ssd_vg2

--- a/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-samara.yml
+++ b/ansible/ceph/inventories/sietch-ceph.staging.austin.int/host_vars/sietch-ceph-samara.yml
@@ -16,6 +16,8 @@ ssd2_phy: 13    # serial 17251B44DF51
 # LVM VGs on SSD partition 5
 ceph_db_vg1: ceph-db-rear12   # VG on SSD1 (phy12) partition 5
 ceph_db_vg2: ceph-db-rear13   # VG on SSD2 (phy13) partition 5
+ceph_ssd_vg1: ceph-ssd-rear12  # VG on SSD1 (phy12) partition 6 -- SSD OSD data
+ceph_ssd_vg2: ceph-ssd-rear13  # VG on SSD2 (phy13) partition 6 -- SSD OSD data
 
 # HDD OSD mappings: PHY slot -> block.db LV
 # PHY 0-5 -> SSD1 (ceph-db-rear12/db-slot0..5)
@@ -50,7 +52,5 @@ ceph_hdd_osds:
 
 # SSD OSD partitions (partition 6 on each rear SSD, no separate block.db)
 ceph_ssd_osds:
-  - path_phy: phy12
-    partition: 6
-  - path_phy: phy13
-    partition: 6
+  - lv: ceph-ssd-rear12/osd-ssd   # SSD1 part6 (phy12) -> ceph_ssd_vg1
+  - lv: ceph-ssd-rear13/osd-ssd   # SSD2 part6 (phy13) -> ceph_ssd_vg2

--- a/ansible/ceph/roles/ceph_deploy/tasks/lvm-setup.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/lvm-setup.yml
@@ -100,6 +100,68 @@
       register: vg2_lv_results
       changed_when: "'already exists' not in (vg2_lv_results.stdout | default(''))"
 
+    # --- SSD OSD data LVs (partition 6) ---
+    # part6 of each SSD is the SSD-class OSD data device. cephadm cannot deploy
+    # an OSD on a bare partition (only a whole disk or an LV), so wrap each
+    # part6 in its own VG + a 100%FREE LV that ceph_ssd_osds references as
+    # `<vg>/osd-ssd`. Gated on ceph_ssd_vg1/2: clusters that want no SSD tier
+    # simply omit those vars and these tasks no-op.
+    - name: Check if SSD OSD VG1 exists
+      ansible.builtin.shell: vgs {{ ceph_ssd_vg1 }} 2>/dev/null
+      register: ssd_vg1_check
+      changed_when: false
+      failed_when: false
+      when: ceph_ssd_vg1 is defined
+
+    - name: Check if SSD OSD VG2 exists
+      ansible.builtin.shell: vgs {{ ceph_ssd_vg2 }} 2>/dev/null
+      register: ssd_vg2_check
+      changed_when: false
+      failed_when: false
+      when: ceph_ssd_vg2 is defined
+
+    - name: Create PV and VG on SSD1 partition 6 (SSD OSD)
+      ansible.builtin.shell: |
+        PART="{{ ssd1_dev.stdout }}6"
+        wipefs -af "$PART"
+        pvcreate -f "$PART" && vgcreate {{ ceph_ssd_vg1 }} "$PART"
+      when:
+        - ceph_ssd_vg1 is defined
+        - ssd_vg1_check.rc | default(1) != 0
+      changed_when: true
+
+    - name: Create PV and VG on SSD2 partition 6 (SSD OSD)
+      ansible.builtin.shell: |
+        PART="{{ ssd2_dev.stdout }}6"
+        wipefs -af "$PART"
+        pvcreate -f "$PART" && vgcreate {{ ceph_ssd_vg2 }} "$PART"
+      when:
+        - ceph_ssd_vg2 is defined
+        - ssd_vg2_check.rc | default(1) != 0
+      changed_when: true
+
+    - name: Create SSD OSD LV on VG1 (100%FREE)
+      ansible.builtin.shell: |
+        if lvs {{ ceph_ssd_vg1 }}/osd-ssd 2>/dev/null; then
+          echo "osd-ssd already exists"
+        else
+          lvcreate --yes -Wy -l 100%FREE -n osd-ssd {{ ceph_ssd_vg1 }}
+        fi
+      register: ssd_lv1_result
+      changed_when: "'already exists' not in (ssd_lv1_result.stdout | default(''))"
+      when: ceph_ssd_vg1 is defined
+
+    - name: Create SSD OSD LV on VG2 (100%FREE)
+      ansible.builtin.shell: |
+        if lvs {{ ceph_ssd_vg2 }}/osd-ssd 2>/dev/null; then
+          echo "osd-ssd already exists"
+        else
+          lvcreate --yes -Wy -l 100%FREE -n osd-ssd {{ ceph_ssd_vg2 }}
+        fi
+      register: ssd_lv2_result
+      changed_when: "'already exists' not in (ssd_lv2_result.stdout | default(''))"
+      when: ceph_ssd_vg2 is defined
+
     - name: Verify LVM setup
       ansible.builtin.command: lvs -o lv_name,vg_name,lv_size --noheadings
       register: lvm_state


### PR DESCRIPTION
sietch gets a standalone SSD OSD tier (6 OSDs, ssd device class, replicated\_ssd CRUSH rule, 12 TiB) for future independent workloads -- not wired into RGW. cephadm cannot deploy an OSD on a bare partition, so lvm-setup wraps each SSD's part6 (2 TB) in its own VG (ceph\_ssd\_vg1/2 = ceph-ssd-rear12/13) plus a 100%FREE LV (osd-ssd), and ceph\_ssd\_osds references those LVs -- the painbox-shape path the osd-spec template already supports. The replicated\_ssd rule auto-creates once the ssd class exists (per the crush-class gating that landed in #183). No existing pool is moved; future workloads create their own pools on replicated\_ssd. Applied to staging: 42/42 OSDs up, HEALTH\_OK, 12 TiB SSD capacity. Gated on ceph\_ssd\_vg1/2 so clusters without an SSD tier no-op. See ansible/ceph/roles/ceph\_deploy/tasks/lvm-setup.yml.

- `main` <!-- branch-stack -->
  - \#184 :point\_left:
