### PR TITLE
fix(ceph): expect the declared MON quorum in drift detection

### DIFF
--- a/ansible/ceph/drift.yml
+++ b/ansible/ceph/drift.yml
@@ -261,16 +261,20 @@
       when: inventory_hostname in groups['ceph_bootstrap']
       changed_when: false
 
+    # Expect the declared quorum, not one MON per node. ceph_mon holds the hosts
+    # whose `roles` include "mon": every node on a small cluster, a pinned subset
+    # on a large one (spice runs 5 across 48). Comparing against ceph_nodes read
+    # as permanent drift on any cluster that pins its quorum.
     - name: Record MON drift
       ansible.builtin.set_fact:
         drift_results: >-
           {{ drift_results + [{
             'category': 'ceph',
             'item': 'MON count',
-            'expected': groups['ceph_nodes'] | length | string,
+            'expected': groups['ceph_mon'] | length | string,
             'actual': mon_count.stdout | trim,
             'match': (mon_count.stdout | trim)
-                     == (groups['ceph_nodes'] | length | string)
+                     == (groups['ceph_mon'] | length | string)
           }] }}
       when: inventory_hostname in groups['ceph_bootstrap']
 


### PR DESCRIPTION
Drift detection compares the live MON count against the declared quorum rather
than the node count:

- `groups['ceph_nodes'] | length` -> `groups['ceph_mon'] | length`

`ceph_mon` is rendered by `inventory.ini.tftpl` from the hosts whose `roles`
include "mon", so it is every node on sietch and the pinned 5 on spice. The old
comparison reported permanent drift on any cluster pinning a quorum: spice read
`expected: 48 / actual: 5`, and now reads `expected: 5 / actual: 5`. Verified
against spice, read-only, on one node.

Independent of #373 -- a different hunk of the same file, so either order merges.

- `main` <!-- branch-stack -->
  - \#374 :point\_left:
