### PR TITLE
fix(ceph): parenthesize the ceph-safety verdict ternary

### DIFF
--- a/ansible/ceph/roles/reprovision_hetzner/tasks/ceph_safety.yml
+++ b/ansible/ceph/roles/reprovision_hetzner/tasks/ceph_safety.yml
@@ -90,10 +90,12 @@
     that:
       # strict requires a POSITIVE permit (an unreachable delegate yields empty
       # stdout, which must fail closed); auto only requires the absence of a refuse.
+      # Outer parens are load-bearing: assert wraps each entry in {% if ... %},
+      # and Jinja cannot parse a bare conditional expression there.
       - >-
-        ('VERDICT=PERMIT' in (_cs_eval.stdout | default('')))
-        if _cs_mode == 'strict'
-        else ('VERDICT=REFUSE' not in (_cs_eval.stdout | default('')))
+        (('VERDICT=PERMIT' in (_cs_eval.stdout | default('')))
+         if _cs_mode == 'strict'
+         else ('VERDICT=REFUSE' not in (_cs_eval.stdout | default(''))))
     success_msg: "ceph-safety: {{ _cs_eval.stdout | default('skipped (permissive or no peer)') | trim }}"
     fail_msg: >-
       reprovision_ceph_safety={{ _cs_mode }}: REFUSING to reimage {{ inventory_hostname }}.


### PR DESCRIPTION
The reprovision ceph-safety gate can now actually deliver its verdict: the assert's bare `X if C else Y` ternary was unparseable once wrapped in Jinja's `{% if %}` ("expected token 'end of statement block', got 'if'"), so every non-permissive run that reached the verdict died on a template error instead of a decision. Surfaced on the gate's first real invocation (imaging noreen against the live cluster). Outer parens fix the parse; fail-closed semantics are unchanged and verified for all four mode/verdict cases (strict+permit pass, strict+empty fail, auto+refuse fail, auto+permit pass).

- `main` <!-- branch-stack -->
  - \#272 :point\_left:
