### PR TITLE
chore(ci): format infra.yml with prettier

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -390,8 +390,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.staging_matrix) }}
-    env: &plan-env
-      # Read-scoped SA + env-file by partition.
+    env: &plan-env # Read-scoped SA + env-file by partition.
       OP_SERVICE_ACCOUNT_TOKEN: ${{ matrix.partition == 'prod' && secrets.OP_TF_YUCCA_PROD_ENV || secrets.OP_TF_YUCCA_STAGING_ENV }}
       OP_ENV_FILE: ${{ matrix.partition == 'prod' && 'tf/.env.prod' || 'tf/.env' }}
       SITE: ${{ matrix.region }}


### PR DESCRIPTION
\#268 merged with the format check still red, leaving an unformatted .github/workflows/infra.yml on main; since the format task runs prettier --check over the whole tree, that gate is red for every PR until this lands. This is the prettier --write output only, no workflow behavior change: prettier pulled the trailing comment onto the `env: &plan-env` line.

- `main` <!-- branch-stack -->
  - \#269 :point\_left:
