### PR TITLE
fix(ceph): render inventories with the partition's op env file

### DIFF
--- a/ansible/ceph/scripts/render-inventories.sh
+++ b/ansible/ceph/scripts/render-inventories.sh
@@ -38,8 +38,13 @@ INV_ROOT="$ANSIBLE_CEPH/inventories"
 
 # The `render` output is non-sensitive (inventory text + op:// references — no
 # raw secrets). Reading state needs the S3 backend creds, so go through the
-# op-run wrapper which injects them from tf/.env.
-JSON="$(cd "$STACK_DIR" && OP_ENV_FILE="$REPO_ROOT/tf/.env" "$REPO_ROOT/tf/op-run.sh" terragrunt output -json render)"
+# op-run wrapper which injects them from the partition's env file: prod refs
+# live in tf/.env.prod, everything else in tf/.env (the same split infra.yml
+# makes). op run resolves every ref up front, so a mismatched file fails on the
+# wrong vault under the prod service-account token.
+ENV_FILE="$REPO_ROOT/tf/.env"
+if [ "$PARTITION" = "prod" ]; then ENV_FILE="$REPO_ROOT/tf/.env.prod"; fi
+JSON="$(cd "$STACK_DIR" && OP_ENV_FILE="$ENV_FILE" "$REPO_ROOT/tf/op-run.sh" terragrunt output -json render)"
 
 # JSON travels via env (RENDER_JSON); the heredoc owns python's stdin (the
 # program), so we can't also pipe the data in.


### PR DESCRIPTION
render-inventories.sh now reads TF state through the partition's own op env file (tf/.env.prod for prod, tf/.env otherwise), matching the split infra.yml already makes, so the greenfield prod ceph apply stops failing its inventory-render step with "yucca\_tf\_staging isn't a vault in this account". The step runs under the prod 1Password service-account token, which only carries yucca\_tf\_prod; the old hardcoded tf/.env resolved op\://yucca\_tf\_staging refs and died before terragrunt ran. The file is derived from $PARTITION as an absolute path (already used to locate the stack), which also sidesteps the workflow's relative OP\_ENV\_FILE. The TF apply itself had already succeeded, so a re-dispatch resumes at the read-only render step.

- `main` <!-- branch-stack -->
  - \#270 :point\_left:
