### PR TITLE
fix(ceph): take osd specs out of the cephadm serve loop

### DIFF
--- a/ansible/ceph/README.md
+++ b/ansible/ceph/README.md
@@ -5,13 +5,22 @@ operating Ceph Tentacle (v20) clusters on bare-metal hardware via cephadm.
 Lives in the `yucca` monorepo at `ansible/ceph/`; secrets and inventory
 scaffolding are provisioned from `yucca/tf/` (see `../../tf/`).
 
-| Cluster | Domain | Location | Hardware | Nodes |
-|---------|--------|----------|----------|-------|
-| **sietch** | `staging.austin.int.futo.cloud` | Austin DC | Dell R730xd | 3 |
+| Cluster | Partition@region | Domain | Location | Hardware | Nodes |
+|---------|------------------|--------|----------|----------|-------|
+| **sietch** | `staging@austin` | `staging.austin.int.futo.cloud` | Austin DC | Dell R730xd | 3 |
+| **spice** | `prod@htz-fsn1` | `prod.fsn1.htz.futo.cloud` | Hetzner FSN1-DC24 | SX295 | 48 |
 
-Clusters are declared in `yucca/tf/deployment/staging/austin/ceph/clusters.auto.tfvars`;
-`tofu apply` renders `inventories/<partition>-<region>/<cluster>/inventory.ini`
-and `secrets.yml.tpl` per cluster. The `CEPH_ENV` variable selects the active
+spice serves production traffic: 720 OSDs across the 48 nodes, 672 HDD plus 48
+NVMe-backed `ssd-osd` LVs. That is an OSD count, not a disk count -- the
+physical disks are 672 HDD plus 96 NVMe (two per node, mirrored into `vg0`).
+Per-cluster SSH targets, vaults, and the shape differences that change a
+procedure are in [docs/cluster-profiles.md](docs/cluster-profiles.md).
+
+Clusters are declared in
+`yucca/tf/deployment/<partition>/<region>/ceph/clusters.auto.tfvars`;
+`terragrunt apply` plus `scripts/render-inventories.sh <partition> <region>`
+writes `inventories/<partition>-<region>/<cluster>/inventory.ini` and
+`secrets.yml.tpl` per cluster. The `CEPH_ENV` variable selects the active
 cluster for any `mise run` or direct ansible invocation.
 
 ## Architecture
@@ -22,16 +31,27 @@ graph TB
         A[mise + ansible + 1Password CLI]
     end
 
-    subgraph "Austin DC -- 10.10.10.0/24"
+    subgraph SIETCH["sietch -- Austin DC, 10.10.10.0/24 flat"]
         direction TB
         L[laurel<br/>MON+MGR+OSD+RGW]
         W[lawson<br/>MON+MGR+OSD+RGW]
         S[samara<br/>MON+MGR+OSD+RGW]
     end
 
-    A -->|SSH| L
-    A -->|SSH| W
-    A -->|SSH| S
+    subgraph SPICE["spice -- Hetzner FSN1-DC24<br/>public 10.40.20.0/23 - cluster 10.40.22.0/23"]
+        direction TB
+        M["adelia (bootstrap), curtis, hayley,<br/>lizzie, serena<br/>MON+MGR+OSD+RGW"]
+        O["43x OSD+RGW"]
+        V["ingress VIP 10.40.20.250<br/>haproxy + keepalived -> 48 RGW"]
+        O -.-> V
+        M -.-> V
+    end
+
+    A -->|SSH ansible-iac| L
+    A -->|SSH ansible-iac| W
+    A -->|SSH ansible-iac| S
+    A -->|SSH root| M
+    A -->|SSH root| O
 ```
 
 See [docs/architecture.md](docs/architecture.md) for role dependencies,
@@ -40,8 +60,10 @@ data flow, and design rationale.
 ## Quick Start
 
 ```bash
-# 1. Render cluster inventories + secrets templates (once, from yucca/tf/)
-(cd ../../tf/deployment/staging/austin/ceph && tofu init && tofu apply)
+# 1. Render the cluster's inventory + secrets template. The stack must have
+#    been applied first -- the script is read-only against TF state.
+#      sietch: staging austin      spice: prod htz-fsn1
+scripts/render-inventories.sh staging austin
 
 # 2. Set up the ansible side
 mise trust && mise run setup          # bootstrap dev environment
@@ -51,11 +73,16 @@ mise trust && mise run setup          # bootstrap dev environment
 #    block -- that would override your shell value and silently target the
 #    wrong cluster; see docs/scripts.md "Setting CEPH_ENV".
 export CEPH_ENV=inventories/staging-austin/sietch/inventory.ini
+# ...or, for production:
+# export CEPH_ENV=inventories/prod-htz-fsn1/spice/inventory.ini
 mise run preflight       # TF artifacts + 1P + SSH + connectivity
 mise run status          # read-only cluster health check
 mise run drift           # configuration drift detection
 mise run deploy          # full pipeline (idempotent)
 ```
+
+An unset `CEPH_ENV` does not fail -- it falls back to sietch. Check it before
+anything that writes.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
 
@@ -63,23 +90,29 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
 
 | Order | Role | Description |
 |-------|------|-------------|
-| 1 | `provision_host` | Bare-metal Debian 12 install via debootstrap (Austin only) |
+| 1 | `provision_host` | Bare-metal Debian 12 install via debootstrap (sietch only) |
+| 1 | `reprovision_hetzner` | Hetzner rescue + installimage reprovision via the Robot API (spice only) |
 | 2 | `baseline` | Post-boot OS baseline: ops user, packages, /etc/hosts, services |
-| 3 | `os_tuning` | Kernel sysctl, TCP buffers, optional centralized logging |
-| 4 | `hardware_tuning` | I/O scheduler, readahead, udev rules, optional CPU governor |
-| 5 | `ceph_deploy` | cephadm bootstrap, join, placement, OSDs, RGW, monitoring |
-| 6 | `ceph_tuning` | Recovery throttling, scrub window, CRUSH, telemetry, audit |
-| 7 | `security` | nftables firewall, SSH hardening |
-| 8 | `ceph_destroy` | Complete cluster teardown (safety-gated) |
-| 9 | `s3_bench` | Parallel S3 benchmark against local RGW |
+| 3 | `netbird` | NetBird overlay enrollment (gated by `ceph_netbird_enabled`) |
+| 4 | `os_tuning` | Kernel sysctl, TCP buffers, optional centralized logging |
+| 5 | `hardware_tuning` | I/O scheduler, readahead, udev rules, optional CPU governor |
+| 6 | `ceph_deploy` | cephadm bootstrap, join, placement, OSDs, RGW, monitoring |
+| 7 | `ceph_tuning` | Recovery throttling, scrub window, CRUSH, telemetry, audit |
+| 8 | `security` | nftables firewall, SSH hardening |
+| -- | `networkd` | Bond + VLAN config under systemd-networkd; applied on its own, one node at a time |
+| -- | `ceph_backup` | Scheduled cluster-state backup timer on the bootstrap node |
+| -- | `ceph_destroy` | Complete cluster teardown (safety-gated) |
+| -- | `s3_bench` | Parallel S3 benchmark against local RGW |
 
 ## Playbooks
 
 | Playbook | Description |
 |----------|-------------|
-| `site.yml` | Full pipeline: baseline + tune + deploy + tune + harden |
-| `provision.yml` | Bare-metal provisioning (Austin, `-i` provision inventory) |
+| `site.yml` | Full pipeline: baseline + netbird + tune + deploy + tune + harden |
+| `provision.yml` | Bare-metal provisioning (sietch, `-i` provision inventory) |
+| `reprovision.yml` | Hetzner installimage reprovision (spice; destructive, canary first) |
 | `baseline.yml` | OS baseline (users, packages, hosts) |
+| `netbird.yml` | NetBird overlay enrollment |
 | `tune-os.yml` | Kernel/sysctl tuning |
 | `tune-hardware.yml` | Disk I/O tuning |
 | `deploy-ceph.yml` | Ceph cluster deployment (tags: prerequisites, bootstrap, join, placement, lvm, osds, crush, rgw, monitoring, verify) |
@@ -96,6 +129,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
 | `rotate-ssh-key.yml` | Distribute current ansible-iac pubkey from 1P to nodes |
 | `migrate-networkd.yml` | One-shot networkd/bridge migration (rolling, noout-gated) |
 | `hardware-inventory.yml` | Hardware facts to JSON |
+| `add-node.yml` | Reimage one spice node the operator has already put into Hetzner rescue by hand (no Robot API) |
+| `backup-ceph.yml` | Install the scheduled cluster-state backup timer |
+| `upgrade-ceph.yml` | Health-gated cephadm cluster upgrade; explicit target image required, never run by converge |
 
 ## mise Tasks
 
@@ -118,9 +154,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow.
 | `rotate-ssh-key` | Distribute current ansible-iac pubkey from 1P to nodes |
 | `hardware-inventory` | Capture hardware facts to JSON |
 | `migrate-networkd` | One-shot networkd/bridge migration (rolling, noout-gated) |
+| `netbird` | Enroll nodes into the NetBird overlay (reads the setup key from 1P) |
+| `reprovision` | Hetzner installimage reprovision (destructive -- canary first) |
+| `backup-timer` | Install the scheduled cluster-state backup timer on the bootstrap node |
 
-Inventory + secrets-template scaffolding live in `yucca/tf/` -- run
-`tofu apply` in `tf/deployment/staging/austin/ceph/` to (re-)render
+Inventory + secrets-template scaffolding live in `yucca/tf/` -- apply the
+cluster's stack under `tf/deployment/<partition>/<region>/ceph/`, then run
+`scripts/render-inventories.sh <partition> <region>` to (re-)render
 `inventories/<partition>-<region>/<cluster>/inventory.ini` and `secrets.yml.tpl`.
 
 ## Documentation
@@ -144,7 +184,13 @@ Inventory + secrets-template scaffolding live in `yucca/tf/` -- run
 
 ## Known Limitations
 
-- **Single-network topology**: public = cluster network on sietch.
-- **Self-signed TLS**: RGW clients need `--no-verify-ssl`. Production needs real certs.
+- **Single-network topology on sietch**: public = cluster network (both
+  `10.10.10.0/24`). spice splits them across fabric VLANs -- public
+  `10.40.20.0/23` on VLAN 120, cluster `10.40.22.0/23` on VLAN 122 at MTU 9000.
+- **spice still routes over its 1G WAN**: the default route and the ansible/SSH
+  path are the 1G `enp197s0`, not the 25G bond. Ceph itself never touches it
+  (daemons are pinned to the fabric networks), but a WAN outage still costs
+  reachability.
+- **Self-signed TLS**: RGW clients need `--no-verify-ssl`, on both clusters.
 - **`ops` user is password-only**: no SSH keys installed; password sourced from 1P. Intended as an interactive console or recovery account, not for automation.
 - **DNS not managed**: `s3.<domain>` and `*.s3.<domain>` records must exist externally.

--- a/ansible/ceph/docs/architecture.md
+++ b/ansible/ceph/docs/architecture.md
@@ -16,14 +16,16 @@ specialized docs under `docs/`.
 flowchart LR
     OP([Operator workstation<br/>mise, op CLI, ansible, tofu])
     YUCCA[/Yucca monorepo<br/>tf/ + ansible/ceph/ + kubernetes//]
-    ONEP[("1Password org<br/>yucca_tf, yucca_tf_staging, ...")]
+    ONEP[("1Password org<br/>yucca_tf, yucca_tf_staging,<br/>yucca_tf_prod, ...")]
     S3[("OVH S3<br/>yucca-tf-state bucket")]
-    SIETCH["Sietch, Austin DC<br/>3x Dell R730xd"]
+    SIETCH["<b>sietch</b> -- staging<br/>Austin DC<br/>3x Dell R730xd"]
+    SPICE["<b>spice</b> -- prod<br/>Hetzner FSN1-DC24<br/>48x SX295"]
 
     OP -->|edits| YUCCA
     OP -->|reads/writes secrets| ONEP
     OP -->|TF state I/O| S3
     OP -->|SSH ansible-iac| SIETCH
+    OP -->|SSH root| SPICE
 ```
 
 The yucca monorepo is the single source of truth for cluster identity and
@@ -38,8 +40,17 @@ External dependencies are minimal and explicit:
 - **OVH S3** -- `yucca-tf-state` bucket at `s3.eu-west-par.io.cloud.ovh.net`.
   Keyed by `yucca/<partition>/<region>/<stack>/terraform.tfstate` so multiple
   stacks share the bucket without collision.
-- **Hardware** -- Austin colo for sietch (Dell R730xd x 3, single 10G bond).
-  Detail in [hardware.md](hardware.md).
+- **Hardware** -- Austin colo for sietch (3x Dell R730xd, one flat subnet);
+  Hetzner FSN1-DC24 for spice (48x SX295, a 1G WAN alongside a bonded 2x 25G
+  fabric with split public/cluster VLANs). Detail in
+  [hardware.md](hardware.md).
+- **Hetzner Robot API** -- spice only. Rescue mode plus installimage is the
+  provisioning path (`reprovision_hetzner` role); there is no IPMI, so the API
+  is the only remote hands short of a support ticket.
+- **NetBird overlay** -- spice nodes are enrolled peers. Human SSH is
+  SSO-gated through NetBird's own server; CI reaches the nodes over the
+  overlay. Ansible still connects over the WAN address, which holds the
+  default route.
 
 ---
 
@@ -50,16 +61,23 @@ tool in the mesh derives both from the same source -- directory layout
 (`tf/deployment/<partition>/<region>/<stack>`) -- so isolation is structural,
 not flag-driven.
 
-| Layer        | staging / austin (today)                                | dev / local (planned)                          | prod / htz-fsn1 (planned)                      |
+| Layer        | staging / austin (live)                                 | prod / htz-fsn1 (live)                         | dev / local (planned)                          |
 |--------------|---------------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| TF stack dir | `tf/deployment/staging/austin/ceph/`                    | `tf/deployment/dev/local/ceph/`                | `tf/deployment/prod/htz-fsn1/ceph/`            |
-| TF state key | `yucca/staging/austin/ceph/terraform.tfstate`           | `yucca/dev/local/ceph/terraform.tfstate`       | `yucca/prod/htz-fsn1/ceph/terraform.tfstate`   |
-| 1P vaults    | `yucca_tf_staging`, `yucca_tf_staging_manual`          | `yucca_tf_dev`, `yucca_tf_dev_manual`         | `yucca_tf` (live), `yucca_tf_prod_manual`     |
-| Ansible inv  | `inventories/staging-austin/<cluster>/`                 | `inventories/dev-local/<cluster>/`             | `inventories/prod-htz-fsn1/<cluster>/`         |
+| Cluster      | `sietch` -- 3x Dell R730xd                              | `spice` -- 48x Hetzner SX295                   | --                                             |
+| TF stack dir | `tf/deployment/staging/austin/ceph/`                    | `tf/deployment/prod/htz-fsn1/ceph/`            | `tf/deployment/dev/local/ceph/`                |
+| TF state key | `yucca/staging/austin/ceph/terraform.tfstate`           | `yucca/prod/htz-fsn1/ceph/terraform.tfstate`   | `yucca/dev/local/ceph/terraform.tfstate`       |
+| 1P vaults    | `yucca_tf_staging`, `yucca_tf_staging_manual`          | `yucca_tf_prod`, `yucca_tf_prod_manual`       | `yucca_tf_dev`, `yucca_tf_dev_manual`         |
+| Ansible inv  | `inventories/staging-austin/sietch/`                    | `inventories/prod-htz-fsn1/spice/`             | `inventories/dev-local/<cluster>/`             |
 | mise default | `CEPH_ENV=...staging-austin/sietch/inventory.ini`       | overridden via env at invocation               | overridden via env at invocation               |
 
-Today the only deployed cluster is sietch (staging / austin). Adding another
-region or partition is purely additive: create the matching
+Two clusters are deployed today: sietch (staging / austin) and spice
+(prod / htz-fsn1), which serves production traffic. They share one module, one
+set of roles, and one set of mise tasks -- what differs is their
+`clusters.auto.tfvars` entry and their inventory. Per-cluster hosts, SSH
+targets, vaults, and the shape differences that change a procedure are
+tabulated in [cluster-profiles.md](cluster-profiles.md).
+
+Adding another region or partition is purely additive: create the matching
 `tf/deployment/<partition>/<region>/ceph/` directory, populate
 `clusters.auto.tfvars`, and the same module + Ansible roles + mise tasks work
 unchanged. The state backend key path, 1P vault selection, and inventory
@@ -118,9 +136,11 @@ flowchart TB
 
 ### Handoff points (the edges of the mesh)
 
-1. **TF -> repo** -- `terragrunt apply` renders `inventory.ini`,
-   `inventory-destroy.ini`, optional `inventory-provision.ini`,
-   and `secrets.yml.tpl` into `inventories/<partition>-<region>/<cluster>/`. These files are
+1. **TF -> repo** -- `terragrunt apply` computes `inventory.ini`,
+   `inventory-destroy.ini`, optional `inventory-provision.ini`, and
+   `secrets.yml.tpl` into a `render` output;
+   `scripts/render-inventories.sh <partition> <region>` writes them into
+   `inventories/<partition>-<region>/<cluster>/`. These files are
    gitignored -- the source of truth is `clusters.auto.tfvars` + the
    ceph-cluster module.
 2. **TF <-> op CLI** -- TF runs are wrapped with `op run --env-file=tf/.env`,
@@ -150,14 +170,18 @@ tf/
 |-- .env                              op:// references (committed; no literal secrets)
 |-- shared/modules/ceph-cluster/      per-cluster orchestration module
 |   |-- main.tf, variables.tf, outputs.tf, rendering.tf
-|   |-- wordlist.txt                  923 words for auto-picked hostnames
 |   `-- templates/                    inventory + secrets.yml.tpl templates
+|-- shared/modules/node-names/
+|   `-- wordlist.txt                  923 words for auto-picked hostnames
 `-- deployment/
     |-- terragrunt.hcl                root: state backend, partition/region/stack derived from path
-    `-- staging/austin/ceph/
-        |-- terragrunt.hcl            includes root, sets ansible_project_root
-        |-- main.tf, variables.tf, versions.tf
-        `-- clusters.auto.tfvars      declarative cluster list
+    |-- staging/austin/ceph/          sietch
+    |   |-- terragrunt.hcl            includes root, sets ansible_project_root
+    |   |-- main.tf, variables.tf, versions.tf, secrets.tf
+    |   `-- clusters.auto.tfvars      declarative cluster list
+    `-- prod/htz-fsn1/ceph/           spice -- same shape, plus:
+        `-- spice-hosts.yaml          server_number -> WAN IP -> host_index sidecar,
+                                      read by the reprovision driver and the fabric config
 ```
 
 ### Cluster identity is declared, not derived
@@ -184,6 +208,12 @@ sietch = {
 }
 ```
 
+spice's entry is the same schema with two additions the 48-node shape needs:
+`provision_profile = null` (Hetzner installimage, not debian-live) and a
+per-host `roles` list, which is how MON quorum is declared -- five of the 48
+carry `"mon"` (adelia is bootstrap, then curtis, hayley, lizzie, serena), the
+rest are `osd` + `rgw`.
+
 The module computes everything else: hostname (`<cluster>-<role>-<name>`),
 FQDN (`<hostname>.<domain>`), 1P item names
 (`<CLUSTER>_CEPH_<ROLE>_PASSWORD`), inventory directory path
@@ -191,19 +221,25 @@ FQDN (`<hostname>.<domain>`), 1P item names
 
 ### Auto-naming via wordlist
 
-For hosts where `name = null`, the module picks a stable name from a
-923-word pool using `random_shuffle` seeded by `(cluster_name, name_seed)`.
-Operator-declared names are excluded from the pool to prevent collisions
-within a cluster. Adding hosts at the tail is safe -- existing positions
-keep their names across applies.
+For hosts where `name = null`, the module picks a stable name from the shared
+923-word pool (`tf/shared/modules/node-names/wordlist.txt`) using
+`random_shuffle` seeded by `(cluster_name, name_seed)`. Operator-declared names
+are excluded from the pool to prevent collisions within a cluster. Adding hosts
+at the tail is safe -- existing positions keep their names across applies.
 
-A host declared with no `name` demonstrates this: TF auto-picks a stable
-word (e.g. `evelyn`) -> hostname `<cluster>-ceph-evelyn`.
+Both live clusters name every host explicitly, so nothing is auto-picked today:
+spice's reprovision driver needs hostnames before any apply has run, and
+sietch is small enough that naming three nodes by hand costs nothing. The pool
+is there for clusters that do not care what their nodes are called.
 
 ### Rendered artifacts (gitignored)
 
-Per `tf/shared/modules/ceph-cluster/rendering.tf`, the module writes four
-files into `inventories/<partition>-<region>/<cluster>/`:
+`tf/shared/modules/ceph-cluster/rendering.tf` exposes the artifacts as a
+`rendered_files` output rather than writing them with `local_file` -- a
+`local_file` destination path lands in shared state, which coupled that state
+to whichever worktree applied last. `scripts/render-inventories.sh <partition>
+<region>` reads the output and writes four files into
+`inventories/<partition>-<region>/<cluster>/`:
 
 | File                                       | Purpose                                                                                  |
 |--------------------------------------------|------------------------------------------------------------------------------------------|
@@ -212,7 +248,11 @@ files into `inventories/<partition>-<region>/<cluster>/`:
 | `inventory-provision.ini`                  | Provisioning inventory (only when `provision_profile != null`; uses live-image creds; the profile names the template, not the output) |
 | `secrets.yml.tpl`                          | `vault_*: op://<vault>/<CLUSTER>_CEPH_*/password` pointers, consumed by `op inject -f`   |
 
-All four are in `ansible/ceph/.gitignore`. Re-render with `mise run tf:apply`.
+All four are in `ansible/ceph/.gitignore` for every cluster. Re-render with
+`mise run tf:apply` followed by `scripts/render-inventories.sh` for the
+partition + region you applied (`staging austin`, `prod htz-fsn1`). The script
+is read-only against state, so the apply has to come first for the `render`
+output to reflect the current cluster spec.
 
 ### State backend
 
@@ -231,13 +271,28 @@ to already exist -- fresh-backend init fails with 404 before it can create
 one. Single-operator workflow today; revisit when concurrent applies become
 likely. See `deployment/terragrunt.hcl` for the inline rationale.
 
-### What TF does not yet manage
+### What TF does not manage
 
-`onepassword_item` resources are **dormant** (`tf/.../secrets.tf.disabled`).
-1P items are created today via the `op` CLI (operator runs `op item create`
-once per cluster). The gate to re-enabling them is the dedicated
-`sietch-ceph` service account that lets us split write authority from the
-org-wide superuser SA.
+Both ceph stacks own their generated password items: `secrets.tf` declares
+`onepassword_item.ceph_password` per (cluster, secret role), titled from the
+module's `secrets` output. It lives at the stack, not in the shared module, so
+a stack that manages no secrets never pulls in the onepassword provider -- the
+module's own copy stays parked as `secrets.tf.disabled`.
+
+Four categories stay out of TF by design:
+
+- **S3 service-user keys** (`*_S3_SVC_YUCCA_RESTIC_{ACCESS,SECRET}_KEY`) --
+  a live contract with the restic consumer; recreating them would churn values
+  the RGW is seeded from.
+- **The `ansible-iac` SSH key item** -- generated with
+  `op item create --ssh-generate-key`; the provider cannot generate inline and
+  importing would put the private key in state.
+- **DR documents** (RGW TLS cert/key, admin keyring) -- captured post-deploy by
+  `mise run capture`.
+- **spice's alertmanager webhook** (`SPICE_CEPH_ALERTMANAGER_WEBHOOK_URL`) --
+  an externally issued Zulip receiver URL, not a generated credential. TF
+  references it; managing it would overwrite the live URL with a random
+  password on the next apply and silently stop alert delivery.
 
 ---
 
@@ -248,14 +303,17 @@ org-wide superuser SA.
 | Vault                     | Purpose                                                | Who reads it                       | Who writes it                       |
 |---------------------------|--------------------------------------------------------|------------------------------------|-------------------------------------|
 | `yucca_tf`                | Cross-partition shared (TF state S3 creds)             | TF (via `tf/op-run.sh`)            | Operator (manual)                   |
-| `yucca_tf_staging`        | staging live values (sietch today)                     | Ansible runtime (op inject)        | Superuser SA (TF) + operator (op CLI) |
+| `yucca_tf_staging`        | staging live values (sietch)                            | Ansible runtime (op inject)        | Write SA (TF) + operator (op CLI)   |
+| `yucca_tf_prod`           | prod live values (spice)                                | Ansible runtime (op inject)        | Write SA (TF) + operator (op CLI)   |
 | `yucca_tf_staging_manual` | staging human-fillable placeholders (API tokens, OAuth)| Ansible runtime                    | Operator (manual)                   |
-| `yucca_tf_dev(_manual)`, `yucca_tf`, `yucca_tf_prod_manual` | dev + prod analogues, same shape    | per partition                      | per partition                       |
+| `yucca_tf_prod_manual`, `yucca_tf_dev(_manual)` | prod + dev analogues, same shape  | per partition                      | per partition                       |
 
-Each partition has its own live + `_manual` vault pair; sietch runs in
-staging, so its items live in `yucca_tf_staging`. The `_manual` vaults exist
-for items that can't be auto-generated (third-party API tokens, OAuth client
-secrets) -- they're populated by humans, not by TF.
+Each partition has its own live + `_manual` vault pair, and a cluster's
+`vault` field in `clusters.auto.tfvars` picks the live one: sietch runs in
+staging so its items live in `yucca_tf_staging`, spice runs in prod so its
+items live in `yucca_tf_prod`. The `_manual` vaults exist for items that
+can't be auto-generated (third-party API tokens, OAuth client secrets) --
+they're populated by humans, not by TF.
 
 ### Service accounts
 
@@ -279,8 +337,8 @@ Rotation procedure: [docs/runbooks/rotate-sa-token.md](runbooks/rotate-sa-token.
 
 ### Item categories and naming
 
-Per cluster, the following items live in the cluster's `vault` (currently
-`yucca_tf_staging` for sietch):
+Per cluster, the following items live in the cluster's `vault`
+(`yucca_tf_staging` for sietch, `yucca_tf_prod` for spice):
 
 | Category   | Item title pattern                                      | Field consumed       |
 |------------|---------------------------------------------------------|----------------------|
@@ -289,9 +347,15 @@ Per cluster, the following items live in the cluster's `vault` (currently
 | Password   | `<CLUSTER>_CEPH_GRAFANA_PASSWORD`                       | `password`           |
 | Password   | `<CLUSTER>_CEPH_S3_SVC_YUCCA_RESTIC_ACCESS_KEY`         | `password`           |
 | Password   | `<CLUSTER>_CEPH_S3_SVC_YUCCA_RESTIC_SECRET_KEY`         | `password`           |
+| Password   | `<CLUSTER>_METRICS_WORKER_ACCESS_KEY`, `..._SECRET_KEY` | `password`           |
+| Password   | `<CLUSTER>_CEPH_ALERTMANAGER_WEBHOOK_URL` (spice only)  | `password`           |
 | SSH Key    | `<CLUSTER>_CEPH_ANSIBLE_IAC_SSH_KEY`                    | `private_key` / `public_key` |
 | Document   | `<CLUSTER>_CEPH_RGW_TLS_CERT`, `..._RGW_TLS_KEY`       | file content         |
 | Document   | `<CLUSTER>_CEPH_CLIENT_ADMIN_KEYRING`                   | file content         |
+
+The metrics-worker keys drop the `_CEPH` segment: they belong to the
+yucca-metrics-worker service, which reads bucket usage from RadosGW, not to
+the Ceph cluster itself.
 
 The `<CLUSTER>_CEPH_*` prefix is hardcoded in
 `tf/shared/modules/ceph-cluster/main.tf` (`secret_prefix = "${upper(var.cluster_name)}_CEPH"`)
@@ -312,8 +376,8 @@ serves a different shape of secret consumption:
 2. **`op inject -f -i <tpl> -o <out>`** -- file-template resolution.
    Reads a file containing inline `op://` references, resolves each, writes
    to the output path. Used by `scripts/ansible-play.sh` to render
-   `secrets.yml.tpl` -> tmpfile, and by the Hetzner installimage flow to
-   render `post-install.sh.tpl` -> `post-install.sh`.
+   `secrets.yml.tpl` -> tmpfile. (The Hetzner installimage templates carry no
+   secrets and are rendered by Ansible's `template` module, not by op.)
 3. **`op read "op://<vault>/<item>/<field>"`** -- single-value read.
    Used by `scripts/install-ssh-keys.sh`, `rotate-ssh-key.yml`,
    `post-deploy-capture.yml`. Returns one value to stdout for one specific
@@ -333,13 +397,18 @@ The current flow fails closed instead.
 
 ### Role dependency graph
 
-Provisioning is a separate concern (`provision.yml`, sietch only). The main
-pipeline (`site.yml`) runs everything else in this order:
+Getting a bare box to a bootable OS is a separate concern, and each cluster
+takes its own route: sietch runs `provision.yml` (`provision_host`, debootstrap
+from a Debian live image booted over the iDRAC virtual console), spice runs
+`reprovision.yml` (`reprovision_hetzner`, Hetzner rescue mode + installimage
+driven through the Robot API). Both hand off to the same convergence pipeline.
+`site.yml` runs everything after that, in this order:
 
 ```mermaid
 flowchart TB
-    PROV["provision_host<br/><i>separate playbook, live image</i>"]
+    PROV["provision_host (sietch)<br/>reprovision_hetzner (spice)<br/><i>separate playbooks</i>"]
     BASE["baseline<br/><i>users, packages, /etc/hosts</i>"]
+    NB["netbird<br/><i>overlay enrollment;<br/>no-op unless ceph_netbird_enabled</i>"]
     OST["os_tuning<br/><i>sysctl, TCP buffers</i>"]
     HWT["hardware_tuning<br/><i>I/O scheduler, readahead</i>"]
     DEPLOY["ceph_deploy<br/><i>bootstrap, join, OSDs, RGW,<br/>crush rules, monitoring</i>"]
@@ -347,8 +416,9 @@ flowchart TB
     SEC["security<br/><i>nftables, SSH hardening</i>"]
 
     PROV -.->|reboot into installed OS| BASE
-    BASE --> OST
-    BASE --> HWT
+    BASE --> NB
+    NB --> OST
+    NB --> HWT
     OST --> DEPLOY
     HWT --> DEPLOY
     DEPLOY --> CTUNE
@@ -358,21 +428,32 @@ flowchart TB
     class PROV separate
 ```
 
-`site.yml` starts at `baseline` -- `provision_host` runs only on first
-install via `provision.yml`. (The roles above are imported as per-role
-playbooks: `baseline.yml`, `tune-os.yml`, `tune-hardware.yml`,
-`deploy-ceph.yml`, `tune-ceph.yml`, `harden.yml`.)
+`site.yml` starts at `baseline` -- the provisioning roles run only on first
+install, or on a deliberate rebuild. (The roles above are imported as per-role
+playbooks: `baseline.yml`, `netbird.yml`, `tune-os.yml`, `tune-hardware.yml`,
+`deploy-ceph.yml`, `tune-ceph.yml`, `harden.yml`.) The `networkd` role is not
+in `site.yml`; it is applied on its own through `migrate-networkd.yml`, rolling
+one node at a time behind a `noout` gate.
 
 The split is deliberate. `provision_host` does the minimum inside the
 live-image chroot -- just the `ansible-iac` user, so Ansible can connect after
 reboot -- because chroot work is fragile. The ops user, packages, and
 `/etc/hosts` move to the convergeable `baseline` role, which re-runs against a
-live node to fix drift without reprovisioning.
+live node to fix drift without reprovisioning. `reprovision_hetzner` lands in
+the same place by a different road: an `autosetup` file tells installimage to
+build the NVMe mdraid-1 and `vg0`, and a `post-install.sh` chroot step does
+nothing but authorize the cluster key for `root` and `ansible-iac`. That
+chroot step is deliberately inert -- no apt, no `lvcreate` -- because those
+are the steps that broke installimage on the SX295 precedent; packages and
+block.db LVs wait for post-boot convergence.
 
-The OS is installed with `debootstrap` from the live image rather than a
-preseed/autoinstall. The disk layout (mdraid-1 across two SSDs, partitions
-reserved for ceph block.db and SSD OSDs) needs scripted partitioning and
-pre-flight hardware validation that preseed's `partman` recipes can't express.
+On sietch the OS is installed with `debootstrap` from the live image rather
+than a preseed/autoinstall. The disk layout (mdraid-1 across two SSDs,
+partitions reserved for ceph block.db and SSD OSDs) needs scripted partitioning
+and pre-flight hardware validation that preseed's `partman` recipes can't
+express. spice has no such freedom -- installimage owns partitioning on
+Hetzner, so the block.db and `ssd-osd` LVs get carved later, by
+`ceph_deploy/lvm-setup.yml`, on a booted node.
 
 ### Why this order matters
 
@@ -401,7 +482,7 @@ flowchart TB
     P2["Phase 2, bootstrap.yml<br/><i>cephadm bootstrap on first node</i>"]
     P3["Phase 3, join.yml<br/><i>ceph orch host add for remaining nodes</i>"]
     P4["Phase 4, placement.yml<br/><i>MON/MGR placement calculation</i>"]
-    P45["Phase 4.5, lvm-setup.yml<br/><i>ensure block.db VGs/LVs exist (sietch-shape only;<br/>NVMe-RAID shape skips -- LVM owned by installimage post-install)</i>"]
+    P45["Phase 4.5, lvm-setup.yml<br/><i>ensure block.db VGs/LVs exist; branches on shape<br/>(sietch: two SSD VGs; spice: db-slots + ssd-osd on vg0)</i>"]
     P5["Phase 5, osds.yml<br/><i>render osd-spec.yml.j2 -> ceph orch apply osd<br/>(cephadm provisions LUKS + LVM internally)</i>"]
     P55["Phase 5.5, crush-rules.yml<br/><i>replicated_hdd / replicated_ssd rules</i>"]
     P575["Phase 5.75, rgw.yml<br/><i>EC pools, realm/zone, TLS, S3 user</i>"]
@@ -419,28 +500,43 @@ just those phases.
 
 ```
 inventories/
-  staging-austin/sietch/    Austin staging cluster
+  staging-austin/sietch/    Austin staging cluster, 3 nodes
     inventory.ini                     TF-generated, gitignored
     inventory-destroy.ini             TF-generated, gitignored
-    inventory-provision.ini           TF-generated, gitignored
+    inventory-provision.ini           TF-generated, gitignored (debian-live profile)
     secrets.yml.tpl                   TF-generated, gitignored
     group_vars/all/vars.yml           cluster-wide variables (committed)
     host_vars/                        per-node hardware topology (committed)
       sietch-ceph-laurel.yml          bond_ip, SAS path prefix, OSD maps
       sietch-ceph-lawson.yml
       sietch-ceph-samara.yml
-    installimage/                     Hetzner installimage assets (sietch n/a)
+  prod-htz-fsn1/spice/      Falkenstein production cluster, 48 nodes
+    inventory.ini                     TF-generated, gitignored
+    inventory-destroy.ini             TF-generated, gitignored
+    secrets.yml.tpl                   TF-generated, gitignored
+    group_vars/all/vars.yml           committed; carries the fabric VLANs, the
+                                      EC profile, and the shared OSD device map
+    host_vars/                        48 files, committed
+      spice-ceph-adelia.yml           bond_ip, host_index, server number, mon
+      ...                             flag -- no OSD map, that is in group_vars
 ```
 
-A Hetzner NVMe-RAID cluster would follow the same layout, adding an
-`installimage/` directory with a `post-install.sh.tpl` (op-injected) that
-owns LVM setup. No such cluster is deployed today -- sietch is the only live
-cluster -- but the module and roles already support the shape.
+There is no `inventory-provision.ini` for spice: `provision_profile = null`,
+because Hetzner installimage replaces the debian-live provisioning path. The
+installimage assets are role-owned (`roles/reprovision_hetzner/templates/`),
+not inventory-owned, since every Hetzner cluster renders the same two
+templates from its own variables.
 
-`host_vars/*.yml` is committed because per-node hardware facts (bond_ip, SAS
-expander paths, SSD PHY positions, HDD-to-block.db mappings) are stable
-inventory truth -- not operator preference. The `.local.yml` suffix is
-gitignored as an escape hatch for operator-local overrides.
+spice inverts sietch's host_vars/group_vars balance. Its by-path OSD map is
+identical on 47 of the 48 nodes, so the map lives in `group_vars` and only
+`spice-ceph-miguel` overrides it (one disk sits on a different AHCI
+controller). Writing 48 near-identical host_vars files would have made a
+one-node exception invisible.
+
+`host_vars/*.yml` is committed because per-node hardware facts (bond_ip,
+host_index, SAS expander paths, SSD PHY positions, HDD-to-block.db mappings)
+are stable inventory truth -- not operator preference. The `.local.yml` suffix
+is gitignored as an escape hatch for operator-local overrides.
 
 ### Variable precedence
 
@@ -463,7 +559,8 @@ flowchart TB
 - **host_vars** provides per-node physical topology.
 - **extra-vars from @tmpfile** carries op-injected `vault_ops_password`,
   `vault_ceph_dashboard_password`, `vault_grafana_admin_password`,
-  `vault_s3_restic_access_key`, `vault_s3_restic_secret_key`.
+  `vault_s3_restic_access_key`, `vault_s3_restic_secret_key`, plus
+  `vault_metrics_worker_*` and (spice) `vault_alertmanager_webhook_url`.
 - **extra-vars via `-e`** carries safety gates: `confirm_wipe=true`,
   `provision_skip_reboot=true`, `yes_destroy_ceph=true`.
 
@@ -472,9 +569,10 @@ flowchart TB
 `ansible.cfg` contains zero site-specific values. No default inventory, no
 ProxyJump, no hardcoded key paths. Site-specifics live exclusively in
 `clusters.auto.tfvars` (which TF renders into the inventory) or in the
-inventory's `group_vars`. The same `ansible.cfg` and the same roles work
-unchanged across Austin, Hetzner, or any future cluster -- only the cluster
-entry in `clusters.auto.tfvars` differs.
+inventory's `group_vars`. The same `ansible.cfg` and the same roles drive both
+a 3-node SAS-expander cluster in Austin and a 48-node NVMe-RAID cluster on a
+25G Hetzner fabric -- only the cluster entry in `clusters.auto.tfvars` and the
+inventory's `group_vars` differ.
 
 ---
 
@@ -497,7 +595,8 @@ entry in `clusters.auto.tfvars` differs.
 | Bootstrap      | `setup`                                                                  |
 | Verify         | `lint`, `check`, `test`, `preflight`                                  |
 | Read-only ops  | `status`, `drift`                                                       |
-| State change   | `deploy`, `destroy`, `capture`, `backup`                              |
+| State change   | `deploy`, `destroy`, `capture`, `backup`, `backup-timer`              |
+| Provisioning   | `reprovision` (Hetzner installimage), `netbird` (overlay enrollment)     |
 | Rotation       | `rotate-certs`, `rotate-ssh-key`                                        |
 | Inventory      | `hardware-inventory`, `migrate-networkd`                                |
 | Benchmarks     | `bench`, `bench-rados`                                                  |
@@ -530,22 +629,26 @@ wrong cluster. Instead each ceph ops task falls back to sietch only when
 CEPH_ENV="${CEPH_ENV:-inventories/staging-austin/sietch/inventory.ini}"
 
 # operate on another cluster by exporting once per shell, or inline:
-export CEPH_ENV=inventories/staging-austin/sietch/inventory.ini
+export CEPH_ENV=inventories/prod-htz-fsn1/spice/inventory.ini
 CEPH_ENV=inventories/<partition>-<region>/<cluster>/inventory.ini mise run status
 ```
+
+The fallback is why spice work starts with an export. A task run without
+`CEPH_ENV` set does not fail -- it quietly targets sietch, which is the whole
+reason the value is not in `[env]`.
 
 `TF_STACK_DIR` works the same way for the root `tf:*` tasks -- it defaults to
 `tf/deployment/staging/austin/ceph` and is overridden per-invocation:
 
 ```bash
-TF_STACK_DIR=tf/deployment/<partition>/<region>/ceph mise run tf:plan
+TF_STACK_DIR=tf/deployment/prod/htz-fsn1/ceph mise run tf:plan
 ```
 
 ---
 
 ## 8. Wrapper scripts (the glue layer)
 
-Three scripts under `ansible/ceph/scripts/` sit between mise and the
+The scripts under `ansible/ceph/scripts/` sit between mise and the
 underlying CLIs. They exist to keep secrets out of `argv`, fail closed
 when 1P is unreachable, and give better error messages than the raw tools.
 
@@ -554,6 +657,7 @@ when 1P is unreachable, and give better error messages than the raw tools.
 | `ansible-play.sh`       | Render secrets via `op inject -f` to a `mktemp`'d file (chmod 600, trap-cleaned), then run `ansible-playbook --extra-vars @<tmpfile>` |
 | `install-ssh-keys.sh`   | Idempotent `op read` -> `~/.ssh/id_ed25519_<cluster>` installer; refuses overwrite on fingerprint mismatch                                |
 | `preflight.sh`          | Verifies TF artifacts present, 1P session live, SSH reachable, Python on targets -- surfaced via `mise run preflight`                    |
+| `render-inventories.sh` | Writes the TF `render` output into this checkout (`<partition> <region>`, defaulting to `staging austin`); read-only against state        |
 
 Per-script reference (synopsis, args, env, exit codes, examples):
 [docs/scripts.md](scripts.md).
@@ -572,6 +676,7 @@ sequenceDiagram
     participant ONEP as 1Password
     participant TG as terragrunt / tofu
     participant S3 as OVH S3
+    participant REND as render-inventories.sh
     participant REPO as Repo (inventories/)
 
     OP->>MISE: mise run tf:apply
@@ -583,7 +688,9 @@ sequenceDiagram
     S3-->>TG: current state
     TG->>TG: plan + apply
     TG->>S3: write updated tfstate
-    TG->>REPO: render inventory.ini,<br/>secrets.yml.tpl, ...
+    OP->>REND: render-inventories.sh <partition> <region>
+    REND->>TG: read the render output
+    REND->>REPO: write inventory.ini,<br/>secrets.yml.tpl, ...
 ```
 
 ### 9.2 `mise run deploy` -- full Ceph deploy
@@ -610,7 +717,7 @@ sequenceDiagram
     OPCLI->>TMP: write resolved YAML
     WRAP->>ANS: run --extra-vars @TMP
     loop phases 1..6
-        ANS->>NODES: SSH ansible-iac@<bond_ip><br/>via id_ed25519_<cluster>
+        ANS->>NODES: SSH <ssh user>@<bond_ip><br/>via id_ed25519_<cluster>
     end
     Note over WRAP,TMP: tmpfile rm'd on exit (trap)
 ```
@@ -676,9 +783,9 @@ sequenceDiagram
 
 ```mermaid
 flowchart TB
-    SIETCH["Sietch prep:<br/>provision_host/disks.yml partitions SSDs<br/>then ceph_deploy/lvm-setup.yml<br/><i>creates VG + db-slot LVs on each SSD's partition 5</i>"]
-    NVMERAID["NVMe-RAID prep:<br/>installimage post-install.sh<br/><i>NVMe RAID-1 -> vg0 -> db-slot0..13 + ssd-osd LVs</i>"]
-    SPEC["ceph_deploy/osds.yml renders<br/>templates/osd-spec.yml.j2 -> /etc/ceph/osd-spec.yml<br/><i>one document per host; paths from host_vars</i>"]
+    SIETCH["sietch prep:<br/>provision_host/disks.yml partitions SSDs<br/>then ceph_deploy/lvm-setup.yml<br/><i>creates VG + db-slot LVs on each SSD's partition 5</i>"]
+    NVMERAID["spice prep:<br/>installimage builds NVMe RAID-1 -> vg0<br/>then ceph_deploy/lvm-setup.yml<br/><i>carves 14x 128G db-slotN + one ssd-osd LV</i>"]
+    SPEC["ceph_deploy/osds.yml renders<br/>templates/osd-spec.yml.j2 -> /etc/ceph/osd-spec.yml<br/><i>one document per host; paths from host_vars/group_vars</i>"]
     APPLY["ceph orch apply osd -i /etc/ceph/osd-spec.yml<br/><i>cephadm: discover disks, LUKS-format, LVM, deploy daemons</i>"]
     POLL["Wait for cephadm to provision<br/><i>poll num_osds until expected count reached</i>"]
     UP["Wait for OSDs up<br/><i>poll num_up_osds == num_osds</i>"]
@@ -712,16 +819,24 @@ auto-discovers and claims an OS or block.db partition.
 have unique SAS prefixes per chassis, so a shared spec doesn't work)
 with two shape branches:
 
-- **Sietch** (`sas_path_prefix` defined): data path =
+- **sietch-shape** (`sas_path_prefix` defined): data path =
   `/dev/disk/by-path/{{ sas_path_prefix }}-{{ path_phy }}-lun-0`; SSD
   OSD = partition on the SAS-attached SSD via `path_phy + partition`.
-- **NVMe-RAID shape** (`sas_path_prefix` undefined): data path =
+- **NVMe-RAID shape** (`sas_path_prefix` undefined -- spice): data path =
   `/dev/disk/by-path/{{ path_phy }}` (operator authors the full PCI-ATA
-  identifier in host_vars); SSD OSD = LV via the `lv` field
-  (`/dev/{{ lv }}`).
+  identifier); SSD OSD = LV via the `lv` field (`/dev/{{ lv }}`).
 
 `db_devices.paths` is always `/dev/{{ db }}` -- both shapes use LVs for
 block.db, no composition needed.
+
+The `{path_phy, db}` pairing in the inventory is presentational, not binding.
+A cephadm OSD spec has no per-disk block.db field, so the template emits
+`data_devices.paths` and `db_devices.paths` as two independent arrays and
+ceph-volume pairs them in whatever order it processes them -- on spice it
+walked the two lists in opposite directions, so disk N landed on `db-slot13-N`.
+Harmless, because all 14 slots are identical 128G LVs on the same mirror; only
+their count and size matter. Resolve a real pairing with
+`cephadm ceph-volume lvm list`, never from the inventory.
 
 ### Idempotency
 
@@ -768,7 +883,9 @@ cephadm's bootstrap automatically deploys:
 1. Enable the `prometheus` MGR module (if not already enabled)
 2. Wait for all five monitoring service types to report `running > 0`
 3. Set dashboard integration URLs for Prometheus, Alertmanager, Grafana
-   (using the bootstrap node's `bond_ip`)
+   (using the bootstrap node's `ceph_service_ip` -- which falls back to
+   `bond_ip` on a flat cluster like sietch, but on spice is the fabric address
+   `10.40.20.<host_index>`, so the dashboard never advertises the 1G WAN)
 4. Set Grafana admin credentials from the op-injected
    `vault_grafana_admin_password`
 5. Disable Grafana SSL cert verification in dashboard (self-signed cert)
@@ -779,6 +896,10 @@ if fewer than 10 rule groups are loaded (expects 16+).
 ---
 
 ## 12. Provision host internals
+
+This is the sietch path only. spice never runs `provision_host` -- Hetzner
+installimage owns partitioning there, and `reprovision_hetzner` drives it
+through the Robot API (rescue -> reset -> installimage -> verify).
 
 ### Ten-phase flow
 
@@ -818,9 +939,8 @@ This prevents:
 - Overwriting the marker with a stale `provisioned_at` timestamp
 
 The marker filename (`ceph-provisioned.json`) is project-scoped, not
-cluster-scoped -- every Ceph cluster (sietch, future) writes the
-same filename. The marker's *contents* identify which cluster + host the
-machine belongs to.
+cluster-scoped -- every cluster provisioned this way writes the same filename.
+The marker's *contents* identify which cluster + host the machine belongs to.
 
 ### Block/rescue cleanup
 
@@ -850,12 +970,13 @@ state.
   shares the terragrunt root config and S3 backend, with its own state key
   (`yucca/<partition>/<region>/talos/terraform.tfstate`). The staging/austin
   talos stack is in the tree.
+- **TF-managed `onepassword_item` resources** -- each ceph stack's
+  `secrets.tf` owns the generated password items, using the partition's write
+  SA. See "What TF does not manage" in section 4 for the categories that stay
+  out.
 
 ### Roadmap
 
-- **TF-managed `onepassword_item` resources** -- re-enable the dormant
-  resources in `secrets.tf.disabled` once the dedicated ceph service account
-  lands, so 1P items are TF-owned rather than created by hand.
 - **OSD LUKS keys in 1P** -- store dm-crypt keys for DR. Deferred until the
   hybrid is stable.
 
@@ -865,6 +986,7 @@ state.
 
 | Topic                              | Doc                                                                            |
 |------------------------------------|--------------------------------------------------------------------------------|
+| Per-cluster hosts, SSH, vaults     | [docs/cluster-profiles.md](cluster-profiles.md)                                |
 | TF/Terragrunt detail               | [`tf/README.md`](../../../tf/README.md)                                        |
 | Wrapper script reference           | [docs/scripts.md](scripts.md)                                                  |
 | Secrets catalog + rotation         | [docs/secrets.md](secrets.md)                                                  |

--- a/ansible/ceph/docs/architecture.md
+++ b/ansible/ceph/docs/architecture.md
@@ -785,16 +785,22 @@ sequenceDiagram
 flowchart TB
     SIETCH["sietch prep:<br/>provision_host/disks.yml partitions SSDs<br/>then ceph_deploy/lvm-setup.yml<br/><i>creates VG + db-slot LVs on each SSD's partition 5</i>"]
     NVMERAID["spice prep:<br/>installimage builds NVMe RAID-1 -> vg0<br/>then ceph_deploy/lvm-setup.yml<br/><i>carves 14x 128G db-slotN + one ssd-osd LV</i>"]
-    SPEC["ceph_deploy/osds.yml renders<br/>templates/osd-spec.yml.j2 -> /etc/ceph/osd-spec.yml<br/><i>one document per host; paths from host_vars/group_vars</i>"]
+    SPEC["ceph_deploy/osds.yml renders<br/>templates/osd-spec.yml.j2 -> /etc/ceph/osd-spec.yml<br/><i>one document per host TYPE; paths from host_vars/group_vars</i>"]
     APPLY["ceph orch apply osd -i /etc/ceph/osd-spec.yml<br/><i>cephadm: discover disks, LUKS-format, LVM, deploy daemons</i>"]
+    WINDOW{"spec unmanaged?"}
+    OPEN["Open provisioning window<br/><i>ceph orch set-managed, gated on<br/>ceph_osd_allow_spec_provisioning</i>"]
     POLL["Wait for cephadm to provision<br/><i>poll num_osds until expected count reached</i>"]
     UP["Wait for OSDs up<br/><i>poll num_up_osds == num_osds</i>"]
+    CLOSE["Close window (always)<br/><i>ceph orch set-unmanaged</i>"]
     UNSET["Defensive: ceph osd unset noin<br/><i>idempotent -- clears stale flag from prior runs</i>"]
-    REWEIGHT["Safety net: fix any reweight=0 OSDs"]
+    REWEIGHT["Safety net: reweight=0 OSDs<br/><i>skips the removal queue; acts only if noin set</i>"]
 
     SIETCH --> SPEC
     NVMERAID --> SPEC
-    SPEC --> APPLY --> POLL --> UP --> UNSET --> REWEIGHT
+    SPEC --> APPLY --> WINDOW
+    WINDOW -->|no, managed| POLL
+    WINDOW -->|yes| OPEN --> POLL
+    POLL --> UP --> CLOSE --> UNSET --> REWEIGHT
 ```
 
 ### Service-spec model, not per-disk loops
@@ -815,9 +821,16 @@ auto-discovers and claims an OS or block.db partition.
 
 ### Hardware-shape independence in the template
 
-`templates/osd-spec.yml.j2` renders one document per host (sietch nodes
-have unique SAS prefixes per chassis, so a shared spec doesn't work)
-with two shape branches:
+`templates/osd-spec.yml.j2` renders one document per host **type**, with two
+shape branches. Hosts whose rendered device lists are identical collapse into
+a single multi-host spec; hosts that differ get their own. sietch nodes have a
+unique SAS prefix per chassis so none of them collapse, which is why the
+template used to emit strictly one document per host. spice is uniform across
+47 of 48 nodes and renders 3 documents instead of 96. Collapsing is opt-in per
+cluster (`ceph_osd_spec_group_by_layout`) because a changed `service_id` does
+not rename a service, it creates a new one and orphans the old.
+
+The two branches are:
 
 - **sietch-shape** (`sas_path_prefix` defined): data path =
   `/dev/disk/by-path/{{ sas_path_prefix }}-{{ path_phy }}-lun-0`; SSD
@@ -841,8 +854,23 @@ their count and size matter. Resolve a real pairing with
 ### Idempotency
 
 `ceph orch apply osd` is idempotent -- re-applying the same spec is a
-no-op when deployed OSDs match. New disks (populating an empty bay
-later, future expansion) are picked up automatically on the next apply.
+no-op when deployed OSDs match.
+
+Whether a spec keeps acting after that apply depends on
+`ceph_osd_spec_unmanaged`. Managed (sietch, the default) it stays in cephadm's
+reconcile loop and new disks -- populating an empty bay, future expansion --
+are picked up automatically. Unmanaged (spice) the spec is registered and
+complete but inert: cephadm will not create OSDs from it, and provisioning
+needs the explicit window in `osds.yml`.
+
+That is not a cosmetic preference. cephadm reconciles every managed spec on
+every serve-loop pass, and each pass costs a `ceph-volume lvm list` plus a
+`raw list` on each matching host. At spice's size that pinned one loop
+iteration at ~35 minutes, so every orchestrator action inherited up to 35
+minutes of latency; unmanaged, the loop runs in seconds. The tradeoff is that
+a replaced disk is no longer rebuilt for you, which
+[docs/runbooks/replace-disk.md](runbooks/replace-disk.md) wants anyway -- see
+Ceph tracker #68436 for why letting cephadm rebuild it is the riskier path.
 Existing OSDs are not destroyed by a spec apply -- removal requires
 explicit `ceph orch osd rm`.
 

--- a/ansible/ceph/docs/architecture.md
+++ b/ansible/ceph/docs/architecture.md
@@ -821,14 +821,20 @@ auto-discovers and claims an OS or block.db partition.
 
 ### Hardware-shape independence in the template
 
-`templates/osd-spec.yml.j2` renders one document per host **type**, with two
-shape branches. Hosts whose rendered device lists are identical collapse into
-a single multi-host spec; hosts that differ get their own. sietch nodes have a
-unique SAS prefix per chassis so none of them collapse, which is why the
-template used to emit strictly one document per host. spice is uniform across
-47 of 48 nodes and renders 3 documents instead of 96. Collapsing is opt-in per
-cluster (`ceph_osd_spec_group_by_layout`) because a changed `service_id` does
-not rename a service, it creates a new one and orphans the old.
+`templates/osd-spec.yml.j2` renders one document per host, with two shape
+branches. `ceph_osd_spec_group_by_layout` optionally collapses hosts whose
+rendered device lists are identical into a single multi-host spec -- the shape
+upstream recommends, and worth having for a large uniform fleet.
+
+Both live clusters leave it off. sietch nodes have a unique SAS prefix per
+chassis, so none of them would collapse. spice would collapse 47 of its 48
+nodes to 3 documents instead of 96, but cannot: an OSD's owning service is
+written into its LVM tags at creation (`ceph.osdspec_affinity`) rather than
+derived from the spec, so applying collapsed specs leaves all 720 existing
+daemons on the old names, and `ceph orch ls` fabricates a service for any
+daemon whose spec is missing. Collapsing an already-built cluster therefore
+adds specs without moving anything. Use the flag on a new cluster, where OSDs
+are tagged with the collapsed names from the start.
 
 The two branches are:
 

--- a/ansible/ceph/docs/cluster-profiles.md
+++ b/ansible/ceph/docs/cluster-profiles.md
@@ -59,16 +59,20 @@ not in Austin. Sequence spice work per node unless you have a reason not to.
 
 ## Inventory files
 
-sietch's `inventory.ini` is rendered by Terraform (`ceph-cluster` module,
-`rendered_files` output) and is not committed; only `group_vars/` and
-`host_vars/` are in the repo. Render it before running a playbook against
-sietch:
+Neither cluster's `inventory.ini` is committed. `ansible/ceph/.gitignore`
+excludes `inventory.ini`, `inventory-destroy.ini`, `inventory-provision.ini`,
+and `secrets.yml.tpl` for every cluster; only `group_vars/` and `host_vars/`
+are in the repo. Render before running a playbook:
 
 ```bash
-ansible/ceph/scripts/render-inventories.sh staging austin
+ansible/ceph/scripts/render-inventories.sh staging austin    # sietch
+ansible/ceph/scripts/render-inventories.sh prod htz-fsn1     # spice
 ```
 
 The script is read-only against state, but it reads the stack's `render`
 output, so a `terragrunt apply` must have run for that output to reflect the
-current cluster spec. spice's `inventory.ini` is committed; the same script
-renders it with `prod htz-fsn1`.
+current cluster spec. A rendered file that predates a `clusters.auto.tfvars`
+change is stale in a way nothing warns you about -- a `secrets.yml.tpl` missing
+a `vault_*` entry that `group_vars` references fails the play at runtime with
+`AnsibleUndefinedVariable`, not at render time. Re-render after any cluster
+spec change lands.

--- a/ansible/ceph/docs/hardware.md
+++ b/ansible/ceph/docs/hardware.md
@@ -1,30 +1,50 @@
 # Hardware Reference
 
-Audience: Ops, procurement, capacity planning. Per-node hardware facts that
-differ across clusters live in
-`ansible/ceph/inventories/<partition>-<region>/<cluster>/host_vars/`
-(bond_ip, SAS path prefix, SSD PHY positions, HDD-to-block.db mappings) --
-those files are committed and are authoritative for physical topology.
+Audience: Ops, procurement, capacity planning. Covers both live clusters:
+**sietch** (staging, Austin, 3 nodes) and **spice** (production, Hetzner
+FSN1-DC24, 48 nodes).
 
-For where this fits in the tool mesh, see [architecture.md](architecture.md).
+Per-node hardware facts live in
+`ansible/ceph/inventories/<partition>-<region>/<cluster>/host_vars/` (bond_ip,
+host_index, SAS path prefix, SSD PHY positions, HDD-to-block.db mappings) --
+those files are committed and are authoritative for physical topology. On
+spice the uniform parts moved up to `group_vars/all/vars.yml`; see the
+host_vars schema section below.
+
+For where this fits in the tool mesh, see [architecture.md](architecture.md);
+for SSH targets, vaults, and per-cluster procedure differences, see
+[cluster-profiles.md](cluster-profiles.md).
 
 ## Network topology
 
-Clusters use a **single-network** design today -- public and cluster
-traffic share one subnet. Production will separate them; see
-[security-model.md](security-model.md) for the threat-model implications.
+The two clusters differ here more than anywhere else. sietch is flat -- public
+and cluster traffic share one subnet. spice splits them across VLANs on a
+bonded 25G fabric. See [security-model.md](security-model.md) for the
+threat-model implications of each.
 
-| Cluster  | Subnet            | Connection                                                             |
-|----------|-------------------|------------------------------------------------------------------------|
-| sietch   | `10.10.10.0/24`   | 2x 10GbE bonded active-backup (eno1 + eno2) per node; private switch   |
+| Cluster  | Networks                                                                                                          | Connection                                                                                     |
+|----------|-------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| sietch   | public = cluster = `10.10.10.0/24`                                                                                | 2x 25GbE Mellanox ConnectX bonded active-backup (eno1np0 + eno2np1) per node; private switch    |
+| spice    | public `10.40.20.0/23` (VLAN 120), cluster `10.40.22.0/23` (VLAN 122, MTU 9000), host-mgmt `10.40.24.0/24` (VLAN 124) | 2x 25GbE Intel E810 in an LACP bond to the leaf, VLAN sub-interfaces; plus a separate 1G WAN     |
 
-A Hetzner NVMe-RAID host attaches over a public /32 with a single NIC
-and direct SSH (no bond, no ProxyJump).
+On spice the 1G WAN (`enp197s0`, igb) stays on ifupdown exactly as installimage
+configured it and holds the default route; only the bond and its VLANs are
+networkd-managed (`networkd_replace_ifupdown: false`). That split is deliberate:
+the WAN is the reachability link, so a networkd error on the fabric cannot cost
+access to the node. Ansible connects over the WAN address; Ceph daemons never
+bind it. Per-host fabric addresses are `10.40.2x.<host_index>`, derived in
+`group_vars` rather than written out 48 times.
 
-Per-node connection IPs (`bond_ip`) are declared in
-`tf/deployment/staging/austin/ceph/clusters.auto.tfvars` and rendered by TF into the
-cluster's `inventory.ini`. They're also mirrored into `host_vars/` for use
-by roles that need the IP as a variable (e.g., cephadm public-network
+Jumbo frames are enabled on VLAN 122 only. That path is closed, homogeneous,
+and entirely ours, so the packet/interrupt savings on replication and recovery
+actually land. VLAN 120 carries RGW traffic to heterogeneous S3 clients and the
+~1400-MTU NetBird overlay, where a jumbo mismatch is a partial blackhole (small
+ops fine, large PUT/GET hang) for near-zero gain.
+
+Per-node connection IPs (`bond_ip`) are declared in the cluster's
+`tf/deployment/<partition>/<region>/ceph/clusters.auto.tfvars` and rendered by
+TF into the cluster's `inventory.ini`. They're also mirrored into `host_vars/`
+for use by roles that need the IP as a variable (e.g., cephadm public-network
 resolution, dashboard URL construction).
 
 ## sietch -- Dell R730xd (Austin)
@@ -39,7 +59,7 @@ resolution, dashboard URL construction).
 | SSD OSDs | Partition 6 on each boot SSD (colocated, no separate block.db) |
 | Block.db | 6x 240GB LVs per SSD (partition 5, LVM VG) |
 | HBA | Broadcom/LSI SAS3008 IT mode (mpt3sas, no RAID) |
-| Network | 2x 10GbE bonded active-backup (eno1 + eno2) |
+| Network | 2x 25GbE Mellanox ConnectX bonded active-backup (eno1np0 + eno2np1) |
 | Boot | UEFI, dual ESP (one per SSD, rsync-mirrored) |
 | OS | Debian 12 Bookworm (debootstrap provisioned) |
 | Provisioning | Live image -> `provision.yml` -> debootstrap |
@@ -55,14 +75,32 @@ resolution, dashboard URL construction).
 | 5 | ~1.4 TB | Ceph block.db LVs (LVM VG) |
 | 6 | ~2 TB | SSD OSD data (ceph-volume) |
 
-## Hetzner NVMe-RAID shape (e.g. SX295)
+## spice -- Hetzner SX295 (FSN1-DC24, Falkenstein)
 
-The roles also support a Hetzner-style single-box shape for future
-hosting-provider clusters: NVMe boot drives in installimage RAID-1
-(`vg0`), HDD OSDs over onboard SATA with per-HDD block.db LVs on the NVMe
-VG, and a single LV-backed SSD OSD carved from the NVMe remainder.
-Provisioning is rescue mode -> `installimage/autosetup` + `post-install.sh`,
-booting Debian 12 Bookworm.
+48 nodes, 15 OSDs each: 720 OSDs total (672 HDD + 48 NVMe-backed). That is an
+OSD count, not a disk count -- the physical disks are 672 HDD + 96 NVMe = 768.
+Confusing the two badly overstates spindle count.
+
+| Component | Spec |
+|-----------|------|
+| Chassis | Hetzner SX295, 48 nodes across 4 racks in FSN1-DC24 |
+| HDD OSDs | 14x 22TB SATA per node, on 3 AHCI controllers (`pci-0000:45:00.0` x8, `:46:00.0` x2, `:87:00.0` x4), addressed by-path |
+| Boot NVMe | 2x 7.68TB NVMe in mdraid-1 -> `vg0` (`nvme0n1` + `nvme1n1`) |
+| vg0 OS LVs | swap 32G, `/` 100G, `/var` 200G, `/var/log` 50G; `/boot` is a 1G ext4 partition outside the VG |
+| Block.db | 14x 128G `db-slotN` LVs on `vg0` |
+| SSD OSD | one `ssd-osd` LV, `vg0` free minus a 512 GiB reserve |
+| Network | 2x 25GbE Intel E810 (`enp193s0f0/f1`, ice) in an LACP bond; 1G WAN `enp197s0` (igb) |
+| Boot | BIOS (`reprovision_boot_mode: bios`), grub |
+| OS | Debian 12 Bookworm (Hetzner installimage) |
+| Provisioning | Rescue mode -> `installimage -a -c /autosetup -x post-install.sh` (`reprovision_hetzner` role) |
+| Remote hands | No IPMI, one KVM for 48 nodes -- physical work is a Hetzner ticket, and drives are identified by **serial**, not bay |
+
+installimage builds the mdraid-1, `vg0`, and the OS LVs. It does not create the
+`db-slot` or `ssd-osd` LVs: those are carved at converge by
+`ceph_deploy/lvm-setup.yml`'s NVMe-RAID branch. The `-x post-install.sh` chroot
+step is deliberately limited to seeding root and `ansible-iac` SSH keys -- no
+apt, no `lvcreate` -- because those are the steps that broke installimage on
+the SX295 precedent.
 
 > **Why Bookworm and not Trixie:** upstream Ceph Tentacle's Debian
 > repository at `download.ceph.com/debian-tentacle/dists/` publishes only
@@ -70,11 +108,16 @@ booting Debian 12 Bookworm.
 > autosetup `IMAGE` line MUST select a Bookworm tarball until upstream
 > ships Trixie packages.
 
+The E810 needs the `firmware-misc-nonfree` DDP package. Without it the NIC boots
+into Safe Mode, whose crippled classifier drops LACP and LLDP control frames, so
+the bond never aggregates. `baseline` installs it and reboots once to load it.
+
 ## host_vars schema by hardware shape
 
 Storage topologies differ across hardware shapes, and so does the
 `host_vars/<host>.yml` schema. When adding a new cluster, pick the schema
-that matches the hardware -- don't copy an existing cluster's.
+that matches the hardware -- don't copy an existing cluster's. sietch uses the
+first schema, spice the second.
 
 ### sietch-shape (SAS expander + dual-SSD-VG)
 
@@ -116,9 +159,26 @@ ceph_ssd_osds:
 
 The role uses `path_phy` directly as the by-path identifier (no composition
 needed -- operator authors the full string). For SSD OSDs, `lv` field is
-used (`/dev/<lv>`) instead of `path_phy + partition`. `lvm-setup.yml` is
-**skipped** on this shape (gated `when: sas_path_prefix is defined`) --
-LVM is owned by the Hetzner installimage post-install script.
+used (`/dev/<lv>`) instead of `path_phy + partition`.
+
+`lvm-setup.yml` branches rather than skipping: `sas_path_prefix is undefined`
+selects the NVMe-RAID path, which asserts `vg0` exists (installimage made it)
+and then creates the `db-slotN` LVs plus the `ssd-osd` LV from the remainder
+minus `ceph_ssd_osd_reserve_gib`. It never shrinks an existing LV -- truncating
+a live block.db corrupts the OSD.
+
+On spice these keys live in `group_vars` rather than in 48 host_vars files,
+because the by-path map is identical on 47 of the 48 nodes;
+`spice-ceph-miguel` overrides `ceph_hdd_osds` in its own host_vars (one HDD on
+a different AHCI controller). The per-node files carry only `bond_ip`,
+`host_index`, `hetzner_server_number`, and the `mon` flag. Prefer that split
+whenever a fleet is uniform: 48 near-identical files would have buried the
+one-node exception.
+
+The `{path_phy, db}` pairing is presentational either way. A cephadm OSD spec
+has no per-disk block.db field, so the template emits two independent path
+arrays and ceph-volume pairs them in its own order. Resolve a real pairing with
+`cephadm ceph-volume lvm list`, never from the inventory.
 
 ### Decision rule for new clusters
 

--- a/ansible/ceph/docs/patterns.md
+++ b/ansible/ceph/docs/patterns.md
@@ -318,8 +318,8 @@ template's Jinja conditional, not the role logic.
 - `templates/rgw-spec.yaml.j2` + `tasks/rgw.yml`'s `ceph orch apply -i`
   task -- RGW daemon placement spec.
 - `templates/osd-spec.yml.j2` + `tasks/osds.yml`'s
-  `ceph orch apply osd -i` task -- OSD service spec; per-host documents
-  in a multi-doc YAML; Jinja conditional handles sietch-shape vs
+  `ceph orch apply osd -i` task -- OSD service spec; one document per host
+  *type* in a multi-doc YAML; Jinja conditional handles sietch-shape vs
   NVMe-RAID-shape path composition.
 
 **Template skeleton:**
@@ -336,6 +336,17 @@ spec:
   <kind-specific fields>
 {% endfor %}
 ```
+
+One document per host is the simple form, and it is what `rgw-spec.yaml.j2`
+still does. Watch it at scale: cephadm reconciles every managed spec on every
+serve-loop pass, so N specs across N hosts makes the loop cost scale with the
+fleet. If the hosts are uniform, bucket them by their rendered field values and
+emit one document per bucket with a multi-host `placement.hosts` -- see
+`osd-spec.yml.j2`, which collapses spice's 96 documents to 3. Keep single-host
+buckets on the original `<hostname>-<role>` `service_id`: changing a
+`service_id` does not rename a service, it creates a new one and orphans the
+old, so collapsing an already-deployed cluster is a migration and belongs
+behind a flag.
 
 **Apply pattern in tasks/*.yml:**
 

--- a/ansible/ceph/docs/patterns.md
+++ b/ansible/ceph/docs/patterns.md
@@ -338,15 +338,18 @@ spec:
 ```
 
 One document per host is the simple form, and it is what `rgw-spec.yaml.j2`
-still does. Watch it at scale: cephadm reconciles every managed spec on every
+does. Watch it at scale: cephadm reconciles every managed spec on every
 serve-loop pass, so N specs across N hosts makes the loop cost scale with the
 fleet. If the hosts are uniform, bucket them by their rendered field values and
-emit one document per bucket with a multi-host `placement.hosts` -- see
-`osd-spec.yml.j2`, which collapses spice's 96 documents to 3. Keep single-host
-buckets on the original `<hostname>-<role>` `service_id`: changing a
-`service_id` does not rename a service, it creates a new one and orphans the
-old, so collapsing an already-deployed cluster is a migration and belongs
-behind a flag.
+emit one document per bucket with a multi-host `placement.hosts` --
+`osd-spec.yml.j2` does this behind `ceph_osd_spec_group_by_layout`.
+
+Decide the bucketing when the cluster is built, not after. A daemon's owning
+service is fixed at creation (for OSDs, in the LVM tag
+`ceph.osdspec_affinity`), and `ceph orch ls` fabricates a service for any
+daemon whose spec has gone missing, so re-bucketing a live cluster adds specs
+without moving daemons onto them. Where a cluster is already deployed, the
+mitigation for loop cost is `unmanaged`, not re-bucketing.
 
 **Apply pattern in tasks/*.yml:**
 

--- a/ansible/ceph/docs/runbooks/replace-disk.md
+++ b/ansible/ceph/docs/runbooks/replace-disk.md
@@ -206,6 +206,10 @@ scripts/ansible-play.sh deploy-ceph.yml \
   --tags osds --limit sietch-ceph-<host>,sietch-ceph-laurel
 ```
 
+This works on sietch because its OSD specs are managed, so cephadm acts on the
+re-applied spec. It does **not** carry over to spice, whose specs are
+deliberately unmanaged -- see the spice section below.
+
 ## 7. Verify
 
 ### Check the new OSD is up
@@ -369,19 +373,23 @@ cephadm ceph-volume \
 ceph cephadm osd activate <hostname>
 ```
 
-Re-applying the spec (`ceph orch apply osd -i /etc/ceph/osd-spec.yml`) also
-works when exactly one data path and one db slot are free, because then only
-one pairing is possible. With more than one of either free, cephadm chooses,
-and it may not choose what you expect.
+**Do not rebuild a replaced disk by re-managing the OSD spec.** spice's specs
+carry `unmanaged: true` (`ceph_osd_spec_unmanaged` in its group_vars) precisely
+so cephadm cannot act on a blank disk on its own, and `ceph orch set-managed`
+undoes that. Upstream [tracker #68436][t68436] is this exact sequence: with the
+spec managed after a hardware swap the drivegroup preview fails, and cephadm
+recreates the OSD **without the BlueStore db setup**. On spice that is a silent
+downgrade -- block.db lands colocated on the 22TB HDD instead of the `vg0`
+db-slot LV, and the OSD comes up healthy-looking with the write latency of a
+spinning disk in front of every metadata operation. The bug is open against
+18.2.4 and the cluster runs 20.2.2.
 
-The Ansible equivalent, if you would rather not hand-run ceph-volume:
+The same applies to `deploy-ceph.yml --tags osds`. It re-renders and re-applies
+the spec, which stays unmanaged, so it will not create the OSD for you; the
+`ceph_osd_allow_spec_provisioning` window that would let it is for initial
+cluster provisioning only. Use `ceph-volume` above.
 
-```bash
-scripts/ansible-play.sh deploy-ceph.yml \
-  --tags osds --limit spice-ceph-<host>,spice-ceph-adelia
-```
-
-`spice-ceph-adelia` is the spice bootstrap node and must be in `--limit`.
+[t68436]: https://tracker.ceph.com/issues/68436
 
 ### 7. Verify
 

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -183,6 +183,34 @@ ceph_db_lvs_per_node: 14
 ceph_ssd_osd_lv: ssd-osd          # NVMe-backed OSD LV (fast replicated pool)
 ceph_ssd_osd_reserve_gib: 512     # vg0 free left unallocated for headroom/expansion
 
+# Keep the OSD specs registered but inert. cephadm reconciles every MANAGED spec
+# on every serve-loop pass, and each pass costs a ceph-volume lvm list + raw list
+# per host; at spice's size that pinned one full loop iteration at ~35 minutes
+# (measured 2026-07-28: nine consecutive intervals, 33m57s to 35m43s), so every
+# orchestrator action -- an OSD drain, a daemon restart -- inherited up to 35
+# minutes of latency before cephadm even looked at it. Unmanaged specs are
+# skipped, and upstream sanctions this for drivegroups ("use the unmanaged
+# parameter" to disable automatic creation on available devices).
+#
+# The specs stay complete and applied, so they remain the record of intent; they
+# just do not act on their own. Creating OSDs from them is gated behind
+# ceph_osd_allow_spec_provisioning (osds.yml), which is for INITIAL provisioning
+# only. Rebuilding a replaced disk goes through ceph-volume by hand -- see
+# docs/runbooks/replace-disk.md. Ceph tracker #68436: re-managing a spec after a
+# disk swap can recreate the OSD without its block.db, which on spice silently
+# colocates block.db on the 22TB HDD instead of the vg0 db-slot LV.
+ceph_osd_spec_unmanaged: true
+
+# Collapse the per-host OSD specs into one per host TYPE, which is the shape
+# upstream expects ("typically you will have a single spec for each type of
+# host"). spice renders 3 instead of 48x2: one for the 47 nodes sharing an
+# identical by-path map, one for miguel (whose 87:00.0-ata-4 disk sits on
+# 46:00.0 instead), one for the ssd-osd LV common to all 48. Off by default so
+# clusters that have per-host specs deployed are not silently renamed -- a
+# changed service_id creates a new service and orphans the old one, so turning
+# this on is a migration (apply, then `ceph orch rm` the superseded services).
+ceph_osd_spec_group_by_layout: true
+
 # OSD device map (by-path, consumed by ceph_deploy/osd-spec.yml.j2, NVMe-RAID shape:
 # no sas_path_prefix -> data path is /dev/disk/by-path/<path_phy>, db is /dev/<db>).
 # The 14x 22TB SATA HDDs sit on 3 AHCI controllers; the by-path layout is IDENTICAL

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -3,9 +3,9 @@
 # Committed. Hand-maintained. Adapted from the painbox (SX295/Hetzner) precedent
 # with the network reshaped onto the bonded-25G fabric VLANs.
 #
-# NOTE: sections marked DRAFT are ceph data-protection / RGW decisions that must
-# be reviewed before `mise run deploy` against 48 nodes. They do NOT affect the
-# OS-install milestone (installimage), only the later cephadm convergence.
+# The cluster is deployed and serving production traffic. Every value here lands
+# on 48 live nodes, so converge one node at a time (--limit) and watch cluster
+# health between batches unless you have a specific reason not to.
 
 # === Naming ===
 cluster_name: spice
@@ -80,7 +80,7 @@ fabric_public_vlan: 120
 fabric_private_vlan: 122
 fabric_mgmt_vlan: 124
 dns_server: 185.12.64.1            # Hetzner recursive (reachable via WAN default route)
-# Time sync: Hetzner's own NTP (low-latency from FSN1, consistent across all 47).
+# Time sync: Hetzner's own NTP (low-latency from FSN1, consistent across all 48).
 # Ceph mon quorum is skew-sensitive; pin the source rather than the distro pool.
 chrony_ntp_servers:
   - ntp1.hetzner.de
@@ -159,12 +159,13 @@ ceph_rgw_s3_user_secret_key: "{{ vault_s3_restic_secret_key }}"
 
 # === Reprovision (installimage; reprovision_hetzner role) ===
 # Most knobs live in roles/reprovision_hetzner/defaults; override the operator-
-# facing ones here. VERIFY image name + boot_mode on node 1 (mise run reprovision
-# -- --limit spice-ceph-adelia -e confirm_wipe=true -e reprovision_mode=inspect).
+# facing ones here. These were verified against the fleet during the build-out;
+# re-inspect before trusting them on a different batch of hardware:
+#   mise run reprovision -- --limit <host> -e confirm_wipe=true -e reprovision_mode=inspect
 reprovision_boot_mode: bios          # SX295 painbox precedent = BIOS (verified)
 reprovision_expect_nvme: 2
 reprovision_expect_sata: 14
-# reprovision_image: override only if node-1 inspect shows a different image path/name.
+# reprovision_image: override only if an inspect run shows a different image path/name.
 
 # === Storage (SX295: 2x NVMe RAID-1 OS + 14x SATA HDD per node) ===
 # block.db LVs carved from the NVMe RAID-1 vg0 at converge by ceph_deploy's
@@ -184,7 +185,7 @@ ceph_ssd_osd_reserve_gib: 512     # vg0 free left unallocated for headroom/expan
 
 # OSD device map (by-path, consumed by ceph_deploy/osd-spec.yml.j2, NVMe-RAID shape:
 # no sas_path_prefix -> data path is /dev/disk/by-path/<path_phy>, db is /dev/<db>).
-# The 14x 20TB SATA HDDs sit on 3 AHCI controllers; the by-path layout is IDENTICAL
+# The 14x 22TB SATA HDDs sit on 3 AHCI controllers; the by-path layout is IDENTICAL
 # across 47 of the 48 nodes (verified 2026-07-10), so it lives here as a group_var
 # instead of 48 host_vars. Exception: spice-ceph-miguel has one disk on
 # 46:00.0-ata-4 (not 87:00.0-ata-4) and overrides ceph_hdd_osds in its host_vars.
@@ -260,7 +261,7 @@ ceph_osd_pool_default_min_size: 2
 # --- Device-class CRUSH pool placement ---
 # crush-rules.yml creates replicated_ssd/replicated_hdd but binds nothing; every
 # replicated pool otherwise falls to the default class-agnostic rule, so the
-# omap-heavy bucket index lands on HDD (~98.5% of weight) while the 47-OSD NVMe
+# omap-heavy bucket index lands on HDD (~98.5% of weight) while the 48-OSD NVMe
 # ssd-osd tier sits idle. Pin the latency-sensitive index/metadata/mgr pools to
 # the SSD tier; keep the bulk non-EC pool on HDD. The EC data pool is pinned to
 # hdd via ceph_rgw_ec_device_class (the EC profile), not here. OSD device classes
@@ -297,10 +298,10 @@ ceph_rgw_ssl_cert_email: yucca@futo.org
 ceph_rgw_scheme: "{{ 'https' if ceph_rgw_ssl else 'http' }}"
 # --- RGW ingress: health-checked S3 VIP (haproxy + keepalived, TLS terminate) ---
 # A cephadm ingress service puts a keepalived floating VIP with haproxy health
-# checks in front of the 47 RGW daemons, in TLS TERMINATION mode (haproxy
+# checks in front of the 48 RGW daemons, in TLS TERMINATION mode (haproxy
 # `mode http`: haproxy terminates the client TLS on the VIP with the reused RGW
 # self-signed cert, then re-encrypts to each beast backend). Without it a dead RGW
-# node blackholes ~1/47 of S3 connections; with it the node is health-checked out
+# node blackholes ~1/48 of S3 connections; with it the node is health-checked out
 # of the VIP. The VIP sits on the fabric public network (10.40.20.0/23, bond0.120);
 # NetBird already advertises 10.40.20.0/23 into the overlay, so the VIP is
 # reachable, and DNS points s3.<domain> at it (that DNS cutover is a separate TF
@@ -349,8 +350,9 @@ ceph_firewall_rgw_any_source: false
 # group-scoped, enforced in its own nftables table) is the access-control
 # plane for mesh traffic, so this firewall must not second-guess it per port.
 # In particular netbird-ssh DNATs overlay :22 to :22022 on the netbird
-# address, which a dport allow-list here would silently drop post-DNAT. Inert until a
-# node is enrolled (no wt0 = no match), so it ships ahead of the peer rollout.
+# address, which a dport allow-list here would silently drop post-DNAT. Inert on
+# a node with no wt0, which is how it shipped ahead of the peer rollout; all 48
+# are enrolled now.
 ceph_firewall_trusted_ifaces:
   - bond0.122
   - wt0

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -201,15 +201,28 @@ ceph_ssd_osd_reserve_gib: 512     # vg0 free left unallocated for headroom/expan
 # colocates block.db on the 22TB HDD instead of the vg0 db-slot LV.
 ceph_osd_spec_unmanaged: true
 
-# Collapse the per-host OSD specs into one per host TYPE, which is the shape
-# upstream expects ("typically you will have a single spec for each type of
-# host"). spice renders 3 instead of 48x2: one for the 47 nodes sharing an
-# identical by-path map, one for miguel (whose 87:00.0-ata-4 disk sits on
-# 46:00.0 instead), one for the ssd-osd LV common to all 48. Off by default so
-# clusters that have per-host specs deployed are not silently renamed -- a
-# changed service_id creates a new service and orphans the old one, so turning
-# this on is a migration (apply, then `ceph orch rm` the superseded services).
-ceph_osd_spec_group_by_layout: true
+# Collapsing the per-host specs into one per host TYPE is the shape upstream
+# expects, and spice is the obvious candidate: 47 of 48 nodes share a by-path
+# map, so it would render 3 documents instead of 96. It stays OFF here anyway,
+# because the collapse cannot be retrofitted onto a cluster that is already
+# built.
+#
+# An OSD's owning service is not a property of the spec, it is written into the
+# OSD's LVM tags at creation time from CEPH_VOLUME_OSDSPEC_AFFINITY
+# (`ceph.osdspec_affinity=spice-ceph-<host>-<class>`, on the data and db LVs
+# alike). Applying the collapsed specs would not move the 720 existing daemons
+# onto them, and `ceph orch ls` fabricates a service for any daemon whose spec
+# is missing (cephadm describe_service: "new unmanaged service"), so removing
+# the old 96 would only make them reappear synthesized. The end state is 99
+# entries instead of 96, no daemon changed, nothing gained -- the serve-loop
+# cost this was meant to address is already gone via ceph_osd_spec_unmanaged,
+# which cephadm honours regardless of how many specs exist.
+#
+# Re-attributing for real means retagging ~1440 LVs across 48 live hosts, or
+# destroying and rebuilding 720 OSDs. Neither is worth a cosmetic win. Turn
+# this on for a NEW cluster, where the OSDs are tagged with the collapsed names
+# from the start; leave it off for one that already has per-host specs deployed.
+ceph_osd_spec_group_by_layout: false
 
 # OSD device map (by-path, consumed by ceph_deploy/osd-spec.yml.j2, NVMe-RAID shape:
 # no sas_path_prefix -> data path is /dev/disk/by-path/<path_phy>, db is /dev/<db>).

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/host_vars/spice-ceph-miguel.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/host_vars/spice-ceph-miguel.yml
@@ -5,7 +5,7 @@ hetzner_server_number: 3014576
 host_index: 38
 mon: false
 # OVERRIDE of the group_vars ceph_hdd_osds: miguel has one HDD on 46:00.0-ata-4
-# (not 87:00.0-ata-4 like the other 46 nodes) -- verified 2026-07-10. host_vars
+# (not 87:00.0-ata-4 like the other 47 nodes) -- verified 2026-07-10. host_vars
 # fully replaces the group_var, so the whole 14-disk map is repeated here.
 ceph_hdd_osds:
   - { path_phy: pci-0000:45:00.0-ata-1, db: vg0/db-slot0 }

--- a/ansible/ceph/roles/ceph_deploy/tasks/osds.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/osds.yml
@@ -1,22 +1,29 @@
 ---
 # Phase 5: Create OSDs via cephadm orch service spec
 #
-# Renders a multi-document OSD service spec (one document per host, see
+# Renders a multi-document OSD service spec (one document per host TYPE, see
 # templates/osd-spec.yml.j2) and applies via `ceph orch apply osd`. Cephadm
 # handles per-disk LUKS provisioning, LVM creation, daemon deployment, and
-# CRUSH placement internally — the role no longer iterates disks.
+# CRUSH placement internally; the role no longer iterates disks.
 #
 # Hardware-shape independence: the template's Jinja conditionals handle
 # both sietch (SAS expander + dual-SSD-VG) and NVMe-RAID hosts (PCI-ATA + single
 # NVMe-RAID VG + LV-backed SSD OSD) without per-shape branching here.
 #
 # Required host_vars (per host, in inventories/<cluster>/host_vars/<host>.yml):
-#   ceph_hdd_osds   — list of {path_phy, db} mappings per HDD
-#   ceph_ssd_osds   — list of {path_phy + partition} (SAS shape) or {lv} (NVMe-RAID shape)
-#   sas_path_prefix — REQUIRED for sietch; OMITTED for NVMe-RAID-shape hosts
+#   ceph_hdd_osds   : list of {path_phy, db} mappings per HDD
+#   ceph_ssd_osds   : list of {path_phy + partition} (SAS shape) or {lv} (NVMe-RAID shape)
+#   sas_path_prefix : REQUIRED for sietch; OMITTED for NVMe-RAID-shape hosts
 #
-# Idempotent: re-applying the same spec is a no-op when OSDs match. New
-# disks (e.g. populating an empty bay later) are picked up automatically.
+# Idempotent: re-applying the same spec is a no-op when OSDs match.
+#
+# Whether cephadm acts on the spec depends on ceph_osd_spec_unmanaged. Left
+# false (sietch) the spec is managed and cephadm picks up new disks on its own,
+# which is the behaviour this role has always had. Set true (spice) the spec is
+# registered but inert, because reconciling a managed spec costs a ceph-volume
+# lvm+raw list per host on every serve-loop pass and that dominated the loop at
+# 48 hosts. Provisioning from an inert spec then needs the explicit window
+# below.
 
 - name: Render OSD service spec on bootstrap node
   ansible.builtin.template:
@@ -48,73 +55,173 @@
     'Scheduled' in (orch_apply.stdout | default(''))
     or 'created' in (orch_apply.stdout | default('') | lower)
 
-- name: Wait for cephadm to provision all expected OSDs
-  ansible.builtin.shell: |
-    set -o pipefail
-    EXPECTED={{
-      (groups['ceph_nodes'] | intersect(ansible_play_hosts))
-        | map('extract', hostvars)
-        | map(attribute='ceph_hdd_osds', default=[])
-        | map('length') | sum
-      +
-      (groups['ceph_nodes'] | intersect(ansible_play_hosts))
-        | map('extract', hostvars)
-        | map(attribute='ceph_ssd_osds', default=[])
-        | map('length') | sum
-    }}
-    echo "Expecting $EXPECTED OSDs across the nodes in this run"
-    for i in $(seq 1 180); do
-      ACTUAL=$(ceph osd stat --format json 2>/dev/null \
-        | python3 -c "import sys, json; print(json.load(sys.stdin).get('num_osds', 0))" \
-        2>/dev/null || echo 0)
-      echo "  attempt $i: $ACTUAL/$EXPECTED OSDs created"
-      if [ "$ACTUAL" -ge "$EXPECTED" ]; then
-        echo "All expected OSDs provisioned"
-        exit 0
-      fi
-      sleep 10
-    done
-    echo "WARNING: only $ACTUAL of $EXPECTED OSDs provisioned after 30 minutes"
-    exit 1
-  args:
-    executable: /bin/bash
-  delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
-  run_once: true
-  changed_when: false
-  timeout: 1920
+# Provisioning window.
+#
+# An unmanaged spec creates nothing, so a cluster that sets
+# ceph_osd_spec_unmanaged has to hand cephadm a bounded interval in which to
+# build the OSDs: set-managed, wait, set-unmanaged. Opt in with
+# `-e ceph_osd_allow_spec_provisioning=true`.
+#
+# INITIAL PROVISIONING ONLY. Do not open this window to rebuild a replaced
+# disk. With one blank disk and one free db slot cephadm may recreate the OSD
+# without its block.db (Ceph tracker #68436, open against 18.2.4), which on the
+# NVMe-RAID shape means block.db silently colocated on the 22TB HDD instead of
+# the vg0 db-slot LV. docs/runbooks/replace-disk.md drives ceph-volume directly
+# for exactly that reason.
+#
+# `always` closes the window even if a wait times out, so a failed run cannot
+# leave the specs managed and the serve loop crawling.
+- name: Provision OSDs from the service spec
+  vars:
+    spec_window: >-
+      {{ (ceph_osd_spec_unmanaged | default(false))
+         and (ceph_osd_allow_spec_provisioning | default(false)) }}
+    spec_inert: >-
+      {{ (ceph_osd_spec_unmanaged | default(false))
+         and not (ceph_osd_allow_spec_provisioning | default(false)) }}
+  block:
+    - name: Open the managed provisioning window
+      ansible.builtin.shell: |
+        set -o pipefail
+        ceph orch ls --service-type osd --format json \
+          | python3 -c 'import sys, json; [print(s["service_name"]) for s in json.load(sys.stdin)]' \
+          | xargs -rn1 ceph orch set-managed
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      run_once: true
+      changed_when: true
+      when: spec_window | bool
 
-- name: Wait for OSDs to come up
-  ansible.builtin.shell: |
-    set -o pipefail
-    for i in $(seq 1 180); do
-      up=$(ceph osd stat --format json 2>/dev/null |
-        python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('num_up_osds',0))" \
-        2>/dev/null || echo 0)
-      total=$(ceph osd stat --format json 2>/dev/null |
-        python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('num_osds',0))" \
-        2>/dev/null || echo 0)
-      echo "OSDs: $up/$total up"
-      if [ "$up" -eq "$total" ] && [ "$total" -gt 0 ]; then
-        echo "All OSDs up"; exit 0
-      fi
-      sleep 10
-    done
-    echo "WARNING: Not all OSDs up after 30 minutes"
-    exit 1
-  args:
-    executable: /bin/bash
-  delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
-  run_once: true
-  changed_when: false
-  timeout: 1920
+    - name: Wait for cephadm to provision all expected OSDs
+      ansible.builtin.shell: |
+        set -o pipefail
+        EXPECTED={{
+          (groups['ceph_nodes'] | intersect(ansible_play_hosts))
+            | map('extract', hostvars)
+            | map(attribute='ceph_hdd_osds', default=[])
+            | map('length') | sum
+          +
+          (groups['ceph_nodes'] | intersect(ansible_play_hosts))
+            | map('extract', hostvars)
+            | map(attribute='ceph_ssd_osds', default=[])
+            | map('length') | sum
+        }}
+        echo "Expecting $EXPECTED OSDs across the nodes in this run"
+        for i in $(seq 1 180); do
+          ACTUAL=$(ceph osd stat --format json 2>/dev/null \
+            | python3 -c "import sys, json; print(json.load(sys.stdin).get('num_osds', 0))" \
+            2>/dev/null || echo 0)
+          echo "  attempt $i: $ACTUAL/$EXPECTED OSDs created"
+          if [ "$ACTUAL" -ge "$EXPECTED" ]; then
+            echo "All expected OSDs provisioned"
+            exit 0
+          fi
+          sleep 10
+        done
+        echo "WARNING: only $ACTUAL of $EXPECTED OSDs provisioned after 30 minutes"
+        exit 1
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      run_once: true
+      changed_when: false
+      timeout: 1920
+      when: not (spec_inert | bool)
 
-# Safety net: if any OSD comes up with reweight=0 (rare with orch apply,
-# but possible if a noin flag was set externally before this run), fix it.
+    - name: Wait for OSDs to come up
+      ansible.builtin.shell: |
+        set -o pipefail
+        for i in $(seq 1 180); do
+          up=$(ceph osd stat --format json 2>/dev/null |
+            python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('num_up_osds',0))" \
+            2>/dev/null || echo 0)
+          total=$(ceph osd stat --format json 2>/dev/null |
+            python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('num_osds',0))" \
+            2>/dev/null || echo 0)
+          echo "OSDs: $up/$total up"
+          if [ "$up" -eq "$total" ] && [ "$total" -gt 0 ]; then
+            echo "All OSDs up"; exit 0
+          fi
+          sleep 10
+        done
+        echo "WARNING: Not all OSDs up after 30 minutes"
+        exit 1
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      run_once: true
+      changed_when: false
+      timeout: 1920
+      when: not (spec_inert | bool)
+
+  always:
+    - name: Close the managed provisioning window
+      ansible.builtin.shell: |
+        set -o pipefail
+        ceph orch ls --service-type osd --format json \
+          | python3 -c 'import sys, json; [print(s["service_name"]) for s in json.load(sys.stdin)]' \
+          | xargs -rn1 ceph orch set-unmanaged
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      run_once: true
+      changed_when: true
+      when: spec_window | bool
+
+# Safety net: an OSD that comes up at reweight 0 because a noin flag was set
+# before this run never takes data until something reweights it back.
+#
+# "up with reweight 0" is ambiguous, though -- it is equally the signature of a
+# drain (`ceph orch osd rm`, or the plain `ceph osd out` that replace-disk.md
+# step 2 prescribes), and nothing in the osdmap distinguishes the two. Guessing
+# wrong is expensive in one direction only: reweighting a draining OSD back to
+# 1.0 refills the disk you are removing, silently and mid-drain, whereas failing
+# to fix a genuinely stuck OSD leaves it visibly at reweight 0 in `ceph osd
+# tree`. So this task corrects an OSD only when it can name the cause:
+#
+#   in the cephadm removal queue  -> skip, cephadm is draining it
+#   noin set                      -> reweight to 1.0, the documented cause
+#   neither                       -> warn and leave alone; someone outed it
+#
+# noin is read before the "clear noin flag" task below unsets it. A `destroyed`
+# OSD needs no special case: it is not `up`, so the status filter passes over it.
 
 - name: Fix any OSDs stuck at reweight 0
   ansible.builtin.shell: |
     set -o pipefail
+    # OSD ids cephadm is currently draining. Tolerates an empty queue, a
+    # non-JSON message, and either the bare-list or {"osds": [...]} shape.
+    DRAINING=$(ceph orch osd rm status --format json 2>/dev/null | python3 -c "
+    import sys, json
+    try:
+        data = json.loads(sys.stdin.read() or '[]')
+    except ValueError:
+        data = []
+    if isinstance(data, dict):
+        data = data.get('osds', [])
+    print(' '.join(str(o['osd_id']) for o in data
+                   if isinstance(o, dict) and o.get('osd_id') is not None))
+    " 2>/dev/null || true)
+    echo "cephadm removal queue: ${DRAINING:-<empty>}"
+
+    # Is noin set? Prefer the flags_set list; fall back to the comma string for
+    # older releases that do not emit it. Anything unparseable reads as "not
+    # set", which routes to the warn-only path rather than to reweighting.
+    NOIN=$(ceph osd dump --format json 2>/dev/null | python3 -c "
+    import sys, json
+    try:
+        d = json.load(sys.stdin)
+    except ValueError:
+        print('no'); sys.exit(0)
+    flags = d.get('flags_set') or [f for f in (d.get('flags') or '').split(',') if f]
+    print('yes' if 'noin' in flags else 'no')
+    " 2>/dev/null || echo no)
+    echo "noin flag set: ${NOIN:-no}"
+
     FIXED=0
+    SKIPPED=0
+    LEFT=0
     for osd_id in $(ceph osd tree --format json 2>/dev/null | python3 -c "
     import sys, json
     tree = json.load(sys.stdin)
@@ -123,12 +230,32 @@
            and node.get('reweight', 1) == 0:
             print(node['id'])
     "); do
-      echo "Reweighting osd.$osd_id from 0 to 1.0"
+      case " $DRAINING " in
+        *" $osd_id "*)
+          echo "Skipping osd.$osd_id - draining via ceph orch osd rm"
+          SKIPPED=$((SKIPPED + 1))
+          continue
+          ;;
+      esac
+      if [ "$NOIN" != "yes" ]; then
+        echo "WARNING: osd.$osd_id is up at reweight 0 but noin is not set." \
+             "Leaving it alone - this is what a manual 'ceph osd out $osd_id'" \
+             "looks like. If it is genuinely stuck, run 'ceph osd in $osd_id'."
+        LEFT=$((LEFT + 1))
+        continue
+      fi
+      echo "Reweighting osd.$osd_id from 0 to 1.0 (noin was set)"
       ceph osd reweight "$osd_id" 1.0
       FIXED=$((FIXED + 1))
     done
+    if [ "$SKIPPED" -ne 0 ]; then
+      echo "Left $SKIPPED draining OSDs alone"
+    fi
+    if [ "$LEFT" -ne 0 ]; then
+      echo "Left $LEFT out-looking OSDs alone (see warnings above)"
+    fi
     if [ "$FIXED" -eq 0 ]; then
-      echo "All up OSDs have proper reweight"
+      echo "Reweighted nothing"
     else
       echo "Fixed $FIXED OSDs with reweight=0"
     fi
@@ -138,6 +265,15 @@
   run_once: true
   register: reweight_fix
   changed_when: "'Fixed' in reweight_fix.stdout"
+
+# Without this the warnings sit unread inside reweight_fix. An OSD left at
+# reweight 0 holds no data, so it is worth putting in front of the operator
+# even though it is deliberately not an error.
+- name: Surface OSDs left at reweight 0
+  ansible.builtin.debug:
+    msg: "{{ reweight_fix.stdout_lines | select('search', '^WARNING:') | list }}"
+  run_once: true
+  when: reweight_fix.stdout is defined and 'WARNING:' in reweight_fix.stdout
 
 - name: Show OSD tree
   ansible.builtin.command: ceph osd tree
@@ -172,9 +308,9 @@
 # Defensive: clear the noin flag if it's set. The current spec-apply flow
 # doesn't set noin (cephadm orch handles backfill rollout gracefully), but
 # a prior failed run of this role's older imperative OSD-creation flow may
-# have set it and not unset it. Unset is idempotent — no-op when already off.
+# have set it and not unset it. Unset is idempotent: a no-op when already off.
 
-- name: Defensive — clear noin flag if set
+- name: Defensive - clear noin flag if set
   ansible.builtin.command: ceph osd unset noin
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
   run_once: true

--- a/ansible/ceph/roles/ceph_deploy/templates/osd-spec.yml.j2
+++ b/ansible/ceph/roles/ceph_deploy/templates/osd-spec.yml.j2
@@ -1,20 +1,21 @@
 # OSD service spec -- rendered by ceph_deploy role
 # Applied via: ceph orch apply osd -i /etc/ceph/osd-spec.yml
 #
-# ONE DOCUMENT PER HOST *TYPE*, not per host. Upstream's guidance is "typically
-# you will have a single spec for each type of host"; cephadm reconciles every
-# managed spec on every serve-loop pass, so a spec per host makes the loop cost
-# scale with the fleet. Hosts whose rendered device lists are byte-identical are
-# collapsed into one spec with a multi-host placement.
+# One document per host by default; optionally one per host TYPE. Upstream's
+# guidance is "typically you will have a single spec for each type of host", and
+# with ceph_osd_spec_group_by_layout set, hosts whose rendered device lists are
+# byte-identical collapse into one spec with a multi-host placement.
 #
-# In practice:
+# That flag is for GREENFIELD clusters only. An OSD's owning service is written
+# into its LVM tags at creation (ceph.osdspec_affinity), not derived from the
+# spec, so collapsing an already-built cluster does not move its daemons and
+# `ceph orch ls` re-synthesizes the old service names from them. Both live
+# clusters therefore leave it off:
 #   - sietch: each node has a unique sas_path_prefix (a different SAS expander
-#     address per chassis), so no two nodes collapse and every node keeps its own
-#     spec -- and, because single-host groups keep the <hostname>-<class>
-#     service_id, keeps its existing service name too.
-#   - spice: the by-path map is identical on 47 of 48 nodes, so those 47 collapse
-#     into one spec. miguel has one disk on a different controller and stays in
-#     its own single-host group under its existing name.
+#     address per chassis), so no two nodes would collapse anyway.
+#   - spice: 47 of 48 nodes share a by-path map and would collapse to 3
+#     documents, but its 720 OSDs are already tagged with the per-host names.
+#     See the spice group_vars for the full reasoning.
 #
 # Hardware-shape independence: when sas_path_prefix is defined the host is
 # sietch-shape (SAS expander, dual-SSD-VG block.db); otherwise the host is

--- a/ansible/ceph/roles/ceph_deploy/templates/osd-spec.yml.j2
+++ b/ansible/ceph/roles/ceph_deploy/templates/osd-spec.yml.j2
@@ -1,64 +1,132 @@
-# OSD service spec — rendered by ceph_deploy role
+# OSD service spec -- rendered by ceph_deploy role
 # Applied via: ceph orch apply osd -i /etc/ceph/osd-spec.yml
 #
-# One document per host because per-host disk paths differ:
-#   - sietch nodes: each has a unique sas_path_prefix (different SAS expander
-#     address per chassis), so explicit data_devices.paths can't be shared.
-#   - NVMe-RAID shape: single host, single spec.
+# ONE DOCUMENT PER HOST *TYPE*, not per host. Upstream's guidance is "typically
+# you will have a single spec for each type of host"; cephadm reconciles every
+# managed spec on every serve-loop pass, so a spec per host makes the loop cost
+# scale with the fleet. Hosts whose rendered device lists are byte-identical are
+# collapsed into one spec with a multi-host placement.
+#
+# In practice:
+#   - sietch: each node has a unique sas_path_prefix (a different SAS expander
+#     address per chassis), so no two nodes collapse and every node keeps its own
+#     spec -- and, because single-host groups keep the <hostname>-<class>
+#     service_id, keeps its existing service name too.
+#   - spice: the by-path map is identical on 47 of 48 nodes, so those 47 collapse
+#     into one spec. miguel has one disk on a different controller and stays in
+#     its own single-host group under its existing name.
 #
 # Hardware-shape independence: when sas_path_prefix is defined the host is
 # sietch-shape (SAS expander, dual-SSD-VG block.db); otherwise the host is
 # NVMe-RAID shape (PCI-ATA disks, single NVMe-RAID VG, SSD OSD as an LV).
 #
-# Idempotent: cephadm no-ops when the spec matches what's deployed. New
-# disks (e.g. populating an empty bay) are picked up automatically on apply.
+# unmanaged: cephadm keeps reconciling a managed spec forever, which on a large
+# fleet costs a ceph-volume lvm+raw list per host per pass. Clusters that do not
+# want that set ceph_osd_spec_unmanaged (see the spice group_vars); the spec then
+# stays registered and complete but cephadm will not act on it. Creating OSDs
+# from an unmanaged spec is an explicit, gated step in osds.yml -- and is for
+# initial provisioning only. Do NOT re-manage a spec to rebuild a replaced disk:
+# see docs/runbooks/replace-disk.md and Ceph tracker #68436.
 #
 # Do not edit by hand. Regenerate by re-running the ceph_deploy role.
+{#
+  Pass 1 -- bucket hosts by their rendered device lists. The join()ed paths are
+  the grouping key, so two hosts collapse only if every data path and every db
+  path matches exactly. namespace() is needed because Jinja loop scopes do not
+  leak assignments back out.
+
+  Collapsing is opt-in per cluster (ceph_osd_spec_group_by_layout). With it off
+  the key is just the hostname, so every host lands in its own group and keeps
+  its historical <hostname>-<class> service_id -- byte-identical to what this
+  template rendered before grouping existed. That default matters because
+  changing a service_id does not rename a service, it creates a new one and
+  orphans the old: sietch's three nodes name their SSD LVs identically
+  (ceph-ssd-rear12/osd-ssd on all three), so they would silently collapse and
+  rename on the next converge. Turn it on when the loop cost of one spec per
+  host is worth a deliberate migration.
+#}
+{% set ns = namespace(hdd={}, ssd={}) %}
 {% for host in groups['ceph_nodes'] %}
 {% set h = hostvars[host] %}
 {% if h.ceph_hdd_osds | default([]) | length > 0 %}
+{% set data_paths = [] %}
+{% set db_paths = [] %}
+{% for hdd in h.ceph_hdd_osds %}
+{% if h.sas_path_prefix is defined %}
+{% set _ = data_paths.append('/dev/disk/by-path/' ~ h.sas_path_prefix ~ '-' ~ hdd.path_phy ~ '-lun-0') %}
+{% else %}
+{% set _ = data_paths.append('/dev/disk/by-path/' ~ hdd.path_phy) %}
+{% endif %}
+{% set _ = db_paths.append('/dev/' ~ hdd.db) %}
+{% endfor %}
+{% set key = ((data_paths | join(',')) ~ '||' ~ (db_paths | join(','))) if ceph_osd_spec_group_by_layout | default(false) else h.hostname_short %}
+{% if key not in ns.hdd %}
+{% set _ = ns.hdd.update({key: {'data': data_paths, 'db': db_paths, 'hosts': []}}) %}
+{% endif %}
+{% set _ = ns.hdd[key]['hosts'].append(h.hostname_short) %}
+{% endif %}
+{% if h.ceph_ssd_osds | default([]) | length > 0 %}
+{% set ssd_paths = [] %}
+{% for ssd in h.ceph_ssd_osds %}
+{% if ssd.lv is defined %}
+{% set _ = ssd_paths.append('/dev/' ~ ssd.lv) %}
+{% else %}
+{% set _ = ssd_paths.append('/dev/disk/by-path/' ~ h.sas_path_prefix ~ '-' ~ ssd.path_phy ~ '-lun-0-part' ~ ssd.partition) %}
+{% endif %}
+{% endfor %}
+{% set key = (ssd_paths | join(',')) if ceph_osd_spec_group_by_layout | default(false) else h.hostname_short %}
+{% if key not in ns.ssd %}
+{% set _ = ns.ssd.update({key: {'data': ssd_paths, 'hosts': []}}) %}
+{% endif %}
+{% set _ = ns.ssd[key]['hosts'].append(h.hostname_short) %}
+{% endif %}
+{% endfor %}
+{#
+  Pass 2 -- emit one document per group. A group holding exactly one host keeps
+  the historical <hostname>-<class> service_id so existing single-host clusters
+  are not renamed (renaming a service_id creates a new service and orphans the
+  old one). Multi-host groups get <cluster>-<class>-<n>.
+#}
+{% for grp in ns.hdd.values() %}
 ---
 service_type: osd
-service_id: {{ h.hostname_short }}-hdd
+service_id: {{ grp.hosts[0] ~ '-hdd' if grp.hosts | length == 1 else cluster_name ~ '-hdd-' ~ loop.index }}
+unmanaged: {{ ceph_osd_spec_unmanaged | default(false) | string | lower }}
 placement:
   hosts:
-    - {{ h.hostname_short }}
+{% for hostname in grp.hosts %}
+    - {{ hostname }}
+{% endfor %}
 spec:
   data_devices:
     paths:
-{% for hdd in h.ceph_hdd_osds %}
-{% if h.sas_path_prefix is defined %}
-      - /dev/disk/by-path/{{ h.sas_path_prefix }}-{{ hdd.path_phy }}-lun-0
-{% else %}
-      - /dev/disk/by-path/{{ hdd.path_phy }}
-{% endif %}
+{% for path in grp.data %}
+      - {{ path }}
 {% endfor %}
   db_devices:
     paths:
-{% for hdd in h.ceph_hdd_osds %}
-      - /dev/{{ hdd.db }}
+{% for path in grp.db %}
+      - {{ path }}
 {% endfor %}
   encrypted: true
   crush_device_class: hdd
-{% endif %}
-{% if h.ceph_ssd_osds | default([]) | length > 0 %}
+{% endfor %}
+{% for grp in ns.ssd.values() %}
 ---
 service_type: osd
-service_id: {{ h.hostname_short }}-ssd
+service_id: {{ grp.hosts[0] ~ '-ssd' if grp.hosts | length == 1 else cluster_name ~ '-ssd-' ~ loop.index }}
+unmanaged: {{ ceph_osd_spec_unmanaged | default(false) | string | lower }}
 placement:
   hosts:
-    - {{ h.hostname_short }}
+{% for hostname in grp.hosts %}
+    - {{ hostname }}
+{% endfor %}
 spec:
   data_devices:
     paths:
-{% for ssd in h.ceph_ssd_osds %}
-{% if ssd.lv is defined %}
-      - /dev/{{ ssd.lv }}
-{% else %}
-      - /dev/disk/by-path/{{ h.sas_path_prefix }}-{{ ssd.path_phy }}-lun-0-part{{ ssd.partition }}
-{% endif %}
+{% for path in grp.data %}
+      - {{ path }}
 {% endfor %}
   encrypted: true
   crush_device_class: ssd
-{% endif %}
 {% endfor %}


### PR DESCRIPTION
spice's 96 OSD service specs are now unmanaged, so cephadm stops reconciling them on every serve-loop pass. Each pass cost a `ceph-volume lvm list` plus `raw list` per host and pinned one iteration at \~35 minutes, so every orchestrator action inherited that latency before cephadm looked at it; an OSD drain queued at 12:06 did not begin until the 12:34 tick. The loop now runs in seconds, and the flag is declarative in the spice group\_vars alongside a gated provisioning window in `osds.yml`, because an inert spec creates nothing on its own and rebuilding a replaced disk belongs in `ceph-volume` by hand.

The template can also collapse per-host specs into one per host type, which is what upstream recommends, but it is off for both live clusters and documented as greenfield-only: an OSD's owning service is written into its LVM tags at creation, so collapsing an already-built cluster adds specs without moving the 720 daemons onto them. The ceph docs pick up spice throughout, having described it as planned while it served production. See ansible/ceph/docs/architecture.md, ansible/ceph/docs/runbooks/replace-disk.md.

- `main` <!-- branch-stack -->
  - \#364 :point\_left:
