### PR TITLE
feat(k8s): point michael at the staging RGW endpoint

### DIFF
--- a/kubernetes/apps/base/michael/helmrelease.yaml
+++ b/kubernetes/apps/base/michael/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
       - name: LOG_LEVEL
         value: info
       - name: S3_ENDPOINT
-        value: https://s3.dev.austin.int.futo.cloud
+        value: https://s3.staging.austin.int.futo.cloud
       - name: S3_REGION
         value: us-east-1
       - name: S3_FORCE_PATH_STYLE
@@ -43,7 +43,7 @@ spec:
       - name: S3_BACKEND_SOURCE
         value: dns
       - name: S3_BACKEND_DNS_HOST
-        value: s3.dev.austin.int.futo.cloud
+        value: s3.staging.austin.int.futo.cloud
       - name: S3_BACKEND_SCHEME
         value: https
       - name: S3_BACKEND_PORT


### PR DESCRIPTION
michael (restic backup) now targets the staging Sietch RGW instead of dev: S3\_ENDPOINT and S3\_BACKEND\_DNS\_HOST move from s3.dev.austin.int.futo.cloud to s3.staging.austin.int.futo.cloud. michael resolves that DNS host to the three RGW nodes (round-robin A, already live) and load-balances across them directly over HTTPS with S3\_TLS\_SKIP\_VERIFY (the rgw-haproxy front was removed upstream). The staging RGW zonegroup already lists s3.staging.austin.int.futo.cloud in its hostnames, so SigV4 host validation passes; the svc-yucca-restic S3 user and its keys (read from yucca\_tf\_staging) match. The restic repo starts empty by design (clean dev->staging break). Supersedes the now-obsolete #168 (which targeted the removed haproxy architecture).

- `main` <!-- branch-stack -->
  - \#185 :point\_left:
