### PR TITLE
fix(ceph): mask periodic apt and refresh cache after repo changes

### DIFF
--- a/ansible/ceph/roles/baseline/tasks/apt-daily.yml
+++ b/ansible/ceph/roles/baseline/tasks/apt-daily.yml
@@ -1,0 +1,31 @@
+---
+# Neutralize Debian's stock periodic apt before any dpkg/apt task runs.
+#
+# On a freshly-imaged node the apt-daily / unattended-upgrades units fire at boot
+# and hold the dpkg frontend lock. A converge that then runs apt or dpkg races
+# them and fails ("dpkg frontend lock was locked by another process"). We run no
+# unattended upgrades by design (load-bearing packages are dpkg-held), so masking
+# these units is both the intended end state and the fix for that race.
+
+- name: Stop and mask the periodic apt units
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    masked: true
+  loop:
+    - apt-daily.timer
+    - apt-daily.service
+    - apt-daily-upgrade.timer
+    - apt-daily-upgrade.service
+    - unattended-upgrades.service
+  # A minimal image may omit unattended-upgrades; masking an absent unit is a
+  # no-op we tolerate. The lock wait below is the hard gate.
+  failed_when: false
+
+- name: Wait for the dpkg frontend lock to be released
+  # A boot-time apt run started before we masked the units may still hold the
+  # lock. flock blocks until it is free (the same lock apt/dpkg take), then
+  # releases immediately; it fails only if the lock is still held at timeout.
+  ansible.builtin.command:
+    cmd: flock --timeout 150 /var/lib/dpkg/lock-frontend true
+  changed_when: false

--- a/ansible/ceph/roles/baseline/tasks/main.yml
+++ b/ansible/ceph/roles/baseline/tasks/main.yml
@@ -5,6 +5,12 @@
 #          (created by provision_host during initial OS install).
 # Everything here is convergeable via normal deploy pipeline.
 
+# First, before any dpkg/apt task: stop Debian's periodic apt and drain any
+# boot-time apt still holding the dpkg lock, so the converge cannot race it.
+- name: Neutralize periodic apt and clear the dpkg lock
+  ansible.builtin.import_tasks: apt-daily.yml
+  tags: [packages, apt]
+
 - name: Ensure iac automation access (root key + ansible-iac)
   ansible.builtin.import_tasks: iac-access.yml
   when: provision_iac_ssh_key_path is defined

--- a/ansible/ceph/roles/provision_host/tasks/prerequisites_live.yml
+++ b/ansible/ceph/roles/provision_host/tasks/prerequisites_live.yml
@@ -35,9 +35,10 @@
     mode: '0644'
 
 - name: Update apt cache on live image
+  # Always refresh: the sources.list above was just replaced, so a
+  # cache_valid_time skip would install against the stale live-medium index.
   ansible.builtin.apt:
     update_cache: true
-    cache_valid_time: 3600
   changed_when: false
 
 - name: Install provisioning prerequisites on live image


### PR DESCRIPTION
The ceph baseline now stops and masks Debian's periodic apt (apt-daily / unattended-upgrades) and waits out the dpkg frontend lock before any dpkg or apt task, so a freshly-imaged node's boot-time apt can no longer race the converge. That race failed the greenfield spice bring-up at the dpkg-hold task ("dpkg frontend lock was locked by another process with pid 79890" on 1 of 8 nodes). Masking these units is the intended end state anyway: load-bearing packages are dpkg-held, not auto-upgraded. Separately, the provision live-image step drops its cache\_valid\_time so the apt refresh always runs after sources.list is replaced, matching what the ceph\_deploy repo step already does. See ansible/ceph/roles/baseline/tasks/apt-daily.yml.

- `main` <!-- branch-stack -->
  - \#271 :point\_left:
