### PR TITLE
fix(mgmt): vlan interface names exceeded IFNAMSIZ

### DIFF
--- a/ansible/mgmt/roles/networkd/handlers/main.yml
+++ b/ansible/mgmt/roles/networkd/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
-- name: Reload systemd for networkd
+# RESTART, not reload: `networkctl reload` re-reads .network files but never
+# creates netdevs from new/renamed .netdev files — the VLAN sub-interfaces
+# would silently not exist (2026-07 mgmt converge). Only the fabric NIC and
+# OOB are networkd-managed; the WAN is unmanaged, so a restart can't drop it.
+- name: Restart systemd-networkd
   ansible.builtin.systemd:
     name: systemd-networkd
-    state: reloaded
+    state: restarted

--- a/ansible/mgmt/roles/networkd/tasks/deploy.yml
+++ b/ansible/mgmt/roles/networkd/tasks/deploy.yml
@@ -18,7 +18,7 @@
     group: root
     mode: '0644'
   when: mgmt_oob.nic is defined
-  notify: Reload systemd for networkd
+  notify: Restart systemd-networkd
 
 # ── 25G fabric VLAN sub-interfaces ──────────────────────────────────────────
 - name: Deploy fabric parent .network (declares VLANs, no L3 of its own)
@@ -28,12 +28,12 @@
     owner: root
     group: root
     mode: '0644'
-  notify: Reload systemd for networkd
+  notify: Restart systemd-networkd
 
 - name: Deploy VLAN .netdev files
   ansible.builtin.template:
     src: vlan.netdev.j2
-    dest: "{{ mgmt_networkd_config_dir }}/30-{{ mgmt_fabric_nic }}.{{ vlan.id }}.netdev"
+    dest: "{{ mgmt_networkd_config_dir }}/30-vlan{{ vlan.id }}.netdev"
     owner: root
     group: root
     mode: '0644'
@@ -41,12 +41,12 @@
   loop_control:
     loop_var: vlan
     label: "vlan {{ vlan.id }}"
-  notify: Reload systemd for networkd
+  notify: Restart systemd-networkd
 
 - name: Deploy VLAN .network files
   ansible.builtin.template:
     src: vlan.network.j2
-    dest: "{{ mgmt_networkd_config_dir }}/30-{{ mgmt_fabric_nic }}.{{ vlan.id }}.network"
+    dest: "{{ mgmt_networkd_config_dir }}/30-vlan{{ vlan.id }}.network"
     owner: root
     group: root
     mode: '0644'
@@ -54,4 +54,34 @@
   loop_control:
     loop_var: vlan
     label: "vlan {{ vlan.id }}"
-  notify: Reload systemd for networkd
+  notify: Restart systemd-networkd
+
+# Migration from the dotted <nic>.<id> naming (pre-2026-07): remove the old
+# config files (incl. the hand-applied lb-internal drop-in dir — the route is
+# TF-rendered into vlan routes now) and the old kernel links, so the renamed
+# vlan<id> netdevs don't coexist with same-address duplicates.
+- name: Find old dotted-name VLAN configs
+  ansible.builtin.find:
+    paths: "{{ mgmt_networkd_config_dir }}"
+    patterns: "30-{{ mgmt_fabric_nic }}.*"
+    file_type: any
+  register: old_vlan_cfgs
+
+- name: Remove old dotted-name VLAN configs
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ old_vlan_cfgs.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  notify: Restart systemd-networkd
+
+- name: Remove old dotted-name kernel links
+  ansible.builtin.command: ip link delete {{ mgmt_fabric_nic }}.{{ vlan.id }}
+  loop: "{{ mgmt_fabric_vlans }}"
+  loop_control:
+    loop_var: vlan
+    label: "{{ mgmt_fabric_nic }}.{{ vlan.id }}"
+  register: old_link_del
+  changed_when: old_link_del.rc == 0
+  failed_when: false

--- a/ansible/mgmt/roles/networkd/templates/fabric.network.j2
+++ b/ansible/mgmt/roles/networkd/templates/fabric.network.j2
@@ -9,7 +9,7 @@ Name={{ mgmt_fabric_nic }}
 
 [Network]
 {% for vlan in mgmt_fabric_vlans %}
-VLAN={{ mgmt_fabric_nic }}.{{ vlan.id }}
+VLAN=vlan{{ vlan.id }}
 {% endfor %}
 LinkLocalAddressing=no
 IPv6AcceptRA=no

--- a/ansible/mgmt/roles/networkd/templates/vlan.netdev.j2
+++ b/ansible/mgmt/roles/networkd/templates/vlan.netdev.j2
@@ -1,8 +1,10 @@
 # {{ ansible_managed }}
-# Tagged VLAN {{ vlan.id }} sub-interface on {{ mgmt_fabric_nic }}.
+# Tagged VLAN {{ vlan.id }} sub-interface on {{ mgmt_fabric_nic }}. Short
+# `vlan<id>` name: `{{ mgmt_fabric_nic }}.{{ vlan.id }}` overflows the kernel's
+# 15-char IFNAMSIZ for 3-digit VLAN ids and networkd silently ignores it.
 
 [NetDev]
-Name={{ mgmt_fabric_nic }}.{{ vlan.id }}
+Name=vlan{{ vlan.id }}
 Kind=vlan
 
 [VLAN]

--- a/ansible/mgmt/roles/networkd/templates/vlan.network.j2
+++ b/ansible/mgmt/roles/networkd/templates/vlan.network.j2
@@ -2,10 +2,16 @@
 # L3 on VLAN {{ vlan.id }} sub-interface: {{ vlan.address }} (gateway .1 on the leaf IRB).
 
 [Match]
-Name={{ mgmt_fabric_nic }}.{{ vlan.id }}
+Name=vlan{{ vlan.id }}
 
 [Network]
 Address={{ vlan.address }}
 
 [Link]
 RequiredForOnline=no
+{% for route in vlan.routes | default([]) %}
+
+[Route]
+Destination={{ route.to }}
+Gateway={{ route.via }}
+{% endfor %}

--- a/tf/render/ansible-mgmt/main.tf
+++ b/tf/render/ansible-mgmt/main.tf
@@ -64,7 +64,12 @@ resource "local_file" "host_vars" {
       { id = module.addressing.public_vlan_id, address = "${cidrhost(module.addressing.public_cidr, each.value.host_index)}/${local.pub_mask}" },
       { id = module.addressing.private_vlan_id, address = "${cidrhost(module.addressing.private_cidr, each.value.host_index)}/${local.priv_mask}" },
       { id = module.addressing.host_mgmt_vlan_id, address = "${cidrhost(module.addressing.host_mgmt_cidr, each.value.host_index)}/${local.host_mgmt_mask}" },
-      { id = module.addressing.kube_vlan_id, address = "${cidrhost(module.addressing.kube_cidr, each.value.host_index)}/${local.kube_mask}" },
+      # lb_internal route: the mgmt hosts are the NetBird routing peers for the
+      # internal LB VIPs; the spine (kube IRB .1) carries the /32s via iBGP.
+      # Previously a hand-applied networkd drop-in — owned here now.
+      { id = module.addressing.kube_vlan_id, address = "${cidrhost(module.addressing.kube_cidr, each.value.host_index)}/${local.kube_mask}", routes = [
+        { to = module.addressing.lb_internal_cidr, via = cidrhost(module.addressing.kube_cidr, 1) },
+      ] },
     ]
   })}"
 }


### PR DESCRIPTION
Interfaces names with vlan in the 100 range where 16 characters which is one too many