### PR TITLE
feat(ceph): trust the netbird overlay interface in nftables

### DIFF
--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -317,5 +317,12 @@ ceph_firewall_rgw_any_source: false
 # wholesale so established OSD flows survive firewall (re)activation instead
 # of dying on the drop policy (see the security role defaults for the full
 # rationale; 2026-07-20 incident).
+# wt0 is the NetBird overlay: NetBird's own policy engine (default-deny,
+# group-scoped, enforced in its own nftables table) is the access-control
+# plane for mesh traffic, so this firewall must not second-guess it per port.
+# In particular netbird-ssh DNATs overlay :22 to :22022 on the netbird
+# address, which a dport allow-list here would silently drop post-DNAT. Inert until a
+# node is enrolled (no wt0 = no match), so it ships ahead of the peer rollout.
 ceph_firewall_trusted_ifaces:
   - bond0.122
+  - wt0


### PR DESCRIPTION
The node firewall now accepts the NetBird overlay interface (wt0) wholesale, making NetBird's default-deny policy engine the single access-control plane for mesh traffic ahead of enrolling the spice nodes as peers. Port-level rules here would fight it: netbird-ssh DNATs overlay :22 to :22022 before our input chain runs, so a dport allow-list silently drops it. The rule is inert until a node is enrolled (no wt0, no match), so it converges to the fleet ahead of the peer rollout with no behavior change today; WAN :22 exposure is unchanged and stays a separate decision.

- `main` <!-- branch-stack -->
  - \#285 :point\_left:
