### PR TITLE
fix(ci): apply prettier formatting

### DIFF
--- a/.github/actions/netbird-connect/action.yml
+++ b/.github/actions/netbird-connect/action.yml
@@ -19,7 +19,7 @@ inputs:
   hostname:
     description: Optional peer hostname to register the runner as.
     required: false
-    default: ""
+    default: ''
 
 runs:
   using: composite

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -53,13 +53,13 @@ on:
   push:
     branches: [main]
     paths: &paths
-      - "tf/**"
-      - "ansible/mgmt/**"
-      - "ansible/ceph/**"
-      - ".mise/tasks/**"
-      - ".mise/config.toml"
-      - ".github/actions/netbird-connect/**"
-      - ".github/workflows/infra.yml"
+      - 'tf/**'
+      - 'ansible/mgmt/**'
+      - 'ansible/ceph/**'
+      - '.mise/tasks/**'
+      - '.mise/config.toml'
+      - '.github/actions/netbird-connect/**'
+      - '.github/workflows/infra.yml'
   pull_request:
     paths: *paths
   workflow_dispatch:
@@ -358,7 +358,7 @@ jobs:
         # CI runner has no known_hosts for the bare-metal nodes; first contact is
         # over the NetBird overlay, so disable strict host-key checking for this run.
         env:
-          ANSIBLE_HOST_KEY_CHECKING: "false"
+          ANSIBLE_HOST_KEY_CHECKING: 'false'
           CEPH_ENV: inventories/${{ matrix.partition }}-${{ matrix.region }}/sietch/inventory.ini
         run: mise run deploy
 

--- a/packages/yuctl/README.md
+++ b/packages/yuctl/README.md
@@ -142,15 +142,15 @@ cookies and never an `Authorization` header.
 
 ## Environment variables
 
-| Variable | Purpose | Default |
-|---|---|---|
-| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | state-bucket creds (skip op) | resolved via op |
-| `YUCTL_TF_STATE_ACCESS_KEY_REF` / `…_SECRET_KEY_REF` | op refs for state creds | `op://yucca_tf/TF_STATE_S3_{ACCESS,SECRET}_KEY/password` |
-| `YUCTL_TF_DEPLOYMENT_DIR` | force the local stack-enumeration dir | walk up for `tf/deployment` |
-| `OP_BIN` | 1Password CLI binary | `op` |
-| `OIDC_ADMIN_ISSUER` | admin OIDC issuer (`users list`) | — (flag `--issuer`) |
-| `OIDC_ADMIN_DEVICE_CLIENT_ID` | public device client id (`users list`) | — (flag `--client-id`) |
-| `YUCTL_ADMIN_API_URL` | admin-api base URL (`users list`) | derived from region domain |
+| Variable                                             | Purpose                                | Default                                                  |
+| ---------------------------------------------------- | -------------------------------------- | -------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`        | state-bucket creds (skip op)           | resolved via op                                          |
+| `YUCTL_TF_STATE_ACCESS_KEY_REF` / `…_SECRET_KEY_REF` | op refs for state creds                | `op://yucca_tf/TF_STATE_S3_{ACCESS,SECRET}_KEY/password` |
+| `YUCTL_TF_DEPLOYMENT_DIR`                            | force the local stack-enumeration dir  | walk up for `tf/deployment`                              |
+| `OP_BIN`                                             | 1Password CLI binary                   | `op`                                                     |
+| `OIDC_ADMIN_ISSUER`                                  | admin OIDC issuer (`users list`)       | — (flag `--issuer`)                                      |
+| `OIDC_ADMIN_DEVICE_CLIENT_ID`                        | public device client id (`users list`) | — (flag `--client-id`)                                   |
+| `YUCTL_ADMIN_API_URL`                                | admin-api base URL (`users list`)      | derived from region domain                               |
 
 ## Tests
 


### PR DESCRIPTION
The `format` check in CI was failing because three files had Prettier style violations:

- `.github/actions/netbird-connect/action.yml`
- `.github/workflows/infra.yml`
- `packages/yuctl/README.md`

Ran `prettier --write` on them. `prettier --check .` now passes clean.

Fixes the failing `Checks & Unit Tests` job on main ([run 28374105581](https://github.com/immich-app/yucca/actions/runs/28374105581/job/84059152992)).

- `main` <!-- branch-stack -->
  - \#225 :point\_left:
