### PR TITLE
docs(ceph): cluster-profiles reference and per-cluster runbook parameterization

### DIFF
--- a/ansible/ceph/README.md
+++ b/ansible/ceph/README.md
@@ -134,6 +134,7 @@ Inventory + secrets-template scaffolding live in `yucca/tf/` -- run
 | [docs/adding-a-cluster.md](docs/adding-a-cluster.md) | Developers -- inventory setup, secrets |
 | [docs/secrets.md](docs/secrets.md) | Developers/ops -- 1Password integration |
 | [docs/naming.md](docs/naming.md) | Everyone -- hostname and inventory naming |
+| [docs/cluster-profiles.md](docs/cluster-profiles.md) | Ops -- per-cluster hosts, SSH, vaults, shape differences |
 | [docs/hardware.md](docs/hardware.md) | Ops/procurement -- node specs and hardware shapes |
 | [docs/s3-integration.md](docs/s3-integration.md) | App developers -- endpoints, boto3, certs |
 | [docs/security-model.md](docs/security-model.md) | InfoSec -- encryption, users, firewall |

--- a/ansible/ceph/docs/cluster-profiles.md
+++ b/ansible/ceph/docs/cluster-profiles.md
@@ -1,0 +1,74 @@
+# Cluster Profiles
+
+The runbooks are written against placeholders rather than one cluster's
+hostnames, because the two live Ceph clusters differ in access, layout, and
+hardware. Resolve the placeholders here before running anything.
+
+Most of these facts come from the cluster's `clusters.auto.tfvars` entry and its
+`group_vars/all/vars.yml`; those files are authoritative if this table ever
+drifts from them.
+
+## Placeholders used in runbooks
+
+| Placeholder | Meaning |
+|---|---|
+| `<ssh-target>` | `<ssh user>@<bootstrap host>` for the cluster |
+| `<inventory>` | Inventory directory, relative to `ansible/ceph/` |
+| `<vault>` | 1Password vault holding the cluster's secrets |
+| `<rgw-dns>` | Canonical S3 / RGW DNS name |
+
+## The clusters
+
+| | **sietch** | **spice** |
+|---|---|---|
+| Partition@region | `staging@austin` | `prod@htz-fsn1` |
+| Bootstrap host | `sietch-ceph-laurel` | `spice-ceph-adelia` |
+| SSH user | `ansible-iac` | `root` |
+| SSH key | `~/.ssh/id_ed25519_sietch` | `~/.ssh/id_ed25519_spice` |
+| `<ssh-target>` | `ansible-iac@sietch-ceph-laurel` | `root@spice-ceph-adelia` |
+| `<inventory>` | `inventories/staging-austin/sietch` | `inventories/prod-htz-fsn1/spice` |
+| `<vault>` | `yucca_tf_staging` | `yucca_tf_prod` |
+| `<rgw-dns>` | `s3.staging.austin.int.futo.cloud` | `s3.prod.fsn1.htz.futo.cloud` |
+| Nodes | 3 | 48 |
+| Cert subject | `US` / `Texas` / `Austin` | `DE` / `Saxony` / `Falkenstein` |
+
+## Shape differences that change procedures
+
+These are the places where a runbook needs a genuinely different sequence, not
+just different values substituted in.
+
+**Disk layout.** sietch nodes sit behind a SAS expander: every disk path is
+`/dev/disk/by-path/<sas_path_prefix>-phy<N>-lun-0`, and block.db lives on a
+dual-SSD VG. spice nodes are SX295: 14 SATA HDDs across 3 AHCI controllers
+addressed as `/dev/disk/by-path/pci-<addr>-ata-<n>`, with block.db on 128G
+`db-slotN` LVs carved from the NVMe RAID-1 `vg0`. `sas_path_prefix` is undefined
+on spice, and templates branch on that.
+
+**Hands.** sietch is on-site in Austin with iDRAC, virtual console, and bay LEDs
+for identifying a drive. spice has no IPMI and one KVM for 48 nodes; physical
+work is a Hetzner support ticket, and drives are identified to Hetzner by
+**serial**, not by bay.
+
+**Provisioning.** sietch provisions from a Debian live image booted over the
+iDRAC virtual console. spice uses Hetzner rescue mode plus installimage, driven
+by the `reprovision_hetzner` role.
+
+**Blast radius.** sietch is 3 nodes in staging. spice is 48 nodes serving
+production, so `serial:` batching and health gates matter there in a way they do
+not in Austin. Sequence spice work per node unless you have a reason not to.
+
+## Inventory files
+
+sietch's `inventory.ini` is rendered by Terraform (`ceph-cluster` module,
+`rendered_files` output) and is not committed; only `group_vars/` and
+`host_vars/` are in the repo. Render it before running a playbook against
+sietch:
+
+```bash
+ansible/ceph/scripts/render-inventories.sh staging austin
+```
+
+The script is read-only against state, but it reads the stack's `render`
+output, so a `terragrunt apply` must have run for that output to reflect the
+current cluster spec. spice's `inventory.ini` is committed; the same script
+renders it with `prod htz-fsn1`.

--- a/ansible/ceph/docs/runbooks/backup-restore.md
+++ b/ansible/ceph/docs/runbooks/backup-restore.md
@@ -5,6 +5,16 @@ regular schedule, or during disaster recovery.
 
 **Time estimate:** Backup: 2 minutes. Restore: depends on scenario.
 
+> Resolve `<ssh-target>` for your cluster from
+> [cluster-profiles.md](../cluster-profiles.md) first. Restore steps write to
+> the bootstrap node, and sietch and spice have different bootstrap hosts, SSH
+> users, and keys. Copying a keyring to the wrong cluster's bootstrap is the
+> failure mode this guards against.
+>
+> Every playbook below runs against whichever inventory `CEPH_ENV` points at.
+> `scripts/ansible-play.sh` requires it and exits if it is unset, so there is
+> no default to fall back on: `CEPH_ENV=<inventory>/inventory.ini`.
+
 ---
 
 ## Backup
@@ -93,8 +103,8 @@ ceph orch host rescan <hostname>
 Or manually copy from the backup:
 
 ```bash
-scp backups/<timestamp>/ceph.conf ansible-iac@<host>:/etc/ceph/ceph.conf
-scp backups/<timestamp>/ceph.client.admin.keyring ansible-iac@<host>:/etc/ceph/ceph.client.admin.keyring
+scp backups/<timestamp>/ceph.conf <ssh user>@<host>:/etc/ceph/ceph.conf
+scp backups/<timestamp>/ceph.client.admin.keyring <ssh user>@<host>:/etc/ceph/ceph.client.admin.keyring
 ```
 
 ### Scenario 2: Lost admin keyring on ALL nodes
@@ -105,9 +115,9 @@ scp backups/<timestamp>/ceph.client.admin.keyring ansible-iac@<host>:/etc/ceph/c
 
 ```bash
 scp backups/<timestamp>/ceph.client.admin.keyring \
-  ansible-iac@sietch-ceph-laurel:/etc/ceph/
+  <ssh-target>:/etc/ceph/
 
-ssh ansible-iac@sietch-ceph-laurel
+ssh <ssh-target>
 sudo chmod 600 /etc/ceph/ceph.client.admin.keyring
 sudo chown ceph:ceph /etc/ceph/ceph.client.admin.keyring
 ```

--- a/ansible/ceph/docs/runbooks/rotate-certs.md
+++ b/ansible/ceph/docs/runbooks/rotate-certs.md
@@ -9,16 +9,20 @@ changes (new nodes added, DNS name changed).
 - `op` session live (desktop unlocked or `OP_SERVICE_ACCOUNT_TOKEN` set)
 - Cluster is healthy
 
+> Resolve `<ssh-target>`, `<inventory>`, and `<rgw-dns>` for your cluster from
+> [cluster-profiles.md](../cluster-profiles.md) before running anything here.
+> The examples below show sietch values; spice differs in every one of them.
+
 ---
 
 ## 1. Check current certificate expiry
 
 ```bash
-ssh ansible-iac@sietch-ceph-laurel
+ssh <ssh-target>
 sudo openssl x509 -in /etc/ceph/rgw-ssl.crt -noout -subject -dates -ext subjectAltName
 ```
 
-Output shows:
+Output shows (sietch; spice reads `DE / Saxony / Falkenstein` and its own CN):
 
 ```
 subject=C = US, ST = Texas, L = Austin, O = FUTO, CN = s3.staging.austin.int.futo.cloud
@@ -57,7 +61,7 @@ scripts/ansible-play.sh rotate-certs.yml
   new cert. Export with:
 
 ```bash
-ssh ansible-iac@sietch-ceph-laurel sudo cat /etc/ceph/rgw-ssl.crt
+ssh <ssh-target> sudo cat /etc/ceph/rgw-ssl.crt
 ```
 
 ## 3. Verify after rotation
@@ -67,7 +71,7 @@ ssh ansible-iac@sietch-ceph-laurel sudo cat /etc/ceph/rgw-ssl.crt
 The playbook prints this, but to verify manually:
 
 ```bash
-ssh ansible-iac@sietch-ceph-laurel
+ssh <ssh-target>
 sudo openssl x509 -in /etc/ceph/rgw-ssl.crt -noout -subject -dates -ext subjectAltName
 ```
 
@@ -75,7 +79,7 @@ sudo openssl x509 -in /etc/ceph/rgw-ssl.crt -noout -subject -dates -ext subjectA
 
 ```bash
 # From a node in the cluster (self-signed cert)
-curl -k https://s3.staging.austin.int.futo.cloud:443/
+curl -k https://<rgw-dns>:443/
 ```
 
 Expected: XML response with `ListAllMyBucketsResult` or `AccessDenied`
@@ -83,8 +87,10 @@ Expected: XML response with `ListAllMyBucketsResult` or `AccessDenied`
 
 ### Test direct node access
 
+Any node's bond IP, to confirm the per-node SANs validate:
+
 ```bash
-curl -k https://10.10.10.90:443/
+curl -k https://<node-bond-ip>:443/
 ```
 
 ### Check RGW daemons are running
@@ -93,7 +99,7 @@ curl -k https://10.10.10.90:443/
 ceph orch ls --service-type rgw
 ```
 
-Expected: running count matches the number of ceph_nodes (currently 3).
+Expected: running count matches the cluster's node count (sietch 3, spice 48).
 
 ### Check dashboard can reach RGW
 
@@ -104,18 +110,21 @@ verification disabled for self-signed certs).
 ## Certificate configuration
 
 The cert parameters are controlled by these variables in
-`inventories/staging-austin/sietch/group_vars/all/vars.yml`:
+the cluster's `<inventory>/group_vars/all/vars.yml`:
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `ceph_rgw_ssl` | `true` | Enable TLS on RGW frontend |
-| `ceph_rgw_ssl_cert_days` | `3650` | Validity period (10 years) |
-| `ceph_rgw_ssl_cert_subject_c` | `US` | Country |
-| `ceph_rgw_ssl_cert_subject_st` | `Texas` | State |
-| `ceph_rgw_ssl_cert_subject_l` | `Austin` | Locality |
-| `ceph_rgw_ssl_cert_subject_o` | `FUTO` | Organization |
-| `ceph_rgw_ssl_cert_email` | `yucca@futo.org` | Contact email |
-| `ceph_rgw_dns_name` | `s3.staging.austin.int.futo.cloud` | CN and primary SAN |
+These are set per cluster, not shared, so the values differ between sietch and
+spice. Locality follows where the hardware physically sits.
+
+| Variable | sietch | spice | Purpose |
+|---|---|---|---|
+| `ceph_rgw_ssl` | `true` | `true` | Enable TLS on RGW frontend |
+| `ceph_rgw_ssl_cert_days` | `3650` | `3650` | Validity period (10 years) |
+| `ceph_rgw_ssl_cert_subject_c` | `US` | `DE` | Country |
+| `ceph_rgw_ssl_cert_subject_st` | `Texas` | `Saxony` | State |
+| `ceph_rgw_ssl_cert_subject_l` | `Austin` | `Falkenstein` | Locality |
+| `ceph_rgw_ssl_cert_subject_o` | `FUTO` | `FUTO` | Organization |
+| `ceph_rgw_ssl_cert_email` | `yucca@futo.org` | `yucca@futo.org` | Contact email |
+| `ceph_rgw_dns_name` | `s3.staging.austin.int.futo.cloud` | `s3.{{ cluster_domain }}` | CN and primary SAN |
 
 SANs are auto-generated from inventory: per-node FQDNs and bond IPs are
 included so direct-host access validates.


### PR DESCRIPTION
docs/cluster-profiles.md is the one place that resolves per-cluster facts: bootstrap host, SSH user and key, inventory path, 1P vault, RGW DNS name, cert subject, node count. Runbooks now reference placeholders against it rather than baking in one cluster's hostnames, so a second cluster does not mean a second copy of each procedure. It also records the three places where the shape genuinely changes the sequence rather than just the values: disk layout (SAS expander vs NVMe-RAID db-slots), hands (iDRAC and bay LEDs vs a Hetzner ticket keyed on serial), and provisioning (live image vs rescue-mode installimage).

rotate-certs.md and backup-restore.md come first because both were wrong for spice in a way that does damage rather than merely confusing. Every command in rotate-certs was literally ssh ansible-iac\@sietch-ceph-laurel, and backup-restore hardcoded the same host as the scp target for keyring restore, so following either verbatim during a prod incident points at the staging bootstrap. The cert-config table also listed sietch's Austin/Texas subject as the default when spice issues from Falkenstein, and CEPH\_ENV is documented as required since ansible-play.sh exits without it.

Docs only; no playbook, role, or inventory data changes. The remaining sietch-shaped docs are add-node.md, replace-host.md, rotate-secrets.md, remote-hands-access.md, and recover-bad-tofu-apply.md, which can move to the same placeholders incrementally.

- `main` <!-- branch-stack -->
  - \#354 :point\_left:
