### PR TITLE
fix(fabric): unhinged fix to duplicate config blocks because this is entirely spaget

### DIFF
--- a/tf/deployment/prod/htz-fsn1/fabric/fabric.tf
+++ b/tf/deployment/prod/htz-fsn1/fabric/fabric.tf
@@ -21,9 +21,6 @@ module "core" {
 
   vc_member_serials = var.spine_vc_serials
 
-  # Default DNS resolvers (Cloudflare + Quad9, dual-stack).
-  name_servers = ["1.1.1.1", "9.9.9.9", "2606:4700:4700::1111", "2620:fe::fe"]
-
   # Upstream IP-transit. Today: one transit (Core-Backbone), primary/default
   # (prepend 0). Add a second entry with prepend>0 + a lower local_pref to
   # multi-home (the prepended one is the backup; see core-fabric/transit.tf —
@@ -60,6 +57,12 @@ module "cluster_cls1" {
   vc_member_serials = var.cls1_leaf_serials
 }
 
+# Default DNS resolvers (Cloudflare + Quad9, dual-stack). Set here, not on core,
+# so a single resource owns the whole `system` container per switch.
+locals {
+  fabric_name_servers = ["1.1.1.1", "9.9.9.9", "2606:4700:4700::1111", "2620:fe::fe"]
+}
+
 module "login_spine" {
   source    = "../../../../shared/modules/fabric-login"
   providers = { junos-qfx = junos-qfx.spine }
@@ -67,6 +70,7 @@ module "login_spine" {
   resource_name = "login"
   users         = module.identity.fabric_login.users
   classes       = module.identity.fabric_login.classes
+  name_servers  = local.fabric_name_servers
 }
 
 module "login_leaf_cls1" {
@@ -76,4 +80,5 @@ module "login_leaf_cls1" {
   resource_name = "login"
   users         = module.identity.fabric_login.users
   classes       = module.identity.fabric_login.classes
+  name_servers  = local.fabric_name_servers
 }

--- a/tf/shared/modules/core-fabric/main.tf
+++ b/tf/shared/modules/core-fabric/main.tf
@@ -12,7 +12,6 @@ resource "terraform-provider-junos-qfx" "core" {
   routing_options    = local.routing_options_block
   protocols          = local.protocols_block
   policy_options     = local.transit_policy_options
-  system             = local.system_block
   virtual_chassis    = local.virtual_chassis_block
   vlans              = local.vlans_block
 }

--- a/tf/shared/modules/core-fabric/system.tf
+++ b/tf/shared/modules/core-fabric/system.tf
@@ -45,12 +45,4 @@ locals {
       }
     ]
   }]
-
-  # system name-servers (default resolvers). Merged into `system` — only this
-  # slice; fabric-login owns `system login` via its own resource. Empty = unset.
-  system_block = length(var.name_servers) == 0 ? [] : [
-    {
-      name_server = [for ns in var.name_servers : { name = ns }]
-    }
-  ]
 }

--- a/tf/shared/modules/core-fabric/variables.tf
+++ b/tf/shared/modules/core-fabric/variables.tf
@@ -54,12 +54,6 @@ variable "mgmt_vlan_id" {
   description = "Site-global management VLAN id to stretch."
 }
 
-variable "name_servers" {
-  type        = list(string)
-  default     = []
-  description = "Default DNS resolvers (system name-server). Empty = unset."
-}
-
 variable "mgmt_trusted_sources" {
   type        = list(string)
   default     = ["10.40.5.0/24", "10.254.0.0/15", "100.64.0.0/10", "127.0.0.0/8"]

--- a/tf/shared/modules/fabric-login/main.tf
+++ b/tf/shared/modules/fabric-login/main.tf
@@ -32,9 +32,13 @@ resource "terraform-provider-junos-qfx" "login" {
   resource_name = var.resource_name
   provider      = junos-qfx
 
+  # This resource owns the whole `system` container slice: login + name-servers.
+  # Splitting `system` children across resources makes each one delete the other's
+  # (the provider diffs its managed slice against the live device).
   system = [
-    {
-      login = local.login
-    }
+    merge(
+      { login = local.login },
+      length(var.name_servers) == 0 ? {} : { name_server = [for ns in var.name_servers : { name = ns }] },
+    )
   ]
 }

--- a/tf/shared/modules/fabric-login/variables.tf
+++ b/tf/shared/modules/fabric-login/variables.tf
@@ -27,3 +27,9 @@ variable "resource_name" {
   default     = "login"
   description = "JTAF resource/apply-group name for this login slice."
 }
+
+variable "name_servers" {
+  type        = list(string)
+  default     = []
+  description = "Default DNS resolvers (system name-server). Empty = unset. Lives here (not core-fabric) so the whole `system` container is owned by one resource."
+}


### PR DESCRIPTION
basically you can't configure the `system` twice and we're already doing it with the login module so now name servers are login items ok ?

- `main` <!-- branch-stack -->
  - \#229 :point\_left:
