### PR TITLE
refactor: use existing formatDuration & omit at "100%"

### DIFF
--- a/packages/yucca-sdk/orchestration-ui/src/lib/services/log.service.svelte.ts
+++ b/packages/yucca-sdk/orchestration-ui/src/lib/services/log.service.svelte.ts
@@ -1,4 +1,5 @@
 import { defaults } from '$lib/fetch-client';
+import { formatDuration } from '$lib/utils/format';
 import debounce from 'lodash.debounce';
 
 type SummaryEvent = {
@@ -97,9 +98,10 @@ export function createLogObserver(logId: string) {
       case 'status': {
         state.status = {
           progress: event.percent_done,
-          text: event.seconds_remaining
-            ? `${event.seconds_remaining} seconds remaining`
-            : '',
+          text:
+            event.seconds_remaining && event.percent_done < 100
+              ? `${formatDuration(event.seconds_remaining * 1000)} remaining`
+              : 'Nearly done.',
           currentFiles: event.current_files ?? [],
         };
         flush();


### PR DESCRIPTION
format duration instead of just showing "x seconds remaining":
<img width="1135" height="452" alt="image" src="https://github.com/user-attachments/assets/a183ff43-cf3f-4451-b62c-803786693649" />

hide duration left at 100% as restic estimates become inaccurate
<img width="1053" height="380" alt="image" src="https://github.com/user-attachments/assets/b25b3aae-7f48-4854-a2c7-73b83b963896" />
