### PR TITLE
docs(ceph): repoint example refs from dev to staging

### DIFF
--- a/ansible/ceph/CONTRIBUTING.md
+++ b/ansible/ceph/CONTRIBUTING.md
@@ -59,8 +59,8 @@ mise trust
 mise run setup
 
 # Render cluster inventories + secrets templates (run once, or after any
-# change to tf/deployment/dev/ceph/clusters.auto.tfvars)
-cd ../../tf/deployment/dev/ceph && tofu init && tofu apply && cd -
+# change to tf/deployment/staging/ceph/clusters.auto.tfvars)
+cd ../../tf/deployment/staging/ceph && tofu init && tofu apply && cd -
 ```
 
 This runs:
@@ -83,7 +83,7 @@ It points to an **inventory file** (not a directory):
 
 ```bash
 # Inline prefix — required for `mise run` invocations:
-CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory.ini mise run preflight
+CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory.ini mise run preflight
 CEPH_ENV=inventories/painbox-ceph.dev.hel.htz/inventory.ini   mise run status
 ```
 
@@ -107,7 +107,7 @@ CEPH_ENV=$CE mise run deploy
 Calling scripts directly (e.g., `scripts/preflight.sh`) DOES respect
 shell `export` — it's only the `mise run` path that filters the env.
 
-Cluster identity is declared in `tf/deployment/dev/ceph/clusters.auto.tfvars`
+Cluster identity is declared in `tf/deployment/staging/ceph/clusters.auto.tfvars`
 (keyed by short cluster name). TF renders the directory name, inventory
 file, and secrets template from that entry. `CEPH_ENV` is just a pointer
 to the rendered inventory file; wrappers like `scripts/ansible-play.sh`
@@ -115,9 +115,9 @@ and the `destroy` mise task extract the cluster name from its path for
 convenience:
 
 ```
-CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory.ini
+CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory.ini
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                     inventory dir = sietch-ceph.dev.austin.int   (rendered by TF)
+                     inventory dir = sietch-ceph.staging.austin.int   (rendered by TF)
                      cluster name  = sietch                       (map key in clusters.auto.tfvars)
                      domain        = dev.austin.int.futo.cloud    (domain field in tfvars)
 ```
@@ -159,7 +159,7 @@ mise run tf:apply
 ```
 
 Re-renders `inventory.ini` and `secrets.yml.tpl` for every cluster declared
-in `tf/deployment/dev/ceph/clusters.auto.tfvars`. Required after any cluster-
+in `tf/deployment/staging/ceph/clusters.auto.tfvars`. Required after any cluster-
 spec edit.
 
 ### 5. Dry-run against real nodes
@@ -338,7 +338,7 @@ scripts/ansible-play.sh deploy-ceph.yml --tags bootstrap
 | `destroy` | `mise run destroy` | Destroy cluster (interactive confirmation) |
 
 Inventory rendering and secret-item management are TF responsibilities
-— `tofu apply` in `tf/deployment/dev/ceph/` renders `inventory.ini` and
+— `tofu apply` in `tf/deployment/staging/ceph/` renders `inventory.ini` and
 `secrets.yml.tpl` for every cluster declared in `clusters.auto.tfvars`.
 Cluster secrets live in `yucca_tf_dev` (see [docs/secrets.md](docs/secrets.md)).
 
@@ -348,7 +348,7 @@ Cluster secrets live in `yucca_tf_dev` (see [docs/secrets.md](docs/secrets.md)).
 yucca/
 ├── tf/                                 # Terraform state + secrets + rendering (authoritative)
 │   ├── shared/modules/ceph-cluster/    # Module: per-cluster orchestration + rendering
-│   └── deployment/dev/ceph/            # Cluster declarations + tofu apply target
+│   └── deployment/staging/ceph/            # Cluster declarations + tofu apply target
 └── ansible/ceph/                       # This directory
     ├── *.yml                           # Top-level playbooks (site.yml, deploy-ceph.yml, etc.)
     ├── inventories/

--- a/ansible/ceph/README.md
+++ b/ansible/ceph/README.md
@@ -10,7 +10,7 @@ scaffolding are provisioned from `yucca/tf/` (see `../../tf/`).
 | **sietch** | `dev.austin.int.futo.cloud` | Austin DC | Dell R730xd | 3 |
 | **painbox** | `dev.hel.htz.futo.cloud` | Hetzner Helsinki | SX295 | 1 |
 
-Clusters are declared in `yucca/tf/deployment/dev/ceph/clusters.auto.tfvars`;
+Clusters are declared in `yucca/tf/deployment/staging/ceph/clusters.auto.tfvars`;
 `tofu apply` renders `inventories/<cluster>/inventory.ini` and
 `secrets.yml.tpl` per cluster. The `CEPH_ENV` variable selects the active
 cluster for any `mise run` or direct ansible invocation.
@@ -47,7 +47,7 @@ data flow, and design rationale.
 
 ```bash
 # 1. Render cluster inventories + secrets templates (once, from yucca/tf/)
-(cd ../../tf/deployment/dev/ceph && tofu init && tofu apply)
+(cd ../../tf/deployment/staging/ceph && tofu init && tofu apply)
 
 # 2. Set up the ansible side
 mise trust && mise run setup          # bootstrap dev environment
@@ -55,7 +55,7 @@ mise trust && mise run setup          # bootstrap dev environment
 # 3. Run mise tasks against the target cluster. CEPH_ENV must be set
 #    inline (NOT via `export`) — see docs/scripts.md "Setting CEPH_ENV"
 #    for why mise's [env] block strips shell exports.
-CE=inventories/sietch-ceph.dev.austin.int/inventory.ini
+CE=inventories/sietch-ceph.staging.austin.int/inventory.ini
 CEPH_ENV=$CE mise run preflight       # TF artifacts + 1P + SSH + connectivity
 CEPH_ENV=$CE mise run status          # read-only cluster health check
 CEPH_ENV=$CE mise run drift           # configuration drift detection
@@ -120,7 +120,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
 | `bench-rados` | RADOS bench (raw cluster I/O) |
 
 Inventory scaffolding + secret-item provisioning live in `yucca/tf/` — run
-`tofu apply` in `tf/deployment/dev/ceph/` to (re-)render
+`tofu apply` in `tf/deployment/staging/ceph/` to (re-)render
 `inventories/<cluster>/inventory.ini` and `secrets.yml.tpl`.
 
 ## Documentation

--- a/ansible/ceph/docs/architecture.md
+++ b/ansible/ceph/docs/architecture.md
@@ -66,7 +66,7 @@ roles + mise tasks work unchanged. The state backend key path, 1P vault
 selection, and inventory directory naming all derive from the env segment.
 
 `TF_STACK_DIR` is the operator-side override for `mise run tf:*` tasks; it
-defaults to `tf/deployment/dev/ceph` and points at any sibling stack directory.
+defaults to `tf/deployment/staging/ceph` and points at any sibling stack directory.
 `CEPH_ENV` is the matching override for Ansible — points at the rendered
 `inventory.ini` for the cluster you intend to operate on.
 
@@ -392,7 +392,7 @@ just those phases.
 
 ```
 inventories/
-  sietch-ceph.dev.austin.int/        Austin dev cluster
+  sietch-ceph.staging.austin.int/    Austin staging cluster
     inventory.ini                     TF-generated, gitignored
     inventory-destroy.ini             TF-generated, gitignored
     inventory-provision.ini           TF-generated, gitignored
@@ -492,10 +492,10 @@ env defaults.
 
 ```toml
 [env]
-CEPH_ENV = "inventories/sietch-ceph.dev.austin.int/inventory.ini"
+CEPH_ENV = "inventories/sietch-ceph.staging.austin.int/inventory.ini"
 ```
 
-`TF_STACK_DIR` defaults to `tf/deployment/dev/ceph` inside each `tf:*` task.
+`TF_STACK_DIR` defaults to `tf/deployment/staging/ceph` inside each `tf:*` task.
 Both are overridable per-invocation:
 
 ```bash

--- a/ansible/ceph/docs/hardware.md
+++ b/ansible/ceph/docs/hardware.md
@@ -19,7 +19,7 @@ traffic share one subnet. Production will separate them; see
 | painbox  | public /32        | Single 1GbE, direct SSH (no bond, no ProxyJump)                        |
 
 Per-node connection IPs (`bond_ip`) are declared in
-`tf/deployment/dev/ceph/clusters.auto.tfvars` and rendered by TF into the
+`tf/deployment/staging/ceph/clusters.auto.tfvars` and rendered by TF into the
 cluster's `inventory.ini`. They're also mirrored into `host_vars/` for use
 by roles that need the IP as a variable (e.g., cephadm public-network
 resolution, dashboard URL construction).

--- a/ansible/ceph/docs/patterns.md
+++ b/ansible/ceph/docs/patterns.md
@@ -211,9 +211,9 @@ inventory file. Cluster identity is authoritative in
 `clusters.auto.tfvars`; `CEPH_ENV` is the runtime pointer.
 
 ```
-CEPH_ENV = inventories/sietch-ceph.dev.austin.int/inventory.ini
+CEPH_ENV = inventories/sietch-ceph.staging.austin.int/inventory.ini
            |
-           dirname ->  inventories/sietch-ceph.dev.austin.int
+           dirname ->  inventories/sietch-ceph.staging.austin.int
                        |
                        + "/secrets.yml.tpl"  -> op inject input
 ```
@@ -225,8 +225,8 @@ is missing. See [scripts.md](scripts.md) for the full contract.
 **Destroy task** in `.mise.toml` extracts the domain for the safety gate:
 
 ```bash
-CLUSTER_ID=$(basename "$CEPH_ENV_DIR")        # sietch-ceph.dev.austin.int
-DOMAIN=${CLUSTER_ID#*-ceph.}.futo.cloud       # dev.austin.int.futo.cloud
+CLUSTER_ID=$(basename "$CEPH_ENV_DIR")        # sietch-ceph.staging.austin.int
+DOMAIN=${CLUSTER_ID#*-ceph.}.futo.cloud       # staging.austin.int.futo.cloud
 ```
 
 ---

--- a/ansible/ceph/docs/runbooks/add-node.md
+++ b/ansible/ceph/docs/runbooks/add-node.md
@@ -15,7 +15,7 @@
 
 Pick an unused name, or omit `name` to let TF auto-pick from the
 923-word list seeded per-cluster (see [docs/naming.md](../naming.md)).
-Edit `tf/deployment/dev/ceph/clusters.auto.tfvars` and append to the
+Edit `tf/deployment/staging/ceph/clusters.auto.tfvars` and append to the
 target cluster's `hosts` list:
 
 ```hcl
@@ -45,7 +45,7 @@ their positions.
 ## 2. Create host_vars
 
 ```bash
-cd inventories/sietch-ceph.dev.austin.int
+cd inventories/sietch-ceph.staging.austin.int
 cp host_vars/example.yml host_vars/sietch-ceph-<name>.yml
 ```
 
@@ -67,7 +67,7 @@ hardware:
 After `tofu apply` in step 1, inspect the rendered inventory:
 
 ```bash
-cat inventories/sietch-ceph.dev.austin.int/inventory.ini
+cat inventories/sietch-ceph.staging.austin.int/inventory.ini
 ```
 
 The new host should appear in:
@@ -86,7 +86,7 @@ Bootstrap host is unchanged. TF never moves an existing bootstrap assignment.
 3. Run provisioning:
 
 ```bash
-CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory-provision.ini \
+CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory-provision.ini \
   scripts/ansible-play.sh provision.yml \
   -e confirm_wipe=true \
   --limit sietch-ceph-<name>

--- a/ansible/ceph/docs/runbooks/recover-bad-tofu-apply.md
+++ b/ansible/ceph/docs/runbooks/recover-bad-tofu-apply.md
@@ -44,7 +44,7 @@ mise run tf:apply
 ### Rendered file on disk doesn't match tfvars
 
 ```bash
-cat ansible/ceph/inventories/sietch-ceph.dev.austin.int/inventory.ini
+cat ansible/ceph/inventories/sietch-ceph.staging.austin.int/inventory.ini
 # says ansible_user=root but tfvars says ansible-iac
 ```
 

--- a/ansible/ceph/docs/runbooks/remote-hands-access.md
+++ b/ansible/ceph/docs/runbooks/remote-hands-access.md
@@ -51,7 +51,7 @@ least-privilege principle.
 
 ```bash
 cd ~/yucca/ansible/ceph
-export CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory.ini
+export CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory.ini
 mise run status         # read-only smoke test
 mise run deploy         # or any other task
 ```

--- a/ansible/ceph/docs/runbooks/replace-host.md
+++ b/ansible/ceph/docs/runbooks/replace-host.md
@@ -46,7 +46,7 @@ the same bond IP via the same DHCP reservation / static config.
 # Boot the new box from the Debian 12 live image (same procedure as first
 # provision — see docs/runbooks/add-node.md for iDRAC steps).
 
-CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory-provision.ini \
+CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory-provision.ini \
   scripts/ansible-play.sh provision.yml \
   -e confirm_wipe=true \
   --limit sietch-ceph-<name>

--- a/ansible/ceph/docs/runbooks/rotate-certs.md
+++ b/ansible/ceph/docs/runbooks/rotate-certs.md
@@ -104,7 +104,7 @@ verification disabled for self-signed certs).
 ## Certificate configuration
 
 The cert parameters are controlled by these variables in
-`inventories/sietch-ceph.dev.austin.int/group_vars/all/vars.yml`:
+`inventories/sietch-ceph.staging.austin.int/group_vars/all/vars.yml`:
 
 | Variable | Default | Purpose |
 |---|---|---|

--- a/ansible/ceph/docs/runbooks/rotate-secrets.md
+++ b/ansible/ceph/docs/runbooks/rotate-secrets.md
@@ -28,7 +28,7 @@ deploy` picks up the new value via `op inject`.
 
 Replace `<CLUSTER>` with `SIETCH` or `PAINBOX`. The active vault name is
 declared per-cluster in the `vault` field of the cluster's entry in
-`tf/deployment/dev/ceph/clusters.auto.tfvars` — `yucca_tf_dev` for dev,
+`tf/deployment/staging/ceph/clusters.auto.tfvars` — `yucca_tf_dev` for dev,
 future `yucca_tf_staging` / `yucca_tf` for staging/prod.
 
 ## 1. Rotate in 1Password
@@ -192,7 +192,7 @@ Once the sietch-ceph service account lands and `secrets.tf.disabled` is
 re-enabled, rotations become a `terraform taint` + `apply`:
 
 ```bash
-cd tf/deployment/dev/ceph
+cd tf/deployment/staging/ceph
 terragrunt taint 'module.cluster["sietch"].onepassword_item.secret["dashboard"]'
 terragrunt apply
 ```

--- a/ansible/ceph/docs/scripts.md
+++ b/ansible/ceph/docs/scripts.md
@@ -113,16 +113,16 @@ The `mise run destroy` task (in `.mise.toml`) builds these arguments automatical
 
 ```bash
 # Standard deploy
-CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory.ini \
+CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory.ini \
   scripts/ansible-play.sh deploy-ceph.yml
 
 # Dry-run a role via tags
-CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory.ini \
+CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory.ini \
   scripts/ansible-play.sh site.yml --check --diff --tags baseline
 
 # CI / headless (SA token from env)
 OP_SERVICE_ACCOUNT_TOKEN="$(...)" \
-  CEPH_ENV=inventories/sietch-ceph.dev.austin.int/inventory.ini \
+  CEPH_ENV=inventories/sietch-ceph.staging.austin.int/inventory.ini \
   scripts/ansible-play.sh status.yml
 ```
 

--- a/ansible/ceph/docs/secrets.md
+++ b/ansible/ceph/docs/secrets.md
@@ -9,7 +9,7 @@ For how secrets fit into the broader architecture, see
 ```mermaid
 flowchart TB
     ONEP[("1Password<br/>yucca_tf · yucca_tf_dev · ...<br/><i>source of truth</i>")]
-    TF[Terraform / Tofu<br/>tf/deployment/dev/ceph/]
+    TF[Terraform / Tofu<br/>tf/deployment/staging/ceph/]
     REPO[/"inventories/&lt;cluster&gt;/<br/>inventory.ini (TF-gen, gitignored)<br/>secrets.yml.tpl (TF-gen, gitignored)"/]
     WRAP[scripts/ansible-play.sh<br/><i>mktemp + op inject → exec ansible-playbook --extra-vars @tmp</i>]
     ANS[ansible-playbook]

--- a/tf/README.md
+++ b/tf/README.md
@@ -107,7 +107,7 @@ items this TF depends on."
 
 ### Stack override via `TF_STACK_DIR`
 
-The default `mise run tf:*` tasks target `tf/deployment/dev/ceph`. Point
+The default `mise run tf:*` tasks target `tf/deployment/staging/ceph`. Point
 them at another stack via the `TF_STACK_DIR` env var:
 
 ```bash


### PR DESCRIPTION
Sietch moved dev -> staging and the dev/ceph stack plus the sietch-ceph.dev.austin.int inventory were deleted (PR #186), so doc examples that referenced those deleted paths are repointed to their staging equivalents. ADRs (004, 009) and the dev/staging/prod comparison tables were deliberately left unchanged, as were the existing-dev-inventory examples paired with painbox (still dev).

- `main` <!-- branch-stack -->
  - \#187 :point\_left:
