### PR TITLE
feat(ceph): re-add noreen to spice

### DIFF
--- a/tf/deployment/prod/global/dns/records.auto.tfvars
+++ b/tf/deployment/prod/global/dns/records.auto.tfvars
@@ -1,7 +1,7 @@
 # futo.cloud zone (FUTO Account).
 zone_id = "474fbfd96bf49879054a493f126c4071"
 
-# Spice RGW S3 endpoint (prod). Round-robin A across all 47 spice ceph nodes'
+# Spice RGW S3 endpoint (prod). Round-robin A across all 48 spice ceph nodes'
 # FABRIC public IPs (10.40.20.<host_index>, VLAN 120) -- RGW/beast binds only the
 # fabric (ceph_bind_networks), so that is where it listens. RFC1918: the name
 # resolves anywhere, but the addresses route only from networks that reach the
@@ -9,8 +9,8 @@ zone_id = "474fbfd96bf49879054a493f126c4071"
 # clients (michael) resolve and reach these; proxied stays false (Cloudflare cannot
 # proxy private addresses). The wildcard serves S3 virtual-hosted buckets
 # (<bucket>.s3.prod.fsn1.htz.futo.cloud); the cluster rgw_dns_name and the
-# self-signed TLS cert SANs expect both names. noreen (host_index 40) is excluded
-# (held in triage). Values are the fabric IPs of the IN-SERVICE nodes in
+# self-signed TLS cert SANs expect both names. Values are the fabric IPs of the
+# IN-SERVICE nodes in
 # tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars (host_index -> IP via that
 # stack's spice-hosts.yaml); regenerate if the roster changes. The lists here and
 # the ceph roster are kept in sync by tf/scripts/check-s3-dns-roster.py (CI gate
@@ -27,7 +27,8 @@ records = {
       "10.40.20.25", "10.40.20.26", "10.40.20.27", "10.40.20.28",
       "10.40.20.29", "10.40.20.30", "10.40.20.31", "10.40.20.32",
       "10.40.20.33", "10.40.20.34", "10.40.20.35", "10.40.20.36",
-      "10.40.20.37", "10.40.20.38", "10.40.20.39", "10.40.20.41",
+      "10.40.20.37", "10.40.20.38", "10.40.20.39", "10.40.20.40",
+      "10.40.20.41",
       "10.40.20.42", "10.40.20.43", "10.40.20.44", "10.40.20.45",
       "10.40.20.46", "10.40.20.47", "10.40.20.48", "10.40.20.49",
       "10.40.20.50", "10.40.20.51",
@@ -45,7 +46,8 @@ records = {
       "10.40.20.25", "10.40.20.26", "10.40.20.27", "10.40.20.28",
       "10.40.20.29", "10.40.20.30", "10.40.20.31", "10.40.20.32",
       "10.40.20.33", "10.40.20.34", "10.40.20.35", "10.40.20.36",
-      "10.40.20.37", "10.40.20.38", "10.40.20.39", "10.40.20.41",
+      "10.40.20.37", "10.40.20.38", "10.40.20.39", "10.40.20.40",
+      "10.40.20.41",
       "10.40.20.42", "10.40.20.43", "10.40.20.44", "10.40.20.45",
       "10.40.20.46", "10.40.20.47", "10.40.20.48", "10.40.20.49",
       "10.40.20.50", "10.40.20.51",

--- a/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
+++ b/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
@@ -65,22 +65,18 @@ clusters = {
       { name = "mattie", bond_ip = "178.63.139.237", roles = ["osd", "rgw"] },                                 # srv 3014575 host_index 37
       { name = "miguel", bond_ip = "178.63.139.216", roles = ["osd", "rgw"] },                                 # srv 3014576 host_index 38
       { name = "murphy", bond_ip = "178.63.139.232", roles = ["osd", "rgw"] },                                 # srv 3014577 host_index 39
-      # EXCLUDED until recovered: noreen (srv 3014578, host_index 40, 178.63.139.220)
-      # hit the BIOS boot-order fault and is held in triage (never imaged). Kept out
-      # of TF so the rendered inventory + deploy target only the 47 live nodes.
-      # Re-add this line once Hetzner fixes its boot order and it images cleanly.
-      # { name = "noreen", bond_ip = "178.63.139.220", roles = ["osd", "rgw"] },      # srv 3014578 host_index 40
-      { name = "philip", bond_ip = "178.63.139.219", roles = ["osd", "rgw"] },               # srv 3014579 host_index 41
-      { name = "raymon", bond_ip = "178.63.139.223", roles = ["osd", "rgw"] },               # srv 3014580 host_index 42
-      { name = "romona", bond_ip = "178.63.139.236", roles = ["osd", "rgw"] },               # srv 3014581 host_index 43
-      { name = "serena", bond_ip = "178.63.139.229", roles = ["mon", "mgr", "osd", "rgw"] }, # srv 3014582 host_index 44  MON
-      { name = "shanna", bond_ip = "178.63.139.209", roles = ["osd", "rgw"] },               # srv 3014583 host_index 45
-      { name = "shelby", bond_ip = "178.63.139.224", roles = ["osd", "rgw"] },               # srv 3014584 host_index 46
-      { name = "sommer", bond_ip = "178.63.139.215", roles = ["osd", "rgw"] },               # srv 3014585 host_index 47
-      { name = "sylvia", bond_ip = "178.63.139.235", roles = ["osd", "rgw"] },               # srv 3014586 host_index 48
-      { name = "theron", bond_ip = "178.63.139.238", roles = ["osd", "rgw"] },               # srv 3014587 host_index 49
-      { name = "trista", bond_ip = "178.63.139.233", roles = ["osd", "rgw"] },               # srv 3014588 host_index 50
-      { name = "virgie", bond_ip = "178.63.139.231", roles = ["osd", "rgw"] },               # srv 3014589 host_index 51
+      { name = "noreen", bond_ip = "178.63.139.220", roles = ["osd", "rgw"] },                                 # srv 3014578 host_index 40
+      { name = "philip", bond_ip = "178.63.139.219", roles = ["osd", "rgw"] },                                 # srv 3014579 host_index 41
+      { name = "raymon", bond_ip = "178.63.139.223", roles = ["osd", "rgw"] },                                 # srv 3014580 host_index 42
+      { name = "romona", bond_ip = "178.63.139.236", roles = ["osd", "rgw"] },                                 # srv 3014581 host_index 43
+      { name = "serena", bond_ip = "178.63.139.229", roles = ["mon", "mgr", "osd", "rgw"] },                   # srv 3014582 host_index 44  MON
+      { name = "shanna", bond_ip = "178.63.139.209", roles = ["osd", "rgw"] },                                 # srv 3014583 host_index 45
+      { name = "shelby", bond_ip = "178.63.139.224", roles = ["osd", "rgw"] },                                 # srv 3014584 host_index 46
+      { name = "sommer", bond_ip = "178.63.139.215", roles = ["osd", "rgw"] },                                 # srv 3014585 host_index 47
+      { name = "sylvia", bond_ip = "178.63.139.235", roles = ["osd", "rgw"] },                                 # srv 3014586 host_index 48
+      { name = "theron", bond_ip = "178.63.139.238", roles = ["osd", "rgw"] },                                 # srv 3014587 host_index 49
+      { name = "trista", bond_ip = "178.63.139.233", roles = ["osd", "rgw"] },                                 # srv 3014588 host_index 50
+      { name = "virgie", bond_ip = "178.63.139.231", roles = ["osd", "rgw"] },                                 # srv 3014589 host_index 51
     ]
   }
 }


### PR DESCRIPTION
noreen (srv 3014578, host_index 40) rejoins the spice roster: Hetzner fixed the BIOS boot-order fault, the node imaged clean via the rescue-first add-node path (both 25G legs verified linking at 25G beforehand), and the installed OS booted with hostname, ansible-iac access, and the provisioning marker all verified. Merging re-renders the 48-node inventory; the next ceph apply converges it (baseline through harden) and cephadm adds its 14 HDD + 1 SSD OSDs. Also adds 10.40.20.40 to the prod S3 apex + wildcard rosters (the s3-dns-roster gate correctly refused the one-sided ceph-roster change); host_vars were already committed during the campaign.
