### PR TITLE
fix(ci): exempt the go-templated yuctl warp manifests from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -37,6 +37,12 @@ tf/
 # + kubeconform via `mise k8s:validate` instead.
 charts/
 
+# yuctl warp manifests: Go-templated YAML embedded into the binary (//go:embed
+# in internal/warp/session.go). Worth ignoring rather than fixing up, because
+# prettier --write rewrites `{{ .Name }}` to `{ { .Name } }` (legal YAML, read
+# as a nested flow mapping) and text/template then emits it literally.
+packages/yuctl/internal/warp/manifests/
+
 # auto-generated
 yaak/
 CHANGELOG.md


### PR DESCRIPTION
The yuctl warp manifests are Go-templated YAML embedded into the binary, so prettier has no useful opinion about them. It is not a clean skip either: `prettier --write` rewrites `{{ .Name }}` to `{ { .Name } }`, which text/template stops treating as an action, and deployment.yaml fails to parse outright on its block-level `{{- if }}` / `{{- range }}`. That parse failure is what currently fails `Checks & Unit Tests` on main.

Ignoring the directory follows the existing `charts/` entry, exempt for the same reason.

- `main` <!-- branch-stack -->
  - \#370 :point\_left:
