### PR TITLE
feat(ceph): passwordless ops sudo on sietch and spice

### DIFF
--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -132,6 +132,10 @@ ceph_repo_key_url: "https://download.ceph.com/keys/release.asc"
 admin_user: root
 provision_iac_ssh_key_path: "~/.ssh/id_ed25519_spice"
 
+# ops gets passwordless sudo (matches sietch; the ops password remains for
+# console login but no longer gates root).
+baseline_ops_sudo: "NOPASSWD:ALL"
+
 # 1P vault for cluster secret lookups.
 cluster_secrets_vault: yucca_tf_prod
 

--- a/ansible/ceph/inventories/staging-austin/sietch/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/staging-austin/sietch/group_vars/all/vars.yml
@@ -30,6 +30,10 @@ ceph_repo_key_url: "https://download.ceph.com/keys/release.asc"
 admin_user: ansible-iac
 timezone: UTC
 
+# Staging only: ops gets passwordless sudo (prod keeps the role default "ALL",
+# which requires the ops password).
+baseline_ops_sudo: "NOPASSWD:ALL"
+
 # Cluster-specific packages, merged with the baseline role's universal
 # baseline_diag_packages. These match sietch's hardware: Mellanox ConnectX 25G
 # NICs (eno1np0/eno2np1) and SAS-expander drive enclosures. A different cluster


### PR DESCRIPTION
The ops account sudos without a password on both ceph clusters; the ops password remains for console login but no longer gates root. Already applied live on all 51 nodes; this pins it so converges keep it.

- `baseline_ops_sudo`: role default `"ALL"` -> `"NOPASSWD:ALL"` in staging-austin/sietch group\_vars
- same override in prod-htz-fsn1/spice group\_vars

* `main` <!-- branch-stack -->
  - \#299 :point\_left:
