### PR TITLE
feat(ceph): netbird ssh server for spice (sso-gated human access)

### DIFF
--- a/ansible/ceph/.mise.toml
+++ b/ansible/ceph/.mise.toml
@@ -112,7 +112,13 @@ ACCT=(); [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && ACCT=(--account "${OP_ACCOUNT
 # needed for FRESH enrollment only; converge of enrolled nodes runs key-free via
 # site.yml/deploy.
 NB_SETUP_KEY=$(op read "${ACCT[@]}" "op://yucca_tf_prod/NETBIRD_YUCCA_PROD_HTZ_FSN1_CEPH_SETUP_KEY/password")
-scripts/ansible-play.sh netbird.yml --extra-vars "ceph_netbird_setup_key=$NB_SETUP_KEY" "$@"
+# NetBird API token (management PAT): sets ssh_enabled per peer, which the
+# client --allow-server-ssh flag alone cannot do. Only needed to enable the
+# SSH server; enrollment-only runs work without it.
+NB_API_TOKEN=$(op read "${ACCT[@]}" "op://shared_tf/NETBIRD_TF_PAT/password")
+scripts/ansible-play.sh netbird.yml \
+  --extra-vars "ceph_netbird_setup_key=$NB_SETUP_KEY" \
+  --extra-vars "ceph_netbird_api_token=$NB_API_TOKEN" "$@"
 """
 
 [tasks.deploy]

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -333,3 +333,8 @@ ceph_firewall_trusted_ifaces:
 # Fresh enrollment: `mise run netbird` (canary --limit spice-ceph-philip first);
 # converge of enrolled nodes is key-free. See roles/netbird.
 ceph_netbird_enabled: true
+# Human SSH is SSO/policy-gated via NetBird's own server (overlay :22 -> :22022,
+# wt0-scoped so cephadm/ansible key SSH on fabric+WAN are untouched). Root off:
+# operators `netbird ssh ops@<node>` and sudo. `mise run netbird` sets the
+# per-peer management flag via the API.
+ceph_netbird_ssh_server: true

--- a/ansible/ceph/roles/netbird/defaults/main.yml
+++ b/ansible/ceph/roles/netbird/defaults/main.yml
@@ -22,3 +22,18 @@ ceph_netbird_management_url: "https://api.netbird.io"
 # carry this role with no secrets plumbing. A reimaged node fails the assert
 # below with instructions until an operator runs `mise run netbird` for it.
 ceph_netbird_setup_key: ""
+
+# --- NetBird SSH server (SSO/policy-gated human access over the overlay) ---
+# When true, netbird runs its own SSH server and DNATs overlay :22 -> :22022
+# (the DNAT is wt0-scoped, so sshd keeps fabric+WAN :22 and cephadm + ansible
+# are unaffected). Humans reach nodes with `netbird ssh ops@<node>` and sudo;
+# root login is deliberately OFF. Enabling needs BOTH the client flag below AND
+# ssh_enabled=true on the management side, which is a per-peer NetBird API call
+# (the client flag alone is not enough - verified 2026-07-22). So the API token
+# must be provided: `mise run netbird` reads it from op://shared_tf/
+# NETBIRD_TF_PAT. A token-less converge (CI deploy pipeline) is a no-op on
+# already-enabled peers and leaves un-enabled ones for `mise run netbird`.
+ceph_netbird_ssh_server: false
+ceph_netbird_ssh_sftp: true
+ceph_netbird_api_url: "https://api.netbird.io"
+ceph_netbird_api_token: ""

--- a/ansible/ceph/roles/netbird/tasks/main.yml
+++ b/ansible/ceph/roles/netbird/tasks/main.yml
@@ -31,11 +31,17 @@
     update_cache: true
   changed_when: false
 
-- name: Unhold netbird for the pinned install (no-op unless previously held)
+- name: Query the installed netbird version
+  ansible.builtin.command: dpkg-query -W -f='${Version}' netbird
+  register: ceph_netbird_installed
+  changed_when: false
+  failed_when: false
+
+- name: Unhold netbird only when the pinned version differs (keeps converge clean)
   ansible.builtin.dpkg_selections:
     name: netbird
     selection: install
-  failed_when: false
+  when: (ceph_netbird_installed.stdout | default('')) != ceph_netbird_version
 
 - name: Install NetBird at the pinned version
   ansible.builtin.apt:
@@ -118,3 +124,98 @@
       {{ inventory_hostname }} received overlay network routes - the ceph peer
       group must stay out of all NetBird network distribution groups. Fix the
       TF (tf/deployment/prod/htz-fsn1/netbird) before enrolling further nodes.
+
+# --- NetBird SSH server (SSO-gated human access; ops+sudo, root off) ---
+# Gated on the API token so a token-less converge is a no-op on already-enabled
+# peers. The DNAT is wt0-scoped, so cephadm (fabric) and ansible (WAN) keep
+# key-based sshd on :22 - verified on the philip canary 2026-07-22.
+
+- name: Look up this peer in the NetBird API
+  ansible.builtin.uri:
+    url: "{{ ceph_netbird_api_url }}/api/peers"
+    headers:
+      Authorization: "Token {{ ceph_netbird_api_token }}"
+  delegate_to: localhost
+  register: ceph_netbird_peers
+  no_log: true
+  when:
+    - ceph_netbird_ssh_server | bool
+    - ceph_netbird_api_token | length > 0
+
+- name: Record this peer's id and current ssh state
+  ansible.builtin.set_fact:
+    ceph_netbird_peer: >-
+      {{ ceph_netbird_peers.json
+         | selectattr('name', 'equalto', inventory_hostname)
+         | list | first | default({}) }}
+  when:
+    - ceph_netbird_ssh_server | bool
+    - ceph_netbird_api_token | length > 0
+
+- name: Enable ssh_enabled on the peer (management side; preserves other fields)
+  ansible.builtin.uri:
+    url: "{{ ceph_netbird_api_url }}/api/peers/{{ ceph_netbird_peer.id }}"
+    method: PUT
+    headers:
+      Authorization: "Token {{ ceph_netbird_api_token }}"
+    body_format: json
+    body:
+      name: "{{ ceph_netbird_peer.name }}"
+      ssh_enabled: true
+      login_expiration_enabled: "{{ ceph_netbird_peer.login_expiration_enabled | default(false) }}"
+      inactivity_expiration_enabled: "{{ ceph_netbird_peer.inactivity_expiration_enabled | default(false) }}"
+    status_code: 200
+  delegate_to: localhost
+  no_log: true
+  when:
+    - ceph_netbird_ssh_server | bool
+    - ceph_netbird_api_token | length > 0
+    - ceph_netbird_peer.id is defined
+    - not (ceph_netbird_peer.ssh_enabled | default(false))
+
+- name: Check whether the netbird-ssh server is listening (:22022)
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      ss -tlnH | awk '{print $4}' | grep -cE ':22022$' || true
+    executable: /bin/bash
+  register: ceph_netbird_ssh_listen
+  changed_when: false
+  when:
+    - ceph_netbird_ssh_server | bool
+    - ceph_netbird_api_token | length > 0
+
+- name: Apply the server-ssh client flags (down/up over WAN)
+  # `netbird up` short-circuits on a connected peer ("Already connected"), so a
+  # down/up cycle is needed to (re)apply client flags. Safe: ansible connects
+  # over the WAN, and the cycle drops only the overlay. The server binds once
+  # both the client flag and management ssh_enabled agree. Idempotent - skipped
+  # once :22022 already listens. No --enable-ssh-root: humans use ops + sudo.
+  ansible.builtin.shell: |
+    set -e
+    netbird down
+    sleep 2
+    netbird up \
+      --management-url {{ ceph_netbird_management_url }} \
+      --hostname {{ inventory_hostname }} \
+      --allow-server-ssh {{ '--enable-ssh-sftp' if ceph_netbird_ssh_sftp else '' }}
+  changed_when: true
+  when:
+    - ceph_netbird_ssh_server | bool
+    - ceph_netbird_api_token | length > 0
+    - (ceph_netbird_ssh_listen.stdout | default('0') | trim) == '0'
+
+- name: Assert the netbird-ssh server is listening on :22022
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      ss -tlnH | awk '{print $4}' | grep -cE ':22022$' || true
+    executable: /bin/bash
+  register: ceph_netbird_ssh_final
+  changed_when: false
+  retries: 6
+  delay: 5
+  until: (ceph_netbird_ssh_final.stdout | trim) == '1'
+  when:
+    - ceph_netbird_ssh_server | bool
+    - ceph_netbird_api_token | length > 0


### PR DESCRIPTION
Human SSH to the spice nodes moves to NetBird's own SSO/policy-gated server: the netbird role now sets the client --allow-server-ssh/--enable-ssh-sftp flags AND, via the NetBird API, the per-peer ssh\_enabled flag the client flag alone cannot set. NetBird DNATs overlay :22 to :22022 scoped to wt0, so sshd keeps fabric+WAN :22 and cephadm (fabric) plus ansible (WAN) key-based access are untouched, verified on the philip canary. Root login stays off: operators run `netbird ssh ops@<node>` and sudo. `mise run netbird` supplies the API token (op\://shared\_tf/NETBIRD\_TF\_PAT); a token-less converge is a clean no-op on enabled peers (idempotency confirmed on philip, changed=0). Rollout is the operator step: canary spice-ceph-philip (already enabled), then `mise run netbird` for the fleet. Note: ssh\_enabled is a management-side API call, not TF, so a reimaged node re-enrolls without it until `mise run netbird` runs.

- `main` <!-- branch-stack -->
  - \#290 :point\_left:
