### PR TITLE
fix(ceph): pin mtu-less VLAN sub-interfaces to 1500

### DIFF
--- a/ansible/ceph/roles/networkd/templates/bond-vlan.netdev.j2
+++ b/ansible/ceph/roles/networkd/templates/bond-vlan.netdev.j2
@@ -4,9 +4,9 @@
 [NetDev]
 Name={{ networkd_bond_name }}.{{ vlan.id }}
 Kind=vlan
-{% if vlan.mtu is defined %}
-MTUBytes={{ vlan.mtu | int }}
-{% endif %}
+{# Always pin: an unset MTUBytes inherits the bond's (possibly jumbo) MTU on
+   fresh creation; the documented contract is mtu-less VLANs run at 1500. #}
+MTUBytes={{ vlan.mtu | default(1500) | int }}
 
 [VLAN]
 Id={{ vlan.id }}

--- a/ansible/ceph/roles/networkd/templates/bond-vlan.network.j2
+++ b/ansible/ceph/roles/networkd/templates/bond-vlan.network.j2
@@ -14,6 +14,6 @@ DNS={{ vlan.dns }}
 
 [Link]
 RequiredForOnline=no
-{% if vlan.mtu is defined %}
-MTUBytes={{ vlan.mtu | int }}
-{% endif %}
+{# Always pin: an unset MTUBytes inherits the bond's (possibly jumbo) MTU on
+   fresh creation; the documented contract is mtu-less VLANs run at 1500. #}
+MTUBytes={{ vlan.mtu | default(1500) | int }}


### PR DESCRIPTION
VLAN sub-interfaces without an explicit mtu now get MTUBytes=1500 in both the netdev and network templates, making the role honor its own documented contract ("VLANs without mtu default to 1500"). Previously MTUBytes was only emitted when set, so a freshly created sub-interface inherited the bond's jumbo 9000 -- invisible on the 47 adopted nodes whose VLANs pre-existed at 1500, caught by the role's own verify on noreen's greenfield bringup (bond0.120/124 at 9000, expected 1500). Verified end-to-end on noreen: re-run converged with 1500/9000/1500, LACP up, both gateways reachable, and the migration committed.

- `main` <!-- branch-stack -->
  - \#274 :point\_left:
