### PR TITLE
feat(ceph): enable telemetry phone-home for transparency

### DIFF
--- a/ansible/ceph/docs/security-model.md
+++ b/ansible/ceph/docs/security-model.md
@@ -211,14 +211,24 @@ cluster, including the authenticated user, timestamp, and command arguments.
 
 ## Telemetry
 
-Telemetry phone-home is explicitly disabled:
+Telemetry phone-home is **enabled** -- Yucca is built in the open, so the cluster
+contributes anonymized data upstream to the Ceph project:
 
 ```
-ceph_telemetry_enabled: false
+ceph_telemetry_enabled: true
 ```
 
-No cluster metadata, performance data, or crash reports are sent to upstream
-Ceph. All data stays within the cluster boundary.
+All channels are on: basic (cluster shape, pool usage), crash (daemon crash
+reports), perf (performance counters), ident (cluster identity), and device
+(drive health / failure data). Reports are anonymous -- no contact or
+organization is attached and the public leaderboard is off. Data is shared under
+the Ceph `sharing-1-0` license; the device channel in particular feeds the
+upstream drive-failure-prediction dataset.
+
+Tradeoff worth noting: the device channel's per-drive UUIDs are UUID-v1 and embed
+the mgr host's MAC, so they act as a stable per-cluster fingerprint rather than
+being truly anonymous. This is an accepted consequence of building in the open.
+Set `ceph_telemetry_enabled: false` per-cluster to opt a cluster back out.
 
 ## Network topology
 

--- a/ansible/ceph/roles/ceph_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/defaults/main.yml
@@ -2,8 +2,10 @@
 # Post-deploy Ceph cluster tuning
 # These require a running cluster (ceph config set / ceph commands).
 
-# Disable telemetry phone-home
-ceph_telemetry_enabled: false
+# Enable telemetry phone-home. Yucca is built in the open, so the cluster
+# contributes anonymized data upstream to the Ceph project (all channels; no
+# contact/org attached; leaderboard off). Set false per-cluster to opt out.
+ceph_telemetry_enabled: true
 
 # OSD recovery throttling (also in cluster-spec.yml.j2 initial config,
 # but re-asserted here for idempotency after config changes)
@@ -19,12 +21,12 @@ ceph_osd_deep_scrub_interval: 604800    # 7 days
 # PG autoscaler
 ceph_mon_target_pg_per_osd: 100
 
-# BlueStore block.db — 0 means use the entire LV
+# BlueStore block.db: 0 means use the entire LV
 ceph_bluestore_block_db_size: 0
 
 # Log rotation retention (days)
 ceph_log_retention_days: 30
 
-# Audit logging — logs ceph admin commands to the cluster log channel.
+# Audit logging: records ceph admin commands to the cluster log channel.
 # Viewable via: ceph log last -W audit
 ceph_audit_enabled: true

--- a/ansible/ceph/roles/ceph_tuning/tasks/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/tasks/main.yml
@@ -14,6 +14,14 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
+- name: Enable telemetry phone-home (transparency; anonymous, all channels)
+  ansible.builtin.command: ceph telemetry on --license sharing-1-0
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - ceph_telemetry_enabled | bool
+    - not ((telemetry_status.stdout | from_json).enabled | default(false))
+  changed_when: true
+
 - name: Disable telemetry phone-home
   ansible.builtin.command: ceph telemetry off
   when:


### PR DESCRIPTION
Ceph telemetry is now enabled by default: Yucca builds in the open, so clusters contribute anonymized basic/crash/perf/ident/device data upstream to the Ceph project. The ceph\_tuning role gains an enable path (ceph telemetry on --license sharing-1-0) alongside the existing opt-out, so tune-ceph converges to on; reports stay anonymous, with no contact/org attached and the public leaderboard off. One tradeoff is documented in the security model: the device channel's UUID-v1 device ids embed the mgr host's MAC, so they act as a stable per-cluster fingerprint rather than being truly anonymous. This flips the shared default org-wide (spice already matches this state, so no live change is needed); a cluster opts back out with ceph\_telemetry\_enabled: false in its group\_vars. See ansible/ceph/docs/security-model.md.

- `main` <!-- branch-stack -->
  - \#316 :point\_left:
