### PR TITLE
feat(fabric): add disabled_ports to admin-down leaf server legs

### DIFF
--- a/tf/deployment/prod/htz-fsn1/fabric/fabric.tf
+++ b/tf/deployment/prod/htz-fsn1/fabric/fabric.tf
@@ -40,6 +40,17 @@ module "core" {
   }
 }
 
+# TEMP: 25G server legs to admin-down (no carrier) so the SX295 nodes PXE into
+# rescue over their 1G WAN. Currently all 48 bonds (both VC members); trim to the
+# specific ports you want (e.g. ["et-0/0/0", "et-1/0/0"]) or set [] to bring them
+# all back. ae0 spine-uplink legs are protected by the module regardless.
+locals {
+  cls1_disabled_ports = concat(
+    [for k in range(48) : "et-0/0/${k}"],
+    [for k in range(48) : "et-1/0/${k}"],
+  )
+}
+
 module "cluster_cls1" {
   source    = "../../../../shared/modules/cluster-fabric"
   providers = { junos = junos.leaf_cls1 }
@@ -55,6 +66,8 @@ module "cluster_cls1" {
   prefixlen       = module.addr_cls1.prefixlen
 
   vc_member_serials = var.cls1_leaf_serials
+
+  disabled_ports = local.cls1_disabled_ports
 }
 
 # Default DNS resolvers (Cloudflare + Quad9, dual-stack). Set here, not on core,

--- a/tf/deployment/prod/htz-fsn1/fabric/fabric.tf
+++ b/tf/deployment/prod/htz-fsn1/fabric/fabric.tf
@@ -40,17 +40,6 @@ module "core" {
   }
 }
 
-# TEMP: 25G server legs to admin-down (no carrier) so the SX295 nodes PXE into
-# rescue over their 1G WAN. Currently all 48 bonds (both VC members); trim to the
-# specific ports you want (e.g. ["et-0/0/0", "et-1/0/0"]) or set [] to bring them
-# all back. ae0 spine-uplink legs are protected by the module regardless.
-locals {
-  cls1_disabled_ports = concat(
-    [for k in range(48) : "et-0/0/${k}"],
-    [for k in range(48) : "et-1/0/${k}"],
-  )
-}
-
 module "cluster_cls1" {
   source    = "../../../../shared/modules/cluster-fabric"
   providers = { junos = junos.leaf_cls1 }
@@ -67,7 +56,10 @@ module "cluster_cls1" {
 
   vc_member_serials = var.cls1_leaf_serials
 
-  disabled_ports = local.cls1_disabled_ports
+  # TEMP: admin-down all 25G server legs (no carrier) so the SX295 nodes PXE into
+  # rescue over their 1G WAN. The set comes from the module's own LAG membership,
+  # not a port range. Remove this line to bring the fabric ports back.
+  disable_all_server_ports = true
 }
 
 # Default DNS resolvers (Cloudflare + Quad9, dual-stack). Set here, not on core,

--- a/tf/shared/modules/cluster-fabric/interfaces.tf
+++ b/tf/shared/modules/cluster-fabric/interfaces.tf
@@ -22,7 +22,7 @@ locals {
 resource "junos_interface_physical" "member" {
   for_each = local.member_bundles
   name     = each.key
-  disable  = each.value != "ae0" && (var.disable_all_server_ports || contains(var.disabled_ports, each.key))
+  disable  = (each.value != "ae0" && (var.disable_all_server_ports || contains(var.disabled_ports, each.key))) ? true : null
   ether_opts {
     ae_8023ad = each.value
   }

--- a/tf/shared/modules/cluster-fabric/interfaces.tf
+++ b/tf/shared/modules/cluster-fabric/interfaces.tf
@@ -15,10 +15,14 @@ locals {
   )
 }
 
-# Physical members → their aggregate.
+# Physical members → their aggregate. Ports named in var.disabled_ports are
+# admin-downed (no carrier) — e.g. to force hosts onto their 1G WAN for PXE rescue.
+# The ae0 spine-uplink legs are never disabled here, so the upstream path can't be
+# cut by a fat-fingered list.
 resource "junos_interface_physical" "member" {
   for_each = local.member_bundles
   name     = each.key
+  disable  = contains(var.disabled_ports, each.key) && each.value != "ae0"
   ether_opts {
     ae_8023ad = each.value
   }

--- a/tf/shared/modules/cluster-fabric/interfaces.tf
+++ b/tf/shared/modules/cluster-fabric/interfaces.tf
@@ -15,14 +15,14 @@ locals {
   )
 }
 
-# Physical members → their aggregate. Ports named in var.disabled_ports are
-# admin-downed (no carrier) — e.g. to force hosts onto their 1G WAN for PXE rescue.
-# The ae0 spine-uplink legs are never disabled here, so the upstream path can't be
-# cut by a fat-fingered list.
+# Physical members → their aggregate. A member is admin-downed (no carrier) when
+# disable_all_server_ports is set or it is named in disabled_ports — e.g. to force
+# hosts onto their 1G WAN for PXE rescue. The ae0 spine-uplink legs are never
+# disabled, so the upstream path can't be cut however the inputs are set.
 resource "junos_interface_physical" "member" {
   for_each = local.member_bundles
   name     = each.key
-  disable  = contains(var.disabled_ports, each.key) && each.value != "ae0"
+  disable  = each.value != "ae0" && (var.disable_all_server_ports || contains(var.disabled_ports, each.key))
   ether_opts {
     ae_8023ad = each.value
   }

--- a/tf/shared/modules/cluster-fabric/variables.tf
+++ b/tf/shared/modules/cluster-fabric/variables.tf
@@ -55,15 +55,26 @@ variable "uplink_ports" {
   description = "100G ports bonded into ae0 (the spine uplink)."
 }
 
+variable "disable_all_server_ports" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    Admin-down every server LAG member port (no carrier) without naming any — the
+    set is taken directly from the module's own LAG membership (all members except
+    the ae0 spine uplink), so it can't drift from the configured ports. Used to drop
+    the hosts' 25G NICs so nodes fall back to their 1G WAN for PXE/rescue. Reverting
+    to false brings them back; LAG/aggregates/VLANs are unchanged throughout.
+  EOT
+}
+
 variable "disabled_ports" {
   type        = list(string)
   default     = []
   description = <<-EOT
-    Physical member ports to admin-down (no carrier), by Junos name (e.g.
-    "et-0/0/0", "et-1/0/0"). Used to drop the hosts' 25G NICs so nodes fall back to
-    their 1G WAN for PXE/rescue. ae0 spine-uplink legs are protected — listing one
-    is a no-op. Empty (default) = all ports up. LAG membership, ae<k> aggregates,
-    and VLANs are unchanged, so reverting (drop the port from the list) restores it.
+    Specific physical member ports to admin-down (no carrier), by Junos name (e.g.
+    "et-0/0/0", "et-1/0/0"); use for a subset when disable_all_server_ports is too
+    broad. ae0 spine-uplink legs are protected — listing one is a no-op. Empty
+    (default) = none. Combined with disable_all_server_ports (union).
   EOT
 }
 

--- a/tf/shared/modules/cluster-fabric/variables.tf
+++ b/tf/shared/modules/cluster-fabric/variables.tf
@@ -55,6 +55,18 @@ variable "uplink_ports" {
   description = "100G ports bonded into ae0 (the spine uplink)."
 }
 
+variable "disabled_ports" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    Physical member ports to admin-down (no carrier), by Junos name (e.g.
+    "et-0/0/0", "et-1/0/0"). Used to drop the hosts' 25G NICs so nodes fall back to
+    their 1G WAN for PXE/rescue. ae0 spine-uplink legs are protected — listing one
+    is a no-op. Empty (default) = all ports up. LAG membership, ae<k> aggregates,
+    and VLANs are unchanged, so reverting (drop the port from the list) restores it.
+  EOT
+}
+
 variable "vc_member_serials" {
   type        = list(string)
   description = "The leaf VC member chassis serials (member 0, member 1), for preprovisioned VC."


### PR DESCRIPTION
The cluster-fabric leaf module can admin-down its 25G server legs (no carrier) so attached hosts fall back to another path. Two inputs drive it: `disable_all_server_ports` takes the set straight from the module's own LAG membership (every member except the ae0 spine uplink, which is always protected), so it can't drift from a hand-rolled port range; `disabled_ports` names a specific subset. htz-fsn1 cls1 sets `disable_all_server_ports = true` to force the SX295 nodes onto their 1G WAN for PXE/rescue, declared in the stack's fabric.tf and reverted by dropping the line. LAG membership, the ae<k> aggregates, and VLANs are untouched throughout.

Note: there is no source-of-truth port map for the SX295 cabling yet (NetBox holds only the leaf vme), so the all-server flag intentionally disables exactly the ports the LAGs are configured on rather than guessing physical positions. Confirm the real cabling before relying on a narrower `disabled_ports` list.

- `main` <!-- branch-stack -->
  - \#233 :point\_left:
