### PR TITLE
fix(ceph): flush handlers after the sshd kex workaround

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/tasks/prerequisites.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/prerequisites.yml
@@ -54,3 +54,11 @@
     dest: /etc/ssh/sshd_config.d/no-sntrup.conf
     mode: '0644'
   notify: Restart sshd
+
+# Apply the kex change NOW. Handlers flush at end of play, so an aborted run
+# leaves the drop-in on disk with the old sshd still offering sntrup761 -- the
+# very hang this task exists to prevent then keeps killing the runs that would
+# have flushed the handler (2026-07-16..20: four days unapplied on spice; hung
+# CI sessions and three mgr serve loops before a manual fleet sshd restart).
+- name: Flush handlers so the running sshd stops offering sntrup761
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
The sntrup761 kex workaround now takes effect the moment it is deployed: a meta flush\_handlers right after the drop-in runs the sshd restart immediately instead of deferring it to end of play. Deferred, an aborted run leaves the config on disk with the old sshd still offering sntrup761 -- and the resulting asyncssh hangs are exactly what keeps aborting the runs, so the fix could never land (spice 2026-07-16 to 07-20: four days unapplied; killed two CI deploys mid-SSH and froze three cephadm mgr serve loops before a manual fleet-wide sshd restart broke the cycle).

- `main` <!-- branch-stack -->
  - \#276 :point\_left:
