### PR TITLE
fix(ceph): seed the grafana admin and provision dashboards from the repo

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/files/grafana-dashboards/rgw-bucket-capacity-performance.json
+++ b/ansible/ceph/roles/ceph_deploy/files/grafana-dashboards/rgw-bucket-capacity-performance.json
@@ -1,0 +1,2316 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "id": "grafana",
+      "name": "Grafana",
+      "type": "grafana",
+      "version": "5.3.2"
+    },
+    {
+      "id": "graph",
+      "name": "Graph",
+      "type": "panel",
+      "version": "5.0.0"
+    },
+    {
+      "id": "singlestat",
+      "name": "Singlestat",
+      "type": "panel",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "tags": [],
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "$datasource",
+      "description": "Accurate pool-level usage \u2014 excludes block.db metadata overhead",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "ceph_pool_percent_used{cluster=~\"$cluster\"} * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Capacity Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5497558138880
+              },
+              {
+                "color": "yellow",
+                "value": 21990232555520
+              },
+              {
+                "color": "green",
+                "value": 54975581388800
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "ceph_pool_max_avail{cluster=~\"$cluster\"} * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Remaining Capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Based on average write rate over the last 6 hours",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 604800
+              },
+              {
+                "color": "yellow",
+                "value": 2592000
+              },
+              {
+                "color": "green",
+                "value": 7776000
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "(ceph_pool_max_avail{cluster=~\"$cluster\"} / deriv(ceph_pool_stored{cluster=~\"$cluster\"}[6h])) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"} > 0",
+          "refId": "A"
+        }
+      ],
+      "title": "Time Till Full",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Stored"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Usable"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Objects"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "cyan",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "ceph_pool_stored{cluster=~\"$cluster\"} * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "Stored",
+          "refId": "A"
+        },
+        {
+          "expr": "(ceph_pool_stored{cluster=~\"$cluster\"} + ceph_pool_max_avail{cluster=~\"$cluster\"}) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "Total Usable",
+          "refId": "B"
+        },
+        {
+          "expr": "ceph_pool_objects{cluster=~\"$cluster\"} * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "Objects",
+          "refId": "C"
+        }
+      ],
+      "title": "Capacity Breakdown",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Capacity Trends \u2014 When Do We Need to Act?",
+      "type": "row"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "ceph_pool_stored{cluster=~\"$cluster\"} * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "Stored",
+          "refId": "A"
+        }
+      ],
+      "title": "Data Stored Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bytes/sec"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "objects/sec"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "deriv(ceph_pool_stored{cluster=~\"$cluster\"}[5m]) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "bytes/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "deriv(ceph_pool_objects{cluster=~\"$cluster\"}[5m]) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "objects/sec",
+          "refId": "B"
+        }
+      ],
+      "title": "How Fast Are We Filling?",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Raw vs Usable \u2014 Why Does Cluster Usage Look Inflated?",
+      "type": "row"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Total raw usage = pool data with EC parity + block.db SSD metadata (240 GiB per HDD OSD, fixed cost, doesn't grow with data).",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pool Data + EC Parity"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "block.db Metadata (SSD)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Raw Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 16
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(ceph_pool_stored_raw{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "Pool Data + EC Parity",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(ceph_cluster_total_used_bytes{cluster=~\"$cluster\"}) - sum(ceph_pool_stored_raw{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "block.db Metadata (SSD)",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(ceph_cluster_total_used_bytes{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "Total Raw Used",
+          "refId": "C"
+        }
+      ],
+      "title": "Where Raw Storage Goes",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "% Raw includes ~5.6 TiB of SSD block.db allocations. % Pool reflects actual data capacity. Always use Pool % for capacity planning.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "% Raw (inflated)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "% Pool (accurate)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 10,
+        "y": 16
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "sum(ceph_cluster_total_used_bytes{cluster=~\"$cluster\"}) / sum(ceph_cluster_total_bytes{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "% Raw (inflated)",
+          "refId": "A"
+        },
+        {
+          "expr": "ceph_pool_percent_used{cluster=~\"$cluster\"} * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "instant": true,
+          "legendFormat": "% Pool (accurate)",
+          "refId": "B"
+        }
+      ],
+      "title": "The Two Percentages",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "What makes up total raw usage. block.db (SSD) is a fixed cost from metadata-on-SSD architecture \u2014 it doesn't grow with data.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "User Data"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EC Parity"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "block.db (SSD)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 23,
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(ceph_pool_stored{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "User Data",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(ceph_pool_stored_raw{cluster=~\"$cluster\"}) - sum(ceph_pool_stored{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "EC Parity",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(ceph_cluster_total_used_bytes{cluster=~\"$cluster\"}) - sum(ceph_pool_stored_raw{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "block.db (SSD)",
+          "refId": "C"
+        }
+      ],
+      "title": "Raw Usage Composition",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 30,
+      "panels": [],
+      "title": "S3 Performance \u2014 How Is the System Performing?",
+      "type": "row"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Actual S3 PUT/GET throughput from RGW metrics. Excludes internal recovery, scrub, and EC amplification.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ceph_rgw_op_get_obj_bytes{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "GET",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ceph_rgw_op_put_obj_bytes{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "PUT",
+          "refId": "B"
+        }
+      ],
+      "title": "S3 Client Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Actual S3 PUT/GET/DELETE operations from RGW metrics. Excludes internal recovery and scrub ops.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ceph_rgw_op_get_obj_ops{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "GET",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ceph_rgw_op_put_obj_ops{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "PUT",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(ceph_rgw_op_del_obj_ops{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "DELETE",
+          "refId": "C"
+        }
+      ],
+      "title": "S3 Client IOPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ceph_rgw_op_put_obj_lat_sum{cluster=~\"$cluster\"}[$__rate_interval]) / rate(ceph_rgw_op_put_obj_lat_count{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "RGW PUT Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ceph_rgw_op_get_obj_lat_sum{cluster=~\"$cluster\"}[$__rate_interval]) / rate(ceph_rgw_op_get_obj_lat_count{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "RGW GET Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "failed.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "ops"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "ceph_rgw_qlen{cluster=~\"$cluster\"}",
+          "legendFormat": "queue: {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(ceph_rgw_failed_req{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "failed: {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "RGW Queue & Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 40,
+      "title": "Engineering Deep Dive \u2014 OSD & BlueStore Internals",
+      "type": "row"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 41
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ceph_osd_op_w_latency_sum{cluster=~\"$cluster\"}[$__rate_interval]) / rate(ceph_osd_op_w_latency_count{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "osd.{{ceph_daemon}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OSD Write Latency (per OSD)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 41
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ceph_bluestore_kv_commit_lat_sum{cluster=~\"$cluster\"}[$__rate_interval]) / rate(ceph_bluestore_kv_commit_lat_count{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "osd.{{ceph_daemon}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BlueStore KV Commit (block.db SSD)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 41
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg(ceph_osd_apply_latency_ms{cluster=~\"$cluster\"})",
+          "legendFormat": "apply (avg)",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(ceph_osd_commit_latency_ms{cluster=~\"$cluster\"})",
+          "legendFormat": "commit (avg)",
+          "refId": "B"
+        },
+        {
+          "expr": "max(ceph_osd_apply_latency_ms{cluster=~\"$cluster\"})",
+          "legendFormat": "apply (worst OSD)",
+          "refId": "C"
+        }
+      ],
+      "title": "OSD Apply vs Commit Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ceph_osd_recovery_ops{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "osd.{{ceph_daemon}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Recovery Ops (should be zero during benchmarks)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ceph_rgw_req{cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "RGW Request Rate (per instance)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 50,
+      "panels": [],
+      "title": "System Metrics \u2014 Node-Level Resource Utilization",
+      "type": "row"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Bond interface throughput. With EC 8+3, the primary OSD fans out 11 shards across both nodes. Network saturation caps cluster write throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*TX.*"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total{job=\"node\", device=\"bond0\"}[$__rate_interval])",
+          "legendFormat": "{{instance}} RX",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(node_network_transmit_bytes_total{job=\"node\", device=\"bond0\"}[$__rate_interval])",
+          "legendFormat": "{{instance}} TX",
+          "refId": "B"
+        }
+      ],
+      "title": "Network Throughput (per node)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "RGW is CPU-intensive for S3 request processing and EC coordination. Watch for RGW saturation above 400%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{job=\"node\", mode=\"idle\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} total",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (instance) (rate(node_cpu_seconds_total{job=\"node\", mode=\"iowait\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} iowait",
+          "refId": "B"
+        }
+      ],
+      "title": "CPU Utilization (per node)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Aggregate HDD write throughput. Each node has 11-12 HDDs. At ~150 MiB/s per drive, theoretical max is ~1.8 GiB/s per node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 66
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(node_disk_written_bytes_total{job=\"node\", device=~\"sd[a-m]\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Write Throughput (per node, HDD aggregate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Average write latency across all HDDs. EC writes wait for the slowest shard \u2014 tail latency matters more than average.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 66
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg by (instance) (rate(node_disk_write_time_seconds_total{job=\"node\", device=~\"sd[a-m]\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{job=\"node\", device=~\"sd[a-m]\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} avg",
+          "refId": "A"
+        },
+        {
+          "expr": "max by (instance) (rate(node_disk_write_time_seconds_total{job=\"node\", device=~\"sd[a-m]\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{job=\"node\", device=~\"sd[a-m]\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} worst disk",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk Write Latency (per node, HDD avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Available memory. Each OSD targets ~4 GiB. With 12-14 OSDs + RGW + monitoring, memory pressure can throttle performance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 66
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "node_memory_MemTotal_bytes{job=\"node\"} - node_memory_MemAvailable_bytes{job=\"node\"}",
+          "legendFormat": "{{instance}} used",
+          "refId": "A"
+        },
+        {
+          "expr": "node_memory_MemTotal_bytes{job=\"node\"}",
+          "legendFormat": "{{instance}} total",
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Usage (per node)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Read (-) / Write (+)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reads"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "rate(ceph_pool_rd{cluster=~\"$cluster\"}[$__rate_interval]) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "reads",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "rate(ceph_pool_wr{cluster=~\"$cluster\"}[$__rate_interval]) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "writes",
+          "refId": "B"
+        }
+      ],
+      "title": "Client IOPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Read (-) / Write (+)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reads"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "rate(ceph_pool_rd_bytes{cluster=~\"$cluster\"}[$__rate_interval]) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "reads",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "rate(ceph_pool_wr_bytes{cluster=~\"$cluster\"}[$__rate_interval]) * on(pool_id) group_left(name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\"}",
+          "legendFormat": "writes",
+          "refId": "B"
+        }
+      ],
+      "title": "Client Throughput",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "rows": [],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "ceph",
+    "rgw",
+    "s3",
+    "custom"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data Source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": "cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "label_values(ceph_health_status, cluster)",
+        "refresh": 1,
+        "regex": "(.*)",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "staging-z1.rgw.buckets.data",
+          "value": "staging-z1.rgw.buckets.data"
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pool Name",
+        "multi": false,
+        "name": "pool_name",
+        "options": [],
+        "query": "label_values(ceph_pool_metadata{cluster=~\"$cluster\", }, name)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "RGW Bucket Capacity & Performance",
+  "uid": "pool-details-custom",
+  "version": 1
+}

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -76,7 +76,8 @@
     dest: /etc/ceph/monitoring-spec.yaml
     owner: root
     group: root
-    mode: '0644'
+    # 0600: the spec now carries the grafana initial_admin_password.
+    mode: '0600'
   when:
     - inventory_hostname in groups['ceph_bootstrap']
     - (ceph_bind_networks | default([]) | length) > 0
@@ -228,7 +229,19 @@
   when:
     - inventory_hostname in groups['ceph_bootstrap']
     - grafana_container.stdout | default('') | length > 0
+  register: grafana_pw_reset
   changed_when: false
+  # grafana-cli exits 0 when there is NO admin user to reset (it prints
+  # "specify a user-id" over an empty user list), so rc alone green-lights a
+  # no-op and the vault password never lands (spice, 2026-07-21: fresh
+  # tentacle grafana ships disable_initial_admin_creation, user table empty,
+  # this task "ok" on every converge). The admin is seeded by
+  # initial_admin_password in the monitoring spec; if it is still absent,
+  # fail loudly instead.
+  failed_when: >-
+    (grafana_pw_reset.rc | default(1)) != 0
+    or 'specify a user-id'
+       in ((grafana_pw_reset.stdout | default('')) + (grafana_pw_reset.stderr | default('')))
   no_log: true
   tags: [grafana_admin_password]
 
@@ -248,6 +261,35 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
   no_log: true
+
+# --- Step 4.5: Provision custom Grafana dashboards ---
+
+# Dashboards committed under files/grafana-dashboards/ are uploaded via the
+# Grafana API as the (now seeded) admin, so they live in the repo instead of
+# hand-uploads that a fresh cluster silently lacks (spice shipped without the
+# RGW capacity dashboard until 2026-07-21). overwrite keeps them converged;
+# the cephadm file-provisioned stock dashboards are untouched.
+- name: Upload custom Grafana dashboards
+  ansible.builtin.uri:
+    url: "https://{{ hostvars[groups['ceph_bootstrap'][0]]['ceph_service_ip'] }}:{{ ceph_grafana_port }}/api/dashboards/db"
+    method: POST
+    url_username: "{{ ceph_grafana_admin_user }}"
+    url_password: "{{ ceph_grafana_admin_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    body_format: json
+    body:
+      dashboard: "{{ lookup('ansible.builtin.file', item) | from_json }}"
+      overwrite: true
+      message: provisioned by ansible (ceph_deploy)
+    status_code: 200
+  loop: "{{ query('ansible.builtin.fileglob', role_path ~ '/files/grafana-dashboards/*.json') }}"
+  loop_control:
+    label: "{{ item | basename }}"
+  when: inventory_hostname in groups['ceph_bootstrap']
+  changed_when: false
+  no_log: true
+  tags: [grafana_dashboards]
 
 # --- Step 5: Display monitoring endpoints ---
 

--- a/ansible/ceph/roles/ceph_deploy/templates/monitoring-spec.yaml.j2
+++ b/ansible/ceph/roles/ceph_deploy/templates/monitoring-spec.yaml.j2
@@ -21,6 +21,15 @@ networks:
 service_type: grafana
 placement:
   count: 1
+spec:
+  # Seed the admin user: tentacle cephadm renders grafana with
+  # disable_initial_admin_creation, so without this no admin exists and the
+  # reset-admin-password enforcement below has nothing to reset (it exits 0
+  # anyway - see that task's failed_when). anonymous_access/protocol restate
+  # the cephadm defaults so a re-apply of this spec cannot drop them.
+  initial_admin_password: "{{ ceph_grafana_admin_password }}"
+  anonymous_access: true
+  protocol: https
 {% if ceph_bind_networks | default([]) | length > 0 %}
 networks:
 {% for net in ceph_bind_networks %}


### PR DESCRIPTION
Grafana on a fresh cluster now gets a working admin login and the custom dashboards without hand work. Tentacle cephadm renders grafana with disable\_initial\_admin\_creation, so no admin user ever exists; the reset-admin-password enforcement then exits 0 while resetting nothing (grafana-cli prints "specify a user-id" over an empty user list), and CI green-lit that no-op on every spice converge -- admin login was dead since bootstrap. The monitoring spec now carries initial\_admin\_password (rendered spec file tightened to 0600) so cephadm seeds the admin, and the reset task gains a failed\_when that treats the no-op output as a failure. Dashboards committed under files/grafana-dashboards/ (starting with the 31-panel RGW Bucket Capacity & Performance from sietch) are uploaded via the Grafana API each converge, so they live in grafana's DB and survive redeploys. Verified on spice: admin seeded with exactly the config this spec renders, login 200, API upload green.

- `main` <!-- branch-stack -->
  - \#283 :point\_left:
