### PR TITLE
fix(ceph): keep established flows alive through firewall activation

### DIFF
--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -308,3 +308,9 @@ ceph_alertmanager_port: 9093
 # rather than left world-open (ceph_firewall_rgw_any_source defaults true for
 # flat/dev clusters; spice pins it closed).
 ceph_firewall_rgw_any_source: false
+# The private replication VLAN is a closed L2 (cluster nodes only): accept it
+# wholesale so established OSD flows survive firewall (re)activation instead
+# of dying on the drop policy (see the security role defaults for the full
+# rationale; 2026-07-20 incident).
+ceph_firewall_trusted_ifaces:
+  - bond0.122

--- a/ansible/ceph/roles/security/defaults/main.yml
+++ b/ansible/ceph/roles/security/defaults/main.yml
@@ -12,9 +12,21 @@ ceph_firewall_trusted_networks:
   - 192.168.0.0/16
   - 100.64.0.0/10
 
+# Interfaces accepted WHOLESALE (no port filtering), e.g. the closed
+# replication VLAN (spice: bond0.122). Port rules only match daemon dports,
+# so return traffic of connections established BEFORE the firewall loaded
+# targets ephemeral ports and hits the drop policy (conntrack cannot adopt
+# mid-stream flows it did not see open). On a closed cluster L2, filtering
+# per-port adds nothing; accepting the interface keeps live replication
+# flowing through a firewall (re)activation. Default empty: flat-network
+# clusters (sietch) have no dedicated replication interface to trust.
+ceph_firewall_trusted_ifaces: []
+
 # Ports to open (derived from Ceph service layout)
 ceph_firewall_mon_ports: [3300, 6789]
-ceph_firewall_osd_port_range: "6800-7300"
+# Full modern bind range (ms_bind_port_max default 7568; the historic docs
+# range 6800-7300 under-covers a restart-churned 15-OSD host).
+ceph_firewall_osd_port_range: "6800-7568"
 ceph_firewall_rgw_port: "{{ ceph_rgw_port | default(443) }}"
 # Allow RGW/S3 from any source (true) or restrict to trusted networks (false).
 # Mirrors ceph_firewall_ssh_any_source. Default true so a public S3 endpoint

--- a/ansible/ceph/roles/security/tasks/main.yml
+++ b/ansible/ceph/roles/security/tasks/main.yml
@@ -62,6 +62,27 @@
          else 'started' }}
   when: ceph_firewall_enabled | bool
 
+# Connections established BEFORE the firewall (conntrack) loaded are picked up
+# mid-stream with an unknown window scale; strict tracking marks their packets
+# INVALID, so they miss the established,related accept and die at the drop
+# policy (2026-07-20: wedged 9 OSDs + 7 RGWs on spice at first activation).
+# Liberal window tracking lets those flows match established and survive.
+- name: Keep pre-firewall TCP flows alive (liberal conntrack window tracking)
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/99-ceph-conntrack.conf
+    content: |
+      # Managed by Ansible (security role). See role tasks for rationale.
+      net.netfilter.nf_conntrack_tcp_be_liberal = 1
+    owner: root
+    group: root
+    mode: '0644'
+  when: ceph_firewall_enabled | bool
+
+- name: Apply conntrack sysctl now (module loaded by the nftables ct rules)
+  ansible.builtin.command: sysctl -q -p /etc/sysctl.d/99-ceph-conntrack.conf
+  changed_when: false
+  when: ceph_firewall_enabled | bool
+
 - name: Show active nftables rules
   ansible.builtin.command: nft list ruleset
   register: nft_rules

--- a/ansible/ceph/roles/security/templates/nftables.conf.j2
+++ b/ansible/ceph/roles/security/templates/nftables.conf.j2
@@ -15,6 +15,12 @@ table inet filter {
 
         # Loopback
         iifname "lo" accept
+{% for ifc in ceph_firewall_trusted_ifaces %}
+
+        # Trusted interface (closed cluster L2): accept wholesale so return
+        # traffic of pre-firewall established flows cannot hit the drop policy.
+        iifname "{{ ifc }}" accept
+{% endfor %}
 
         # Established/related
         ct state established,related accept


### PR DESCRIPTION
The nftables activation can no longer black-hole a live cluster: the private replication VLAN (spice: bond0.122, via new ceph\_firewall\_trusted\_ifaces, default empty for flat clusters) is accepted wholesale, and nf\_conntrack\_tcp\_be\_liberal=1 lets conntrack adopt connections established before the firewall loaded instead of marking them INVALID into the drop policy. That combination is what wedged 9 OSDs (1600+ blocked ops) and 7 RGWs at spice's first harden on 2026-07-20: port rules only match daemon dports, so return traffic of pre-firewall flows targets ephemeral ports and died. Also widens the OSD port range to the modern bind default (6800-7568; the historic 6800-7300 under-covers a restart-churned 15-OSD host). Rendered ruleset verified with nft -c on a spice node.

- `main` <!-- branch-stack -->
  - \#275 :point\_left:
