### PR TITLE
fix(michael): dramatically improve michael latencies

### DIFF
--- a/o11y/dashboards/yucca-michael.json
+++ b/o11y/dashboards/yucca-michael.json
@@ -728,12 +728,541 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate({__name__=\"http.server.request.ttfb_bucket\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate({__name__=\"http.server.request.ttfb_bucket\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate({__name__=\"http.server.request.ttfb_bucket\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Request TTFB (quantiles)",
+      "type": "timeseries",
+      "description": "Time to first response byte — michael+RGW latency without body streaming (request duration includes the transfer, so large blobs skew it)."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum(rate({__name__=\"auth.cache.hits\", cluster=~\"$cluster\"}[$__rate_interval])) / (sum(rate({__name__=\"auth.cache.hits\", cluster=~\"$cluster\"}[$__rate_interval])) + sum(rate({__name__=\"auth.cache.misses\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "title": "JWT verify cache hit ratio",
+      "type": "timeseries",
+      "description": "ECDSA verify cost is only paid on misses. restic reuses one token per session, so this should sit near 100%."
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 31
+      },
+      "id": 20,
+      "panels": [],
+      "title": "S3 client (transport to RGW)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum(rate({__name__=\"s3.client.dials\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "TCP dials"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "B",
+          "expr": "sum(rate({__name__=\"s3.client.tls_handshake.duration_count\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "TLS handshakes"
+        }
+      ],
+      "title": "Connection churn",
+      "type": "timeseries",
+      "description": "New TCP connections and TLS handshakes to RGW. Near zero once pools are warm; sustained churn means idle-pool exhaustion or backend churn."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum(rate({__name__=\"s3.client.connections\", cluster=~\"$cluster\", reused=\"true\"}[$__rate_interval])) / sum(rate({__name__=\"s3.client.connections\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "reuse ratio"
+        }
+      ],
+      "title": "Connection reuse ratio",
+      "type": "timeseries",
+      "description": "Share of S3 requests served over a pooled connection."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, method) (rate({__name__=\"s3.client.ttfb_bucket\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "{{method}}"
+        }
+      ],
+      "title": "S3 TTFB p95 by method",
+      "type": "timeseries",
+      "description": "RGW response latency per S3 method. PUT includes the request body upload, so it tracks pack size, not gateway latency."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate({__name__=\"s3.client.tls_handshake.duration_bucket\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate({__name__=\"s3.client.tls_handshake.duration_bucket\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "title": "TLS handshake duration (quantiles)",
+      "type": "timeseries",
+      "description": "Empty once pools are warm — no handshakes, no samples."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
       },
       "id": 13,
       "panels": [],
@@ -789,7 +1318,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 49
       },
       "id": 14,
       "options": {
@@ -878,7 +1407,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 49
       },
       "id": 15,
       "options": {
@@ -957,7 +1486,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 57
       },
       "id": 16,
       "options": {
@@ -1036,7 +1565,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 57
       },
       "id": 17,
       "options": {

--- a/packages/michael/internal/auth/auth.go
+++ b/packages/michael/internal/auth/auth.go
@@ -3,10 +3,12 @@ package auth
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"michael/internal/httputil"
 
@@ -39,10 +41,66 @@ func FromContext(ctx context.Context) Auth {
 	return ctx.Value(authContextKey).(Auth)
 }
 
-func Middleware(publicKey *ecdsa.PublicKey) func(http.Handler) http.Handler {
+const (
+	cacheSize = 8192
+	// cache lifetime for tokens carrying no exp claim
+	defaultCacheTTL = 5 * time.Minute
+)
+
+// Verifier authenticates requests, caching verified tokens so the hot path is
+// a map lookup instead of an ECDSA verify per request (restic reuses one token
+// for a whole session). Only signature-valid tokens enter the cache, and
+// entries expire with the token's exp claim.
+type Verifier struct {
+	publicKey *ecdsa.PublicKey
+	cache     *tokenCache
+	onLookup  func(hit bool)
+}
+
+// NewVerifier builds a Verifier. onLookup, if non-nil, is called with the
+// cache outcome of every authenticated request.
+func NewVerifier(publicKey *ecdsa.PublicKey, onLookup func(hit bool)) *Verifier {
+	return &Verifier{
+		publicKey: publicKey,
+		cache:     newTokenCache(cacheSize),
+		onLookup:  onLookup,
+	}
+}
+
+func (v *Verifier) authenticate(r *http.Request) (Auth, *authError) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return Auth{}, &authError{http.StatusUnauthorized, "Missing Authorization header"}
+	}
+
+	key := sha256.Sum256([]byte(header))
+	if a, ok := v.cache.get(key, time.Now()); ok {
+		v.lookup(true)
+		return a, nil
+	}
+	v.lookup(false)
+
+	a, exp, err := extractAuth(r, v.publicKey)
+	if err != nil {
+		return Auth{}, err
+	}
+	if exp.IsZero() {
+		exp = time.Now().Add(defaultCacheTTL)
+	}
+	v.cache.put(key, a, exp)
+	return a, nil
+}
+
+func (v *Verifier) lookup(hit bool) {
+	if v.onLookup != nil {
+		v.onLookup(hit)
+	}
+}
+
+func (v *Verifier) Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			auth, err := extractAuth(r, publicKey)
+			auth, err := v.authenticate(r)
 			if err != nil {
 				httputil.WriteError(w, r, err.code, err.message)
 				return
@@ -61,6 +119,10 @@ func Middleware(publicKey *ecdsa.PublicKey) func(http.Handler) http.Handler {
 	}
 }
 
+func Middleware(publicKey *ecdsa.PublicKey) func(http.Handler) http.Handler {
+	return NewVerifier(publicKey, nil).Middleware()
+}
+
 type authError struct {
 	code    int
 	message string
@@ -70,14 +132,16 @@ func (e *authError) Error() string {
 	return e.message
 }
 
-func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, *authError) {
+// extractAuth verifies the request's token and returns the Auth plus the
+// token's exp claim (zero if absent).
+func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, *authError) {
 	header := r.Header.Get("Authorization")
 	if header == "" {
-		return Auth{}, &authError{http.StatusUnauthorized, "Missing Authorization header"}
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Missing Authorization header"}
 	}
 
 	if !strings.HasPrefix(header, "Basic ") {
-		return Auth{}, &authError{http.StatusUnauthorized, "Expected Basic auth"}
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Expected Basic auth"}
 	}
 
 	encoded := strings.TrimPrefix(header, "Basic ")
@@ -86,13 +150,13 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, *authError)
 		// Try URL-safe or raw encoding
 		decoded, err = base64.RawStdEncoding.DecodeString(encoded)
 		if err != nil {
-			return Auth{}, &authError{http.StatusUnauthorized, "Invalid base64 in Authorization header"}
+			return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid base64 in Authorization header"}
 		}
 	}
 
 	parts := strings.SplitN(string(decoded), ":", 2)
 	if len(parts) < 2 || parts[1] == "" {
-		return Auth{}, &authError{http.StatusUnauthorized, "Expected Basic auth token"}
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Expected Basic auth token"}
 	}
 
 	token := parts[1]
@@ -104,12 +168,12 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, *authError)
 		return publicKey, nil
 	})
 	if err != nil {
-		return Auth{}, &authError{http.StatusUnauthorized, "Invalid JWT Token"}
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid JWT Token"}
 	}
 
 	claims, ok := parsed.Claims.(jwt.MapClaims)
 	if !ok {
-		return Auth{}, &authError{http.StatusUnauthorized, "Invalid JWT claims"}
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid JWT claims"}
 	}
 
 	// Extract and validate auth fields
@@ -117,21 +181,26 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, *authError)
 
 	user, ok := claims["user"].(string)
 	if !ok || !isValidUUID(user) {
-		return Auth{}, &authError{http.StatusBadRequest, "user must be a UUID"}
+		return Auth{}, time.Time{}, &authError{http.StatusBadRequest, "user must be a UUID"}
 	}
 	auth.User = user
 
 	repository, ok := claims["repository"].(string)
 	if !ok || !isValidUUID(repository) {
-		return Auth{}, &authError{http.StatusBadRequest, "repository must be a UUID"}
+		return Auth{}, time.Time{}, &authError{http.StatusBadRequest, "repository must be a UUID"}
 	}
 	auth.Repository = repository
 
 	writeOnce, ok := claims["writeOnce"].(bool)
 	if !ok {
-		return Auth{}, &authError{http.StatusBadRequest, "writeOnce must be a boolean"}
+		return Auth{}, time.Time{}, &authError{http.StatusBadRequest, "writeOnce must be a boolean"}
 	}
 	auth.WriteOnce = writeOnce
 
-	return auth, nil
+	var exp time.Time
+	if expTime, _ := claims.GetExpirationTime(); expTime != nil {
+		exp = expTime.Time
+	}
+
+	return auth, exp, nil
 }

--- a/packages/michael/internal/auth/auth_test.go
+++ b/packages/michael/internal/auth/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
@@ -47,7 +48,7 @@ func validClaims() jwt.MapClaims {
 
 func TestAuthMissingHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
-	_, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey)
 	if err == nil {
 		t.Fatal("expected error for missing auth header")
 	}
@@ -59,7 +60,7 @@ func TestAuthMissingHeader(t *testing.T) {
 func TestAuthInvalidAuthType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", "Bearer some-token")
-	_, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey)
 	if err == nil {
 		t.Fatal("expected error for non-Basic auth")
 	}
@@ -72,7 +73,7 @@ func TestAuthMissingToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	// Basic auth with no password (just username, no colon)
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("restic")))
-	_, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey)
 	if err == nil {
 		t.Fatal("expected error for missing token")
 	}
@@ -84,7 +85,7 @@ func TestAuthMissingToken(t *testing.T) {
 func TestAuthInvalidJWT(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth("not-a-valid-jwt"))
-	_, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey)
 	if err == nil {
 		t.Fatal("expected error for invalid JWT")
 	}
@@ -102,7 +103,7 @@ func TestAuthInvalidPayloadNonUUID(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
-	_, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey)
 	if err == nil {
 		t.Fatal("expected error for non-UUID user")
 	}
@@ -119,7 +120,7 @@ func TestAuthInvalidPayloadMissingWriteOnce(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
-	_, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey)
 	if err == nil {
 		t.Fatal("expected error for missing writeOnce")
 	}
@@ -133,7 +134,7 @@ func TestAuthSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
 
-	a, err := extractAuth(req, testPublicKey)
+	a, _, err := extractAuth(req, testPublicKey)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -194,5 +195,78 @@ func TestAuthMiddlewareSuccess(t *testing.T) {
 	}
 	if gotAuth.User != testUser {
 		t.Errorf("expected user %s in context, got %s", testUser, gotAuth.User)
+	}
+}
+
+func TestVerifierCachesVerifiedTokens(t *testing.T) {
+	token := makeJWT(t, validClaims())
+
+	var lookups []bool
+	v := NewVerifier(testPublicKey, func(hit bool) { lookups = append(lookups, hit) })
+
+	for range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+		req.Header.Set("Authorization", makeBasicAuth(token))
+		a, err := v.authenticate(req)
+		if err != nil {
+			t.Fatalf("authenticate: %v", err)
+		}
+		if a.User != testUser || a.Repository != testRepository {
+			t.Fatalf("unexpected auth: %+v", a)
+		}
+	}
+
+	want := []bool{false, true, true}
+	if len(lookups) != len(want) {
+		t.Fatalf("lookups = %v, want %v", lookups, want)
+	}
+	for i := range want {
+		if lookups[i] != want[i] {
+			t.Fatalf("lookups = %v, want %v", lookups, want)
+		}
+	}
+}
+
+func TestVerifierCacheHonorsExpiry(t *testing.T) {
+	token := makeJWT(t, validClaims())
+	v := NewVerifier(testPublicKey, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(token))
+	if _, err := v.authenticate(req); err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+
+	// Force the cached entry past its expiry; the stale entry must be evicted
+	// and the (still exp-valid) token re-verified rather than served stale.
+	key := sha256.Sum256([]byte(makeBasicAuth(token)))
+	if _, ok := v.cache.get(key, time.Now().Add(2*time.Hour)); ok {
+		t.Fatal("expired cache entry served")
+	}
+	if _, ok := v.cache.get(key, time.Now()); ok {
+		t.Fatal("expired entry should have been evicted")
+	}
+}
+
+func TestVerifierDoesNotCacheInvalidTokens(t *testing.T) {
+	otherKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	badToken := func() string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodES256, validClaims())
+		signed, err := tok.SignedString(otherKey)
+		if err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		return signed
+	}()
+
+	v := NewVerifier(testPublicKey, nil)
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(badToken))
+	if _, err := v.authenticate(req); err == nil {
+		t.Fatal("expected error for token signed by wrong key")
+	}
+	key := sha256.Sum256([]byte(makeBasicAuth(badToken)))
+	if _, ok := v.cache.get(key, time.Now()); ok {
+		t.Fatal("invalid token must not be cached")
 	}
 }

--- a/packages/michael/internal/auth/cache.go
+++ b/packages/michael/internal/auth/cache.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	key  [32]byte
+	auth Auth
+	exp  time.Time
+}
+
+// tokenCache is a bounded LRU of verified tokens, keyed by a hash of the
+// Authorization header so raw tokens are never retained.
+type tokenCache struct {
+	mu  sync.Mutex
+	max int
+	ll  *list.List // front = most recently used
+	m   map[[32]byte]*list.Element
+}
+
+func newTokenCache(max int) *tokenCache {
+	return &tokenCache{
+		max: max,
+		ll:  list.New(),
+		m:   make(map[[32]byte]*list.Element, max),
+	}
+}
+
+func (c *tokenCache) get(key [32]byte, now time.Time) (Auth, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.m[key]
+	if !ok {
+		return Auth{}, false
+	}
+	e := el.Value.(*cacheEntry)
+	if !now.Before(e.exp) {
+		c.ll.Remove(el)
+		delete(c.m, key)
+		return Auth{}, false
+	}
+	c.ll.MoveToFront(el)
+	return e.auth, true
+}
+
+func (c *tokenCache) put(key [32]byte, a Auth, exp time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.m[key]; ok {
+		e := el.Value.(*cacheEntry)
+		e.auth, e.exp = a, exp
+		c.ll.MoveToFront(el)
+		return
+	}
+	c.m[key] = c.ll.PushFront(&cacheEntry{key: key, auth: a, exp: exp})
+	if c.ll.Len() > c.max {
+		el := c.ll.Back()
+		c.ll.Remove(el)
+		delete(c.m, el.Value.(*cacheEntry).key)
+	}
+}

--- a/packages/michael/internal/handlers/blob.go
+++ b/packages/michael/internal/handlers/blob.go
@@ -1,10 +1,15 @@
 package handlers
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/hlog"
 
@@ -16,28 +21,109 @@ import (
 )
 
 // GET /{path}/{type}
+//
+// Streams the restic v2 JSON array as listing pages arrive instead of
+// buffering the whole repo listing. data/ (the bulk of a repo, hex-named) fans
+// out across 16 hex prefixes: RGW scans them in parallel and each shard lands
+// on its own pool backend.
 func (s *Server) listBlobs(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 
 	accept := r.Header.Get("Accept")
 	if accept != ContentTypeResticV2 {
-		writeError(w, r,http.StatusNotImplemented, "Not Implemented")
+		writeError(w, r, http.StatusNotImplemented, "Not Implemented")
 		return
 	}
 
 	blobType := chi.URLParam(r, "type")
-	prefix := blobType + "/"
-	blobs, err := s.Storage.ListObjects(r.Context(), a.Repository, prefix)
-	if err != nil {
-		hlog.FromRequest(r).Error().Err(err).Msg("list blobs failed")
-		writeError(w, r,http.StatusInternalServerError, "An error occurred with the storage server")
-		return
+	typePrefix := blobType + "/"
+
+	prefixes := []string{typePrefix}
+	if blobType == "data" {
+		prefixes = make([]string, 16)
+		for i := range prefixes {
+			prefixes[i] = fmt.Sprintf("%s%x", typePrefix, i)
+		}
 	}
 
-	w.Header().Set("Content-Type", ContentTypeResticV2)
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(blobs); err != nil {
-		hlog.FromRequest(r).Error().Err(err).Msg("failed to encode blob list response")
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	var (
+		mu    sync.Mutex
+		buf   *bufio.Writer
+		first = true
+	)
+	emit := func(b storage.BlobInfo) error {
+		name := strings.TrimPrefix(b.Name, typePrefix)
+		if name == "" {
+			return nil
+		}
+		entry, err := json.Marshal(storage.BlobInfo{Name: name, Size: b.Size})
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if first {
+			first = false
+			w.Header().Set("Content-Type", ContentTypeResticV2)
+			w.WriteHeader(http.StatusOK)
+			buf = bufio.NewWriterSize(w, 64<<10)
+			if _, err := buf.WriteString("["); err != nil {
+				return err
+			}
+		} else if _, err := buf.WriteString(","); err != nil {
+			return err
+		}
+		_, err = buf.Write(entry)
+		return err
+	}
+
+	var (
+		wg      sync.WaitGroup
+		errOnce sync.Once
+		listErr error
+	)
+	for _, prefix := range prefixes {
+		wg.Add(1)
+		go func(prefix string) {
+			defer wg.Done()
+			if err := s.Storage.ListObjects(ctx, a.Repository, prefix, emit); err != nil {
+				errOnce.Do(func() {
+					listErr = err
+					cancel()
+				})
+			}
+		}(prefix)
+	}
+	wg.Wait()
+
+	if listErr != nil {
+		hlog.FromRequest(r).Error().Err(listErr).Msg("list blobs failed")
+		if first {
+			writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+			return
+		}
+		// The 200 and part of the body are already out; abort the connection
+		// so the client sees a truncated response, not a valid-looking list.
+		panic(http.ErrAbortHandler)
+	}
+
+	if first {
+		w.Header().Set("Content-Type", ContentTypeResticV2)
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("[]")); err != nil {
+			hlog.FromRequest(r).Error().Err(err).Msg("failed to write blob list response")
+		}
+		return
+	}
+	if _, err := buf.WriteString("]"); err != nil {
+		hlog.FromRequest(r).Error().Err(err).Msg("failed to write blob list response")
+		return
+	}
+	if err := buf.Flush(); err != nil {
+		hlog.FromRequest(r).Error().Err(err).Msg("failed to flush blob list response")
 	}
 }
 

--- a/packages/michael/internal/handlers/blob_test.go
+++ b/packages/michael/internal/handlers/blob_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	"michael/internal/storage"
@@ -174,8 +175,8 @@ func TestListBlobs_Success(t *testing.T) {
 	store := &mockStorage{
 		listObjectsFn: func(_ context.Context, _, _ string) ([]storage.BlobInfo, error) {
 			return []storage.BlobInfo{
-				{Name: "abc123", Size: 1024},
-				{Name: "def456", Size: 2048},
+				{Name: "data/abc123", Size: 1024},
+				{Name: "data/def456", Size: 2048},
 			}, nil
 		},
 	}
@@ -196,8 +197,49 @@ func TestListBlobs_Success(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 	if len(blobs) != 2 {
-		t.Errorf("expected 2 blobs, got %d", len(blobs))
+		t.Fatalf("expected 2 blobs, got %d", len(blobs))
 	}
+	// Shard order is nondeterministic; names must be prefix-stripped.
+	got := map[string]int64{}
+	for _, b := range blobs {
+		got[b.Name] = b.Size
+	}
+	if got["abc123"] != 1024 || got["def456"] != 2048 {
+		t.Errorf("unexpected blobs: %v", got)
+	}
+}
+
+func TestListBlobs_MidStreamErrorAbortsConnection(t *testing.T) {
+	// After entries have been streamed, a shard failure can't become a 500 —
+	// the handler must abort the connection so the client doesn't mistake a
+	// truncated listing for a complete one.
+	emitted := make(chan struct{})
+	var once sync.Once
+	store := &mockStorage{
+		listStreamFn: func(_ context.Context, _, prefix string, fn func(storage.BlobInfo) error) error {
+			if prefix == "data/f" {
+				// Fail only after another shard has streamed an entry, so the
+				// 200 + partial body is already out.
+				<-emitted
+				return errors.New("gateway exploded")
+			}
+			if err := fn(storage.BlobInfo{Name: prefix + "0cafe", Size: 1}); err != nil {
+				return err
+			}
+			once.Do(func() { close(emitted) })
+			return nil
+		},
+	}
+	srv := newTestServer(store)
+
+	defer func() {
+		if r := recover(); r != http.ErrAbortHandler {
+			t.Errorf("expected panic(http.ErrAbortHandler), got %v", r)
+		}
+	}()
+	doRequest(t, srv, http.MethodGet, "/"+testRepository+"/data", nil, defaultAuth(), map[string]string{
+		"Accept": ContentTypeResticV2,
+	})
 }
 
 func TestListBlobs_MissingAcceptHeader(t *testing.T) {

--- a/packages/michael/internal/handlers/server.go
+++ b/packages/michael/internal/handlers/server.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"net/http"
@@ -54,8 +55,20 @@ func (s *Server) Handler() http.Handler {
 		r.Use(metrics.Middleware(s.Metrics))
 	}
 
+	var onLookup func(hit bool)
+	if s.Metrics != nil {
+		onLookup = func(hit bool) {
+			if hit {
+				s.Metrics.AuthCacheHits.Add(context.Background(), 1)
+			} else {
+				s.Metrics.AuthCacheMisses.Add(context.Background(), 1)
+			}
+		}
+	}
+	verifier := auth.NewVerifier(s.JWTPublicKey, onLookup)
+
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(auth.Middleware(s.JWTPublicKey))
+		r.Use(verifier.Middleware())
 		r.Use(authLogContext)
 		if s.Metrics != nil {
 			r.Use(metrics.BlobMiddleware(s.Metrics))

--- a/packages/michael/internal/handlers/server_test.go
+++ b/packages/michael/internal/handlers/server_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,6 +54,7 @@ type mockStorage struct {
 	getObjectFn    func(ctx context.Context, bucket, key, rangeHeader string) (*storage.S3Object, error)
 	putObjectFn    func(ctx context.Context, bucket, key string, body io.Reader, contentLength int64, writeOnce bool, sha256Hex string) error
 	listObjectsFn  func(ctx context.Context, bucket, prefix string) ([]storage.BlobInfo, error)
+	listStreamFn   func(ctx context.Context, bucket, prefix string, fn func(storage.BlobInfo) error) error
 	deleteObjectFn func(ctx context.Context, bucket, key string) error
 }
 
@@ -91,11 +93,28 @@ func (m *mockStorage) PutObject(ctx context.Context, bucket, key string, body io
 	return nil
 }
 
-func (m *mockStorage) ListObjects(ctx context.Context, bucket, prefix string) ([]storage.BlobInfo, error) {
-	if m.listObjectsFn != nil {
-		return m.listObjectsFn(ctx, bucket, prefix)
+// ListObjects adapts the slice-returning listObjectsFn to the streaming
+// interface, filtering by prefix so sharded data/ listings behave like S3.
+func (m *mockStorage) ListObjects(ctx context.Context, bucket, prefix string, fn func(storage.BlobInfo) error) error {
+	if m.listStreamFn != nil {
+		return m.listStreamFn(ctx, bucket, prefix, fn)
 	}
-	return []storage.BlobInfo{}, nil
+	if m.listObjectsFn == nil {
+		return nil
+	}
+	blobs, err := m.listObjectsFn(ctx, bucket, prefix)
+	if err != nil {
+		return err
+	}
+	for _, b := range blobs {
+		if !strings.HasPrefix(b.Name, prefix) {
+			continue
+		}
+		if err := fn(b); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (m *mockStorage) DeleteObject(ctx context.Context, bucket, key string) error {
@@ -202,7 +221,7 @@ func TestAccessLogOutput(t *testing.T) {
 
 	store := &mockStorage{
 		listObjectsFn: func(_ context.Context, _, _ string) ([]storage.BlobInfo, error) {
-			return []storage.BlobInfo{{Name: "abc", Size: 42}}, nil
+			return []storage.BlobInfo{{Name: "data/abc", Size: 42}}, nil
 		},
 	}
 	srv := newTestServer(store)

--- a/packages/michael/internal/metrics/metrics.go
+++ b/packages/michael/internal/metrics/metrics.go
@@ -25,8 +25,18 @@ type Metrics struct {
 	UploadedBytes   otelmetric.Int64Counter
 	StoredBytes     otelmetric.Int64UpDownCounter
 	RequestDuration otelmetric.Float64Histogram
+	RequestTTFB     otelmetric.Float64Histogram
 	RequestCount    otelmetric.Int64Counter
 	RequestErrors   otelmetric.Int64Counter
+	AuthCacheHits   otelmetric.Int64Counter
+	AuthCacheMisses otelmetric.Int64Counter
+}
+
+// durationBuckets replaces the SDK default histogram boundaries, which are
+// sized for milliseconds — recording seconds against them put every sub-5s
+// request in the first bucket.
+var durationBuckets = []float64{
+	0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120,
 }
 
 func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
@@ -57,9 +67,20 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 
 	requestDuration, err := meter.Float64Histogram("http.server.request.duration",
 		otelmetric.WithDescription("HTTP server request duration"),
-		otelmetric.WithUnit("s"))
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(durationBuckets...))
 	if err != nil {
 		return nil, fmt.Errorf("creating request_duration histogram: %w", err)
+	}
+
+	// Duration includes streaming the body to the client, so for large blobs it
+	// measures client throughput; TTFB isolates michael+RGW latency.
+	requestTTFB, err := meter.Float64Histogram("http.server.request.ttfb",
+		otelmetric.WithDescription("Time from request start to first response byte"),
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(durationBuckets...))
+	if err != nil {
+		return nil, fmt.Errorf("creating request_ttfb histogram: %w", err)
 	}
 
 	requestCount, err := meter.Int64Counter("http.server.request.count",
@@ -74,14 +95,29 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating request_errors counter: %w", err)
 	}
 
+	authCacheHits, err := meter.Int64Counter("auth.cache.hits",
+		otelmetric.WithDescription("JWT verifications served from the token cache"))
+	if err != nil {
+		return nil, fmt.Errorf("creating auth_cache_hits counter: %w", err)
+	}
+
+	authCacheMisses, err := meter.Int64Counter("auth.cache.misses",
+		otelmetric.WithDescription("JWT verifications requiring a full signature check"))
+	if err != nil {
+		return nil, fmt.Errorf("creating auth_cache_misses counter: %w", err)
+	}
+
 	return &Metrics{
 		RequestedBytes:  requestedBytes,
 		DownloadedBytes: downloadedBytes,
 		UploadedBytes:   uploadedBytes,
 		StoredBytes:     storedBytes,
 		RequestDuration: requestDuration,
+		RequestTTFB:     requestTTFB,
 		RequestCount:    requestCount,
 		RequestErrors:   requestErrors,
+		AuthCacheHits:   authCacheHits,
+		AuthCacheMisses: authCacheMisses,
 	}, nil
 }
 
@@ -209,19 +245,29 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// ResponseWriter wraps http.ResponseWriter to count bytes written and track status.
+// ResponseWriter wraps http.ResponseWriter to count bytes written, track
+// status, and stamp when the response started (for TTFB).
 type ResponseWriter struct {
 	http.ResponseWriter
 	BytesWritten int64
 	Status       int
+	FirstByte    time.Time
+}
+
+func (w *ResponseWriter) markStart() {
+	if w.FirstByte.IsZero() {
+		w.FirstByte = time.Now()
+	}
 }
 
 func (w *ResponseWriter) WriteHeader(code int) {
+	w.markStart()
 	w.Status = code
 	w.ResponseWriter.WriteHeader(code)
 }
 
 func (w *ResponseWriter) Write(p []byte) (int, error) {
+	w.markStart()
 	if w.Status == 0 {
 		w.Status = http.StatusOK
 	}
@@ -233,6 +279,7 @@ func (w *ResponseWriter) Write(p []byte) (int, error) {
 // ReadFrom implements io.ReaderFrom to preserve sendfile/splice zero-copy
 // optimization when the underlying ResponseWriter supports it.
 func (w *ResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	w.markStart()
 	if w.Status == 0 {
 		w.Status = http.StatusOK
 	}
@@ -316,6 +363,9 @@ func Middleware(m *Metrics) func(http.Handler) http.Handler {
 			attrs := HttpMetricOption(r.Method, route, status)
 
 			m.RequestDuration.Record(r.Context(), duration, attrs)
+			if !ww.FirstByte.IsZero() {
+				m.RequestTTFB.Record(r.Context(), ww.FirstByte.Sub(start).Seconds(), attrs)
+			}
 			m.RequestCount.Add(r.Context(), 1, attrs)
 
 			if status >= 400 {

--- a/packages/michael/internal/metrics/transport.go
+++ b/packages/michael/internal/metrics/transport.go
@@ -1,0 +1,152 @@
+package metrics
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptrace"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+// TransportMetrics instruments the per-backend S3 HTTP transports: connection
+// churn (dials, reuse ratio), TLS handshake cost, and time-to-first-byte from
+// the gateway. These separate RGW latency from michael's own overhead and
+// prove out connection-pool tuning.
+type TransportMetrics struct {
+	dials       otelmetric.Int64Counter
+	conns       otelmetric.Int64Counter
+	tlsDuration otelmetric.Float64Histogram
+	ttfb        otelmetric.Float64Histogram
+}
+
+func NewTransportMetrics(meter otelmetric.Meter) (*TransportMetrics, error) {
+	dials, err := meter.Int64Counter("s3.client.dials",
+		otelmetric.WithDescription("New TCP connections dialed to S3 backends"))
+	if err != nil {
+		return nil, fmt.Errorf("creating s3_client_dials counter: %w", err)
+	}
+
+	conns, err := meter.Int64Counter("s3.client.connections",
+		otelmetric.WithDescription("Connections checked out for S3 requests, by reuse"))
+	if err != nil {
+		return nil, fmt.Errorf("creating s3_client_connections counter: %w", err)
+	}
+
+	tlsDuration, err := meter.Float64Histogram("s3.client.tls_handshake.duration",
+		otelmetric.WithDescription("TLS handshake duration to S3 backends"),
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(durationBuckets...))
+	if err != nil {
+		return nil, fmt.Errorf("creating s3_client_tls_handshake histogram: %w", err)
+	}
+
+	ttfb, err := meter.Float64Histogram("s3.client.ttfb",
+		otelmetric.WithDescription("Time from S3 request start to first response byte"),
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(durationBuckets...))
+	if err != nil {
+		return nil, fmt.Errorf("creating s3_client_ttfb histogram: %w", err)
+	}
+
+	return &TransportMetrics{
+		dials:       dials,
+		conns:       conns,
+		tlsDuration: tlsDuration,
+		ttfb:        ttfb,
+	}, nil
+}
+
+// Wrap returns rt instrumented with per-request httptrace hooks, labeled with
+// the backend's address.
+func (t *TransportMetrics) Wrap(backend string, rt http.RoundTripper) http.RoundTripper {
+	return &tracedTransport{tm: t, backend: backend, rt: rt}
+}
+
+type tracedTransport struct {
+	tm      *TransportMetrics
+	backend string
+	rt      http.RoundTripper
+}
+
+func (t *tracedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	var tlsStart time.Time
+	ctx := req.Context()
+	trace := &httptrace.ClientTrace{
+		ConnectDone: func(_, _ string, err error) {
+			if err == nil {
+				t.tm.dials.Add(ctx, 1, backendOption(t.backend))
+			}
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.tm.conns.Add(ctx, 1, connOption(t.backend, info.Reused))
+		},
+		TLSHandshakeStart: func() { tlsStart = time.Now() },
+		TLSHandshakeDone: func(_ tls.ConnectionState, err error) {
+			if err == nil && !tlsStart.IsZero() {
+				t.tm.tlsDuration.Record(ctx, time.Since(tlsStart).Seconds(), backendOption(t.backend))
+			}
+		},
+		GotFirstResponseByte: func() {
+			t.tm.ttfb.Record(ctx, time.Since(start).Seconds(), ttfbOption(t.backend, req.Method))
+		},
+	}
+	return t.rt.RoundTrip(req.WithContext(httptrace.WithClientTrace(ctx, trace)))
+}
+
+// --- cached attribute options (hot path, same pattern as HttpMetricOption) ---
+
+var backendAttrCache sync.Map
+
+func backendOption(backend string) otelmetric.MeasurementOption {
+	if v, ok := backendAttrCache.Load(backend); ok {
+		return v.(otelmetric.MeasurementOption)
+	}
+	opt := otelmetric.WithAttributeSet(attribute.NewSet(attribute.String("backend", backend)))
+	backendAttrCache.Store(backend, opt)
+	return opt
+}
+
+type connAttrKey struct {
+	backend string
+	reused  bool
+}
+
+var connAttrCache sync.Map
+
+func connOption(backend string, reused bool) otelmetric.MeasurementOption {
+	key := connAttrKey{backend, reused}
+	if v, ok := connAttrCache.Load(key); ok {
+		return v.(otelmetric.MeasurementOption)
+	}
+	opt := otelmetric.WithAttributeSet(attribute.NewSet(
+		attribute.String("backend", backend),
+		attribute.Bool("reused", reused),
+	))
+	connAttrCache.Store(key, opt)
+	return opt
+}
+
+type ttfbAttrKey struct {
+	backend string
+	method  string
+}
+
+var ttfbAttrCache sync.Map
+
+func ttfbOption(backend, method string) otelmetric.MeasurementOption {
+	key := ttfbAttrKey{backend, method}
+	if v, ok := ttfbAttrCache.Load(key); ok {
+		return v.(otelmetric.MeasurementOption)
+	}
+	opt := otelmetric.WithAttributeSet(attribute.NewSet(
+		attribute.String("backend", backend),
+		attribute.String("method", method),
+	))
+	ttfbAttrCache.Store(key, opt)
+	return opt
+}

--- a/packages/michael/internal/storage/pool.go
+++ b/packages/michael/internal/storage/pool.go
@@ -340,14 +340,10 @@ func (p *Pool) HeadObject(ctx context.Context, bucket, key string) (int64, error
 	return size, err
 }
 
-func (p *Pool) ListObjects(ctx context.Context, bucket, prefix string) ([]BlobInfo, error) {
-	var blobs []BlobInfo
-	err := p.do(func(s Storage) error {
-		var e error
-		blobs, e = s.ListObjects(ctx, bucket, prefix)
-		return e
+func (p *Pool) ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error {
+	return p.do(func(s Storage) error {
+		return s.ListObjects(ctx, bucket, prefix, fn)
 	})
-	return blobs, err
 }
 
 func (p *Pool) DeleteObject(ctx context.Context, bucket, key string) error {

--- a/packages/michael/internal/storage/pool_test.go
+++ b/packages/michael/internal/storage/pool_test.go
@@ -55,12 +55,12 @@ func (f *fakeStore) HeadObject(_ context.Context, _, _ string) (int64, error) {
 	return 0, nil
 }
 
-func (f *fakeStore) ListObjects(_ context.Context, _, _ string) ([]BlobInfo, error) {
+func (f *fakeStore) ListObjects(_ context.Context, _, _ string, _ func(BlobInfo) error) error {
 	f.calls.Add(1)
 	if f.opFail.Load() {
-		return nil, f.transportErr()
+		return f.transportErr()
 	}
-	return []BlobInfo{}, nil
+	return nil
 }
 
 func (f *fakeStore) DeleteObject(_ context.Context, _, _ string) error {

--- a/packages/michael/internal/storage/s3.go
+++ b/packages/michael/internal/storage/s3.go
@@ -47,7 +47,7 @@ type Storage interface {
 	HeadObject(ctx context.Context, bucket, key string) (int64, error)
 	GetObject(ctx context.Context, bucket, key, rangeHeader string) (*S3Object, error)
 	PutObject(ctx context.Context, bucket, key string, body io.Reader, contentLength int64, writeOnce bool, sha256Hex string) error
-	ListObjects(ctx context.Context, bucket, prefix string) ([]BlobInfo, error)
+	ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error
 	DeleteObject(ctx context.Context, bucket, key string) error
 }
 
@@ -73,6 +73,9 @@ type S3Options struct {
 	// TLSSkipVerify disables TLS certificate verification, for gateways behind a
 	// self-signed cert (matching HAProxy's `ssl verify none`).
 	TLSSkipVerify bool
+	// Wrap, when set, wraps the backend's transport (e.g. with per-backend
+	// client metrics).
+	Wrap func(http.RoundTripper) http.RoundTripper
 }
 
 // NewS3StorageForEndpoint builds an S3Storage bound to a specific endpoint,
@@ -98,19 +101,25 @@ func NewS3StorageWithOptions(cfg config.Config, opts S3Options) *S3Storage {
 		BaseEndpoint: aws.String(opts.Endpoint),
 		UsePathStyle: cfg.S3ForcePathStyle,
 	}
-	if hc := buildHTTPClient(opts); hc != nil {
-		s3opts.HTTPClient = hc
-	}
+	s3opts.HTTPClient = buildHTTPClient(opts)
 	return &S3Storage{client: s3.New(s3opts)}
 }
 
-// buildHTTPClient returns a custom HTTP client when the backend needs a pinned
-// dial address or relaxed TLS, or nil to use the SDK default.
+// buildHTTPClient builds the HTTP client for one backend. Always custom (never
+// the SDK default), so connection pooling behaves identically across
+// dev/staging/prod regardless of pin-host or TLS settings.
 func buildHTTPClient(opts S3Options) *http.Client {
-	if opts.DialAddr == "" && !opts.TLSSkipVerify {
-		return nil
-	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	// Each transport serves a single gateway, and restic fans out far more
+	// concurrent requests than the default per-host idle cap of 2 — anything
+	// past that paid a fresh TCP+TLS handshake. Buffers sized for multi-MB
+	// pack transfers (defaults are 4KB).
+	transport.MaxIdleConns = 0
+	transport.MaxIdleConnsPerHost = 128
+	transport.IdleConnTimeout = 120 * time.Second
+	transport.WriteBufferSize = 64 << 10
+	transport.ReadBufferSize = 64 << 10
 
 	if opts.TLSSkipVerify {
 		if transport.TLSClientConfig == nil {
@@ -132,7 +141,11 @@ func buildHTTPClient(opts S3Options) *http.Client {
 		}
 	}
 
-	return &http.Client{Transport: transport}
+	var rt http.RoundTripper = transport
+	if opts.Wrap != nil {
+		rt = opts.Wrap(transport)
+	}
+	return &http.Client{Transport: rt}
 }
 
 // Probe performs a cheap liveness check against the backend gateway. It issues a
@@ -283,11 +296,12 @@ func (w *sha256Writer) Write(p []byte) (n int, err error) {
 	return w.hash.Write(p)
 }
 
-func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string) ([]BlobInfo, error) {
-	// ListObjectsV2 caps a single page at 1000 keys, and restic's REST protocol
-	// has no listing pagination — a truncated response makes restic report every
-	// pack past the cutoff as missing from the repo. Always walk all pages.
-	blobs := []BlobInfo{}
+// ListObjects streams every object under prefix to fn as pages arrive, instead
+// of buffering the whole listing — restic's REST protocol has no pagination, so
+// a large repo is one response and TTFB otherwise waits on every ListObjectsV2
+// page (1000 keys each). Names are full object keys; callers strip what they
+// need. An fn error aborts the walk.
+func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error {
 	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
 		Prefix: aws.String(prefix),
@@ -295,24 +309,18 @@ func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string) ([]B
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("list objects: %w", err)
+			return fmt.Errorf("list objects: %w", err)
 		}
 		for _, obj := range out.Contents {
 			if obj.Key == nil || obj.Size == nil {
 				continue
 			}
-			name := *obj.Key
-			if len(name) > len(prefix) {
-				name = name[len(prefix):]
+			if err := fn(BlobInfo{Name: *obj.Key, Size: *obj.Size}); err != nil {
+				return err
 			}
-			blobs = append(blobs, BlobInfo{
-				Name: name,
-				Size: *obj.Size,
-			})
 		}
 	}
-
-	return blobs, nil
+	return nil
 }
 
 func (s *S3Storage) DeleteObject(ctx context.Context, bucket, key string) error {

--- a/packages/michael/internal/storage/s3_test.go
+++ b/packages/michael/internal/storage/s3_test.go
@@ -116,12 +116,17 @@ func TestListObjects_PaginatesAllPages(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	blobs, err := s.ListObjects(context.Background(), "bucket", "data/")
+	var blobs []BlobInfo
+	err := s.ListObjects(context.Background(), "bucket", "data/", func(b BlobInfo) error {
+		blobs = append(blobs, b)
+		return nil
+	})
 	if err != nil {
 		t.Fatalf("ListObjects: %v", err)
 	}
 
-	want := []BlobInfo{{Name: "aa", Size: 1}, {Name: "bb", Size: 2}, {Name: "cc", Size: 3}}
+	// Names are full keys; prefix-stripping is the caller's job.
+	want := []BlobInfo{{Name: "data/aa", Size: 1}, {Name: "data/bb", Size: 2}, {Name: "data/cc", Size: 3}}
 	if len(blobs) != len(want) {
 		t.Fatalf("got %d blobs (%v), want %d", len(blobs), blobs, len(want))
 	}
@@ -135,9 +140,8 @@ func TestListObjects_PaginatesAllPages(t *testing.T) {
 	}
 }
 
-func TestListObjects_EmptyIsNonNil(t *testing.T) {
-	// The handler JSON-encodes the result directly; a nil slice would render
-	// as `null` instead of the `[]` restic expects.
+func TestListObjects_EmptyListing(t *testing.T) {
+	// An empty listing completes without invoking the callback.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
 		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
@@ -149,15 +153,16 @@ func TestListObjects_EmptyIsNonNil(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	blobs, err := s.ListObjects(context.Background(), "bucket", "data/")
+	calls := 0
+	err := s.ListObjects(context.Background(), "bucket", "data/", func(BlobInfo) error {
+		calls++
+		return nil
+	})
 	if err != nil {
 		t.Fatalf("ListObjects: %v", err)
 	}
-	if blobs == nil {
-		t.Fatal("expected non-nil empty slice")
-	}
-	if len(blobs) != 0 {
-		t.Fatalf("expected empty result, got %v", blobs)
+	if calls != 0 {
+		t.Fatalf("expected no callbacks for empty listing, got %d", calls)
 	}
 }
 

--- a/packages/michael/main.go
+++ b/packages/michael/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
@@ -57,13 +58,14 @@ func main() {
 		log.Fatal().Err(err).Str("addr", addr).Msg("failed to bind listener")
 	}
 
-	store, pool := buildStorage(cfg)
-
 	if cfg.OTLPLogsEnabled {
 		log.Info().Str("endpoint", cfg.OTLPLogsEndpoint).Msg("OpenTelemetry logs enabled")
 	}
 
+	// Metrics before storage: the backend transports are built instrumented.
 	var m *metrics.Metrics
+	var tm *metrics.TransportMetrics
+	var meter otelmetric.Meter
 	var meterProvider *sdkmetric.MeterProvider
 	if cfg.OTLPEnabled {
 		var err error
@@ -71,17 +73,24 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to setup meter provider")
 		}
-		meter := meterProvider.Meter("michael")
+		meter = meterProvider.Meter("michael")
 		m, err = metrics.NewMetrics(meter)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to create metrics")
 		}
-		if pool != nil {
-			if err := metrics.RegisterBackendMetrics(meter, pool); err != nil {
-				log.Fatal().Err(err).Msg("failed to register backend metrics")
-			}
+		tm, err = metrics.NewTransportMetrics(meter)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to create transport metrics")
 		}
 		log.Info().Str("endpoint", cfg.OTLPMetricsEndpoint).Msg("OpenTelemetry metrics enabled")
+	}
+
+	store, pool := buildStorage(cfg, tm)
+
+	if pool != nil && meterProvider != nil {
+		if err := metrics.RegisterBackendMetrics(meter, pool); err != nil {
+			log.Fatal().Err(err).Msg("failed to register backend metrics")
+		}
 	}
 
 	srv := handlers.NewServer(store, cfg.JWTPublicKey, m)
@@ -136,13 +145,17 @@ func main() {
 // configured it is a single S3 client (legacy behavior) and pool is nil. With
 // source=file or source=dns it is a load-balancing Pool, also returned
 // concretely so the caller can register its metrics and run its reconcile loop.
-func buildStorage(cfg config.Config) (storage.Storage, *storage.Pool) {
+func buildStorage(cfg config.Config, tm *metrics.TransportMetrics) (storage.Storage, *storage.Pool) {
 	if cfg.S3BackendSource == "" {
-		return storage.NewS3Storage(cfg), nil
+		return storage.NewS3StorageWithOptions(cfg, storage.S3Options{
+			Endpoint:      cfg.S3Endpoint,
+			TLSSkipVerify: cfg.S3TLSSkipVerify,
+			Wrap:          transportWrap(tm, cfg.S3Endpoint),
+		}), nil
 	}
 
 	resolver := buildResolver(cfg)
-	factory := backendFactory(cfg)
+	factory := backendFactory(cfg, tm)
 	pool, err := storage.NewPool(storage.PoolConfig{
 		EjectThreshold:    cfg.S3EjectThreshold,
 		ProbeBucket:       cfg.S3ProbeBucket,
@@ -160,10 +173,14 @@ func buildStorage(cfg config.Config) (storage.Storage, *storage.Pool) {
 // directly while still signing/Host-ing with cfg.S3Endpoint (replacing the
 // HAProxy hop); otherwise the resolved endpoint is used as the S3 endpoint
 // as-is.
-func backendFactory(cfg config.Config) storage.BackendFactory {
+func backendFactory(cfg config.Config, tm *metrics.TransportMetrics) storage.BackendFactory {
 	if !cfg.S3BackendPinHost {
 		return func(endpoint string) (storage.Storage, error) {
-			return storage.NewS3StorageForEndpoint(cfg, endpoint), nil
+			return storage.NewS3StorageWithOptions(cfg, storage.S3Options{
+				Endpoint:      endpoint,
+				TLSSkipVerify: cfg.S3TLSSkipVerify,
+				Wrap:          transportWrap(tm, endpoint),
+			}), nil
 		}
 	}
 	return func(endpoint string) (storage.Storage, error) {
@@ -183,7 +200,19 @@ func backendFactory(cfg config.Config) storage.BackendFactory {
 			Endpoint:      cfg.S3Endpoint,
 			DialAddr:      dial,
 			TLSSkipVerify: cfg.S3TLSSkipVerify,
+			Wrap:          transportWrap(tm, dial),
 		}), nil
+	}
+}
+
+// transportWrap returns the metrics wrapper for one backend's transport, or
+// nil when metrics are disabled.
+func transportWrap(tm *metrics.TransportMetrics, backend string) func(http.RoundTripper) http.RoundTripper {
+	if tm == nil {
+		return nil
+	}
+	return func(rt http.RoundTripper) http.RoundTripper {
+		return tm.Wrap(backend, rt)
 	}
 }
 


### PR DESCRIPTION
Give michael all the tools it needs to improve latencies.

1. `listBlobs` now stream blobs AND fans-out against S3 in a way that's totally magical.
2. We now have a JWT cache for tokens and their expiry
3. Promote connection re-use on the transport layer, as well as increase buffer sizes.
4. Make it a lot more observable

- `main` <!-- branch-stack -->
  - \#324 :point\_left:
