### PR TITLE
feat(ceph): make cluster config a layered, mask-aware model

### DIFF
--- a/.github/workflows/ansible-ceph-validate.yml
+++ b/.github/workflows/ansible-ceph-validate.yml
@@ -87,5 +87,9 @@ jobs:
 
       # Byte-compile the helper scripts so a broken generator is caught here,
       # not mid-provision. (shellcheck above covers the *.sh scripts.)
+      # Covers roles/*/files/*.py too: those ship to the nodes via
+      # ansible.builtin.script, so a syntax error there fails mid-converge.
       - name: Compile Python scripts
-        run: mise exec -- python -m py_compile scripts/*.py
+        run: |
+          mise exec -- python -m py_compile \
+            $(find scripts roles -name '*.py' -not -path '*/__pycache__/*')

--- a/ansible/ceph/docs/patterns.md
+++ b/ansible/ceph/docs/patterns.md
@@ -20,37 +20,41 @@ unconditionally makes every play dirty and obscures real drift.
 only if different. The comparison is the key -- raw `ceph config set` with
 `changed_when: true` is a lie.
 
-Canonical example -- `roles/ceph_tuning/tasks/main.yml`:
+Canonical example -- `roles/ceph_tuning/tasks/main.yml`, which diffs the whole
+declared model against `ceph config dump` and loops only over what came back
+different:
 
 ```yaml
-- name: Read current OSD config values
-  ansible.builtin.shell: |
-    set -o pipefail
-    echo "recovery_max_active=$(ceph config get osd osd_recovery_max_active)"
-    # ...
-  register: current_osd_config
+- name: Diff declared Ceph config against the mon database
+  ansible.builtin.script: ceph_config_diff.py
+  environment:
+    CEPH_CONFIG_MODEL: "{{ {'desired': ceph_config_effective, ...} | to_json }}"
+  register: ceph_config_plan
   changed_when: false
 
 - name: Apply Ceph config values
-  ansible.builtin.command: >
-    ceph config set {{ item.section }} {{ item.key }} {{ item.value }}
-  loop:
-    - { section: osd, key: osd_recovery_max_active, value: "{{ ... }}",
-        current: "{{ osd_cfg.recovery_max_active | default('') | float }}" }
-  when: item.current | float != item.value | float
+  ansible.builtin.command:
+    argv: ["ceph", "config", "set", "{{ item.who }}", "{{ item.key }}", "{{ item.value }}"]
+  loop: "{{ ceph_config_changes.set | default([]) }}"
   changed_when: true
 ```
 
 Other instances: `rgw.yml` (zonegroup hostnames), `crush-rules.yml`
 (rule existence), `monitoring.yml` (module enable check).
 
-### Float comparison gotcha
+### Comparing Ceph config values
 
-`ceph config get osd osd_recovery_sleep_hdd` returns `0.100000`, but the
-Ansible variable is `0.1`. String comparison fails; integer comparison
-truncates. Always cast both sides to `| float` before comparing. Affects
-any Ceph config value returned with trailing zeros
-(`osd_recovery_sleep_hdd`, `osd_deep_scrub_interval`, etc.).
+A dump reports every value as a string, and not in the form the model wrote it:
+`604800.000000` for an int option, `0.100000` for `0.1`, `true` for a bool. So a
+plain string comparison produces false drift.
+
+Casting both sides with `| float` fixes the numeric cases and breaks the rest:
+Ansible's `float` filter returns `0.0` for anything non-numeric, so
+`osd_mclock_profile: balanced` and `osd_mclock_profile: high_recovery_ops` both
+cast to `0.0` and compare equal. Once a model can hold strings and bools as well
+as numbers, the comparison has to be typed -- exact match first, numeric match
+second, unequal otherwise. `ceph_config_diff.py` does this; do not reintroduce a
+Jinja `| float` comparison over arbitrary config values.
 
 ---
 
@@ -424,14 +428,85 @@ never claimed by auto-discovery.
 # BAD -- in a role's tasks/main.yml
 - ansible.builtin.command: ceph config set osd osd_recovery_max_active 1
 
-# GOOD -- value comes from defaults, overridable via group_vars
-- ansible.builtin.command: >
-    ceph config set osd osd_recovery_max_active
-    {{ ceph_osd_recovery_max_active }}
+# GOOD -- the value is data, layered by cluster
+ceph_config_cluster:
+  osd:
+    osd_recovery_max_active: 3
 ```
 
 Roles use `defaults/main.yml` for all tunables. Site-specific values live
 in `inventories/<partition>-<region>/<cluster>/group_vars/all/vars.yml`.
+
+### Where a tunable belongs
+
+Three layers, lowest to highest. Ansible's own precedence does the work; no
+`hash_behaviour` change is needed or wanted.
+
+| Layer | Lives in | Holds |
+|---|---|---|
+| Role default | `roles/<role>/defaults/main.yml` | safe on any cluster |
+| Per-cluster | `<inventory>/group_vars/all/vars.yml` | cluster shape |
+| Per-host | `<inventory>/host_vars/<host>.yml` | machine exceptions |
+
+Which layer is available depends on **where the change is applied**, and the
+two tuning surfaces differ:
+
+**OS and hardware tuning** is applied on each node by a role that runs against
+every host, so all three layers work directly. `host_vars` is the right place
+for a per-machine exception.
+
+**Ceph tuning is different.** Those tasks run only on the bootstrap node,
+because the mon config database is cluster-wide state -- another host's
+`host_vars` is not in scope there. Per-host Ceph settings go in the
+`ceph_config` model instead, keyed by Ceph's own mask syntax:
+
+```yaml
+ceph_config_cluster:
+  osd:                              # every OSD
+    osd_max_backfills: 8
+  osd/class:hdd:                    # only HDD-backed OSDs
+    osd_recovery_max_active: 3
+ceph_config_host:
+  osd/host:spice-ceph-alyssa:       # one node
+    osd_scrub_load_threshold: 5
+```
+
+Ceph resolves those most-specific-first on its own (`global` -> `osd` ->
+`osd/class:hdd` -> `osd/host:x` -> `osd.N`), which is why this does not need
+Ansible machinery. cephadm already uses the same mechanism for its per-host
+`osd_memory_target` autotune. Reserve `host_vars` for facts about the machine:
+`host_index`, `bond_ip`, the disk map.
+
+Merging uses `combine(recursive=True)`, so a cluster overriding one option keeps
+the rest of the section. A plain `host_vars` override of a dict or list replaces
+it wholesale -- which is why `spice-ceph-miguel` has to repeat all fourteen
+entries of `ceph_hdd_osds` to change one.
+
+### Reading Ceph config back: `dump`, not `get`
+
+```bash
+# BAD -- resolves the section hierarchy
+ceph config get osd osd_max_backfills      # returns global's value as if it were osd's
+ceph config get osd/class:hdd osd_max_backfills   # EINVAL, masks not accepted
+
+# GOOD -- exact (section, mask, name) rows
+ceph config dump -f json
+```
+
+`ceph config get` answers "what would a daemon in this section see", which is
+not the same question as "what does this model own". A value living in `global`
+reads back identically to one in `osd`, so an idempotency check built on it
+concludes it has nothing to do and never writes. That is exactly how spice ended
+up with its recovery throttles in `global`, untouched by the role that claimed
+to own them, for the cluster's whole life. It also rejects masks outright, which
+would make every per-class and per-host setting invisible.
+
+`roles/ceph_tuning/files/ceph_config_diff.py` does this comparison for both the
+converge and the drift check, so the two cannot disagree about what differs.
+Comparison is typed there rather than in Jinja because a dump reports every
+value as a string (`604800.000000` for an int, `true` for a bool) and the
+`float` filter returns `0.0` for anything non-numeric -- which would read
+`balanced` and `high_recovery_ops` as equal.
 
 ### Using `ansible_play_batch` / `ansible_play_hosts` for placement specs
 

--- a/ansible/ceph/docs/runbooks/replace-host.md
+++ b/ansible/ceph/docs/runbooks/replace-host.md
@@ -98,8 +98,12 @@ sudo ceph -s
 - **Different serial numbers**: acceptable -- `by-path` is used for OSD
   slot identity, not `by-id`.
 - **Backfill thundering herd**: if you skipped step 1, the new OSDs enter
-  the cluster and backfill aggressively. Throttle with
-  `ceph_osd_recovery_max_active` in vars.yml if you see client-IO impact.
+  the cluster and backfill aggressively. Throttle via `ceph_config_cluster`
+  in vars.yml (`osd.osd_recovery_max_active`, `osd.osd_max_backfills`) if you
+  see client-IO impact. Under the mclock scheduler those need
+  `osd_mclock_override_recovery_settings: true` alongside them, which the role
+  default already sets; confirm a change landed with
+  `ceph tell osd.<id> config get <option>`, not `ceph config get`.
 
 ## References
 

--- a/ansible/ceph/roles/ceph_deploy/templates/cluster-spec.yml.j2
+++ b/ansible/ceph/roles/ceph_deploy/templates/cluster-spec.yml.j2
@@ -1,23 +1,21 @@
 [global]
-# Initial cluster config applied during cephadm bootstrap
+# Initial cluster config applied during cephadm bootstrap.
+#
+# Only what bootstrap itself needs: the networks the mons bind, and the pool
+# size floor so anything created before ceph_tuning runs is not left at
+# single-replica.
+#
+# Tunables do NOT belong here. Recovery/backfill throttling, the scrub window,
+# block.db sizing and the PG autoscaler target are declared once in
+# ceph_tuning's ceph_config model. Setting them here as well is what left the
+# recovery throttles sitting in `global` on spice while the role wrote `osd`:
+# two sources for the same option, and the one nobody was looking at won.
+#
+# Dropping them changes nothing at bootstrap. bluestore_block_db_size (0) and
+# mon_target_pg_per_osd (100) already match Ceph's compiled defaults, and the
+# scrub and recovery settings only bite once the cluster holds data, which is
+# after ceph_tuning has run.
 osd_pool_default_size = {{ ceph_osd_pool_default_size | default(2) }}
 osd_pool_default_min_size = {{ ceph_osd_pool_default_min_size | default(1) }}
 public_network = {{ public_network }}
 cluster_network = {{ cluster_network }}
-
-# Recovery/backfill throttling (small cluster, shared network)
-osd_recovery_max_active = 1
-osd_recovery_sleep_hdd = 0.1
-osd_max_backfills = 1
-
-# PG autoscaler target
-mon_target_pg_per_osd = 100
-
-[osd]
-# Let BlueStore use the entire block.db LV (pre-created at 240G)
-bluestore_block_db_size = 0
-
-# Scrub window — 2-6 AM, deep scrub weekly
-osd_scrub_begin_hour = 2
-osd_scrub_end_hour = 6
-osd_deep_scrub_interval = 604800

--- a/ansible/ceph/roles/ceph_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/defaults/main.yml
@@ -7,22 +7,85 @@
 # contact/org attached; leaderboard off). Set false per-cluster to opt out.
 ceph_telemetry_enabled: true
 
-# OSD recovery throttling (also in cluster-spec.yml.j2 initial config,
-# but re-asserted here for idempotency after config changes)
-ceph_osd_recovery_max_active: 1
-ceph_osd_recovery_sleep_hdd: 0.1
-ceph_osd_max_backfills: 1
+# === Ceph config model ===
+#
+# One map instead of a scalar per option. Keys are anything `ceph config set`
+# accepts as its `<who>`: a section (`global`, `osd`, `mon`), a single daemon
+# (`osd.5`), or a section plus a mask (`osd/class:hdd`, `osd/host:<node>`).
+# Ceph resolves those most-specific-first on its own, so per-class and per-host
+# tuning needs no Ansible machinery -- it is another key in this map.
+#
+# Per-host Ceph settings belong here rather than in Ansible host_vars: these
+# tasks run only on the bootstrap node, because the mon config database is
+# cluster-wide state, so another host's host_vars are not in scope. host_vars
+# stays for facts about the machine -- host_index, bond_ip, the disk map.
+#
+# Three layers, merged in tasks/main.yml:
+#   ceph_config_defaults   role                    - safe on any cluster
+#   ceph_config_cluster    group_vars/all/vars.yml - cluster shape
+#   ceph_config_host       group_vars/all/vars.yml - per-host/class exceptions
+# Merged with combine(recursive=True), so a cluster overriding one option keeps
+# the rest of the section instead of replacing it wholesale.
+ceph_config_defaults:
+  global:
+    mon_target_pg_per_osd: 100
+  osd:
+    # Recovery/backfill. Conservative values sized for a small cluster on a
+    # shared network; a cluster with a dedicated replication fabric should raise
+    # them in its own ceph_config_cluster.
+    osd_recovery_max_active: 1
+    osd_recovery_sleep_hdd: 0.1
+    osd_max_backfills: 1
+    # Required for the three options above to stick. Under the mclock scheduler
+    # (the default since Reef) an operator-set recovery limit is reverted to the
+    # mclock default unless this gate is on, and that default is 1000, not 1.
+    # tasks/main.yml applies gate keys ahead of the options they gate and will
+    # not prune the superseded `global` entries until the running OSD values are
+    # confirmed, so a rejected write cannot quietly uncap backfill.
+    osd_mclock_override_recovery_settings: true
+    # Scrub window -- 2-6 AM, deep scrub weekly.
+    osd_scrub_begin_hour: 2
+    osd_scrub_end_hour: 6
+    osd_deep_scrub_interval: 604800
+    # BlueStore block.db: 0 means use the entire LV.
+    bluestore_block_db_size: 0
 
-# Scrub window
-ceph_osd_scrub_begin_hour: 2
-ceph_osd_scrub_end_hour: 6
-ceph_osd_deep_scrub_interval: 604800    # 7 days
+ceph_config_cluster: {}
+ceph_config_host: {}
 
-# PG autoscaler
-ceph_mon_target_pg_per_osd: 100
+# Options whose write is gated by another option. Applied first, in this order,
+# ahead of everything else in the model.
+ceph_config_gate_keys:
+  - osd_mclock_override_recovery_settings
 
-# BlueStore block.db: 0 means use the entire LV
-ceph_bluestore_block_db_size: 0
+# Options the gate keys above unlock, confirmed against a running OSD before any
+# prune. These are the ones where a silently-reverted write is dangerous rather
+# than cosmetic: both fall back to the mclock default of 1000.
+#
+# osd_recovery_sleep_hdd is deliberately absent. mclock forces the recovery-sleep
+# options to 0 whatever the database says, so a running OSD reports 0.000000
+# against a declared 0.1 and would fail this check forever. The declared value
+# still matters if a cluster is moved back to the wpq scheduler, so it stays in
+# the model; it just cannot be verified against a live daemon under mclock.
+ceph_config_gated_options:
+  - osd_max_backfills
+  - osd_recovery_max_active
+
+# One-time reconciliation: entries this model now owns in another section,
+# left behind by an earlier bootstrap. cephadm bootstrap wrote the recovery
+# throttles into `global` while this role writes `osd`. `osd` wins, so the stale
+# `global` copies changed no behaviour, but they read as intent and sent more
+# than one investigation down the wrong path.
+#
+# This is an explicit allowlist and has to stay one. The mon database also holds
+# keys owned by other systems -- cephadm's per-host osd_memory_target masks, the
+# dashboard credentials, the telemetry channels, container_image -- so pruning
+# "everything the model does not declare" would be destructive. Entries already
+# absent are skipped rather than failing.
+ceph_config_prune:
+  - {section: global, name: osd_recovery_max_active}
+  - {section: global, name: osd_recovery_sleep_hdd}
+  - {section: global, name: osd_max_backfills}
 
 # Log rotation retention (days)
 ceph_log_retention_days: 30

--- a/ansible/ceph/roles/ceph_tuning/files/ceph_config_diff.py
+++ b/ansible/ceph/roles/ceph_tuning/files/ceph_config_diff.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Diff a declared Ceph config model against the live mon config database.
+
+Read-only: this computes what would change and prints it as JSON. Applying the
+result is the caller's job, which keeps the script safe to run in check mode and
+keeps Ansible's changed_when honest.
+
+Input (JSON) comes from $CEPH_CONFIG_MODEL, or stdin when that is unset --
+ansible.builtin.script cannot pass stdin, and the stdin path keeps the script
+runnable by hand against a dump for debugging:
+  {
+    "desired":   {"<who>": {"<option>": <value>, ...}, ...},
+    "prune":     [{"section": "global", "name": "osd_max_backfills"}, ...],
+    "gate_keys": ["osd_mclock_override_recovery_settings", ...]
+  }
+
+stdout (JSON):
+  {
+    "set":     [{"who": ..., "key": ..., "value": ..., "current": ...}, ...],
+    "rm":      [{"section": ..., "name": ..., "current": ...}, ...],
+    "in_sync": <bool>
+  }
+
+`<who>` is any string `ceph config set` accepts: a section (`global`, `osd`), a
+single daemon (`osd.5`), or a section with a mask (`osd/class:hdd`,
+`osd/host:spice-ceph-alyssa`). Ceph stores the mask as a field separate from the
+section, so `osd/host:x` has to be split before it can be matched against a dump
+row.
+
+Why a script and not a Jinja comparison: `ceph config dump` reports every value
+as a string (`604800.000000` for an int option, `true` for a bool), while the
+model holds real YAML types. Ansible's `float` filter returns 0.0 for anything
+non-numeric, so a Jinja `| float` comparison would read `balanced` and `dumb` as
+equal. Typed comparison has to happen somewhere that can tell those apart.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def split_who(who):
+    """'osd/host:foo' -> ('osd', 'host:foo'); 'osd' -> ('osd', '')."""
+    section, sep, mask = who.partition("/")
+    return section, mask if sep else ""
+
+
+def to_ceph_str(value):
+    """Render a YAML value the way Ceph would echo it back."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def same_value(desired, live):
+    """Compare a model value against a dump string.
+
+    Exact string match first, then a numeric comparison so 604800 matches
+    '604800.000000' and 0.1 matches '0.100000'. Anything that is not numeric on
+    both sides falls through to unequal rather than being coerced.
+    """
+    rendered = to_ceph_str(desired)
+    if rendered == live:
+        return True
+    try:
+        return float(rendered) == float(live)
+    except (TypeError, ValueError):
+        return False
+
+
+def load_live():
+    """(section, mask, name) -> value, from the mon config database."""
+    out = subprocess.run(
+        ["ceph", "config", "dump", "-f", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return {
+        (row["section"], row.get("mask", ""), row["name"]): row["value"]
+        for row in json.loads(out)
+    }
+
+
+def main():
+    raw = os.environ.get("CEPH_CONFIG_MODEL")
+    payload = json.loads(raw) if raw else json.load(sys.stdin)
+    desired = payload.get("desired", {})
+    prune = payload.get("prune", [])
+    gate_keys = payload.get("gate_keys", [])
+
+    live = load_live()
+
+    pending = []
+    for who, options in desired.items():
+        section, mask = split_who(who)
+        for key, value in options.items():
+            current = live.get((section, mask, key))
+            if current is not None and same_value(value, current):
+                continue
+            pending.append(
+                {
+                    "who": who,
+                    "key": key,
+                    "value": to_ceph_str(value),
+                    "current": current,
+                }
+            )
+
+    # Gating options first. osd_mclock_override_recovery_settings has to be true
+    # before osd_max_backfills or osd_recovery_max_active will stick, and dict
+    # ordering in the model is not a contract we want to depend on.
+    gate_rank = {key: i for i, key in enumerate(gate_keys)}
+    pending.sort(key=lambda c: (gate_rank.get(c["key"], len(gate_rank)), c["who"], c["key"]))
+
+    # Prune is an explicit allowlist, never "everything the model does not
+    # declare". The mon database also holds keys owned by other systems --
+    # cephadm's per-host osd_memory_target masks, the dashboard credentials,
+    # telemetry channels, container_image -- and removing those would be
+    # destructive. Only entries named here are candidates.
+    removals = [
+        {
+            "section": entry["section"],
+            "name": entry["name"],
+            "current": live[(entry["section"], entry.get("mask", ""), entry["name"])],
+        }
+        for entry in prune
+        if (entry["section"], entry.get("mask", ""), entry["name"]) in live
+    ]
+
+    json.dump(
+        {"set": pending, "rm": removals, "in_sync": not pending and not removals},
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/ceph/roles/ceph_tuning/tasks/drift.yml
+++ b/ansible/ceph/roles/ceph_tuning/tasks/drift.yml
@@ -4,42 +4,77 @@
 # Included by drift.yml via include_role + tasks_from -- see the precedence
 # note in roles/os_tuning/tasks/drift.yml.
 #
-# KNOWN GAP: `ceph config get osd <key>` resolves the section hierarchy, so a
-# value set on `global` reads back identically to one set on `osd`, and a value
-# the model does not own at all still reports a match. It also rejects masks
-# outright (`ceph config get osd/class:hdd ...` -> EINVAL), so per-class and
-# per-host settings are invisible here. Comparing against `ceph config dump`
-# matched on (section, mask, name) is the fix; it lands with the ceph_tuning
-# data model rather than here, so this pass stays behaviour-preserving.
+# Compares against `ceph config dump` matched on (section, mask, name), reusing
+# the diff engine tasks/main.yml applies with, so drift and converge cannot
+# disagree about what counts as a difference. `ceph config get osd <key>` cannot
+# do this job: it resolves the section hierarchy, so a value living in `global`
+# reads back identically to one in `osd` and an option the model does not own at
+# all still reports a match. It also rejects masks outright
+# (`ceph config get osd/class:hdd ...` returns EINVAL), which would make every
+# per-class and per-host setting invisible.
 
-- name: Check Ceph config values
-  ansible.builtin.command: "ceph config get osd {{ item.key }}"
-  loop:
-    - key: osd_recovery_max_active
-      expected: "{{ ceph_osd_recovery_max_active }}"
-    - key: osd_max_backfills
-      expected: "{{ ceph_osd_max_backfills }}"
-    - key: osd_scrub_begin_hour
-      expected: "{{ ceph_osd_scrub_begin_hour }}"
-    - key: osd_scrub_end_hour
-      expected: "{{ ceph_osd_scrub_end_hour }}"
-  register: ceph_config_checks
+- name: Merge Ceph config layers
+  ansible.builtin.set_fact:
+    ceph_config_effective: >-
+      {{ ceph_config_defaults
+         | combine(ceph_config_cluster, ceph_config_host, recursive=True) }}
+  when: inventory_hostname in groups['ceph_bootstrap']
+
+- name: Diff declared Ceph config against the mon database
+  ansible.builtin.script: ceph_config_diff.py
+  environment:
+    CEPH_CONFIG_MODEL: >-
+      {{ {'desired': ceph_config_effective,
+          'prune': ceph_config_prune,
+          'gate_keys': ceph_config_gate_keys} | to_json }}
+  register: ceph_config_plan
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
-  loop_control:
-    label: "{{ item.key }}"
 
 - name: Record Ceph config drift
   ansible.builtin.set_fact:
     drift_results: >-
       {{ drift_results + [{
         'category': 'ceph-config',
-        'item': item.item.key,
-        'expected': item.item.expected | string,
-        'actual': item.stdout | trim,
-        'match': (item.stdout | trim) == (item.item.expected | string)
+        'item': item.who ~ '/' ~ item.key,
+        'expected': item.value | string,
+        'actual': item.current | default('unset', true) | string,
+        'match': false
       }] }}
-  loop: "{{ ceph_config_checks.results | default([]) }}"
+  loop: "{{ (ceph_config_plan.stdout | from_json).set | default([]) }}"
   when: inventory_hostname in groups['ceph_bootstrap']
   loop_control:
-    label: "{{ item.item.key | default('skipped') }}"
+    label: "{{ item.who }}/{{ item.key }}"
+
+# A superseded entry is drift in its own right: the value is still live in a
+# section the model does not own, so converging would leave it behind.
+- name: Record superseded Ceph config drift
+  ansible.builtin.set_fact:
+    drift_results: >-
+      {{ drift_results + [{
+        'category': 'ceph-config',
+        'item': item.section ~ '/' ~ item.name ~ ' (superseded)',
+        'expected': 'absent',
+        'actual': item.current | string,
+        'match': false
+      }] }}
+  loop: "{{ (ceph_config_plan.stdout | from_json).rm | default([]) }}"
+  when: inventory_hostname in groups['ceph_bootstrap']
+  loop_control:
+    label: "{{ item.section }}/{{ item.name }}"
+
+# One OK line when the model is fully converged, so the report shows the check
+# ran rather than silently contributing nothing.
+- name: Record Ceph config in sync
+  ansible.builtin.set_fact:
+    drift_results: >-
+      {{ drift_results + [{
+        'category': 'ceph-config',
+        'item': 'declared options',
+        'expected': 'in sync',
+        'actual': 'in sync',
+        'match': true
+      }] }}
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - (ceph_config_plan.stdout | from_json).in_sync | default(false)

--- a/ansible/ceph/roles/ceph_tuning/tasks/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/tasks/main.yml
@@ -30,74 +30,121 @@
     - (telemetry_status.stdout | from_json).enabled | default(true)
   changed_when: true
 
-# --- OSD tuning (check-then-set pattern) ---
+# --- Ceph config model ---
+#
+# Merge the three layers, diff against the live mon database, apply only what
+# differs. The diff is a script rather than a Jinja comparison because
+# `ceph config dump` reports every value as a string (604800.000000 for an int
+# option, "true" for a bool) while the model holds real YAML types, and the
+# `float` filter returns 0.0 for anything non-numeric -- which would read
+# "balanced" and "high_recovery_ops" as equal.
 
-- name: Read current OSD config values
-  ansible.builtin.shell: |
-    set -o pipefail
-    echo "recovery_max_active=$(ceph config get osd osd_recovery_max_active)"
-    echo "recovery_sleep_hdd=$(ceph config get osd osd_recovery_sleep_hdd)"
-    echo "max_backfills=$(ceph config get osd osd_max_backfills)"
-    echo "scrub_begin_hour=$(ceph config get osd osd_scrub_begin_hour)"
-    echo "scrub_end_hour=$(ceph config get osd osd_scrub_end_hour)"
-    echo "deep_scrub_interval=$(ceph config get osd osd_deep_scrub_interval)"
-    echo "bluestore_block_db_size=$(ceph config get osd bluestore_block_db_size)"
-    echo "mon_target_pg_per_osd=$(ceph config get mgr mon_target_pg_per_osd)"
-  args:
-    executable: /bin/bash
-  register: current_osd_config
+- name: Merge Ceph config layers
+  ansible.builtin.set_fact:
+    ceph_config_effective: >-
+      {{ ceph_config_defaults
+         | combine(ceph_config_cluster, ceph_config_host, recursive=True) }}
+  when: inventory_hostname in groups['ceph_bootstrap']
+
+- name: Diff declared Ceph config against the mon database
+  ansible.builtin.script: ceph_config_diff.py
+  environment:
+    CEPH_CONFIG_MODEL: >-
+      {{ {'desired': ceph_config_effective,
+          'prune': ceph_config_prune,
+          'gate_keys': ceph_config_gate_keys} | to_json }}
+  register: ceph_config_plan
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-- name: Parse current OSD config
+- name: Parse Ceph config plan
   ansible.builtin.set_fact:
-    osd_cfg: >-
-      {{ dict(current_osd_config.stdout_lines
-              | map('split', '=')
-              | map('list')) }}
+    ceph_config_changes: "{{ ceph_config_plan.stdout | from_json }}"
   when: inventory_hostname in groups['ceph_bootstrap']
 
+- name: Report pending Ceph config changes
+  ansible.builtin.debug:
+    msg: >-
+      {{ ceph_config_changes.set | length }} option(s) to set,
+      {{ ceph_config_changes.rm | length }} superseded entry(ies) to remove
+  when: inventory_hostname in groups['ceph_bootstrap']
+
+# Gate keys sort first (the script orders them), so
+# osd_mclock_override_recovery_settings lands before the recovery limits it
+# gates rather than depending on dict ordering in the model.
 - name: Apply Ceph config values
-  ansible.builtin.command: >
-    ceph config set {{ item.section }} {{ item.key }} {{ item.value }}
-  loop:
-    - section: osd
-      key: osd_recovery_max_active
-      value: "{{ ceph_osd_recovery_max_active }}"
-      current: "{{ osd_cfg.recovery_max_active | default('') | float }}"
-    - section: osd
-      key: osd_recovery_sleep_hdd
-      value: "{{ ceph_osd_recovery_sleep_hdd }}"
-      current: "{{ osd_cfg.recovery_sleep_hdd | default('') | float }}"
-    - section: osd
-      key: osd_max_backfills
-      value: "{{ ceph_osd_max_backfills }}"
-      current: "{{ osd_cfg.max_backfills | default('') | float }}"
-    - section: osd
-      key: osd_scrub_begin_hour
-      value: "{{ ceph_osd_scrub_begin_hour }}"
-      current: "{{ osd_cfg.scrub_begin_hour | default('') | float }}"
-    - section: osd
-      key: osd_scrub_end_hour
-      value: "{{ ceph_osd_scrub_end_hour }}"
-      current: "{{ osd_cfg.scrub_end_hour | default('') | float }}"
-    - section: osd
-      key: osd_deep_scrub_interval
-      value: "{{ ceph_osd_deep_scrub_interval }}"
-      current: "{{ osd_cfg.deep_scrub_interval | default('') | float }}"
-    - section: osd
-      key: bluestore_block_db_size
-      value: "{{ ceph_bluestore_block_db_size }}"
-      current: "{{ osd_cfg.bluestore_block_db_size | default('') | float }}"
-    - section: global
-      key: mon_target_pg_per_osd
-      value: "{{ ceph_mon_target_pg_per_osd }}"
-      current: "{{ osd_cfg.mon_target_pg_per_osd | default('') | float }}"
+  ansible.builtin.command:
+    argv: ["ceph", "config", "set", "{{ item.who }}", "{{ item.key }}", "{{ item.value }}"]
+  loop: "{{ ceph_config_changes.set | default([]) }}"
+  when: inventory_hostname in groups['ceph_bootstrap']
+  loop_control:
+    label: "{{ item.who }}/{{ item.key }}: {{ item.current | default('unset') }} -> {{ item.value }}"
+  changed_when: true
+
+# Safety interlock for the prune below. The recovery limits are moving from
+# `global` to `osd`, and under mclock an `osd`-section write can be reverted.
+# If that happened and we removed the `global` copy anyway, the effective value
+# would fall through to the mclock default of 1000 concurrent backfills. So
+# confirm the running daemons actually report the declared values first; a
+# mismatch fails the play with `global` still in place, which is the safe state.
+- name: Verify gated options landed on a running OSD
+  ansible.builtin.shell: |
+    set -o pipefail
+    OSD=$(ceph osd tree -f json | python3 -c "
+    import sys, json
+    up = [n['id'] for n in json.load(sys.stdin)['nodes']
+          if n.get('type') == 'osd' and n.get('status') == 'up']
+    print(up[0] if up else '')
+    ")
+    [ -n "$OSD" ] || { echo 'no OSD is up to verify against'; exit 1; }
+    export CEPH_VERIFY_OSD="$OSD"
+    ceph tell osd."$OSD" config show | python3 -c "
+    import json, os, sys
+    expected = json.loads(os.environ['CEPH_EXPECTED_GATED'])
+    running = json.load(sys.stdin)
+    osd = os.environ['CEPH_VERIFY_OSD']
+    bad = []
+    for key, want in expected.items():
+        got = running.get(key)
+        if got is None:
+            bad.append(f'{key}: not reported by osd.{osd}')
+            continue
+        if str(got) == str(want):
+            continue
+        try:
+            if float(got) == float(want):
+                continue
+        except (TypeError, ValueError):
+            pass
+        bad.append(f'{key}: osd.{osd} runs {got}, model declares {want}')
+    if bad:
+        print('\n'.join(bad))
+        sys.exit(1)
+    print(f'osd.{osd} runs the declared values for: ' + ', '.join(expected))
+    "
+  args:
+    executable: /bin/bash
+  environment:
+    CEPH_EXPECTED_GATED: >-
+      {{ (ceph_config_effective.osd | default({}))
+         | dict2items
+         | selectattr('key', 'in', ceph_config_gated_options)
+         | items2dict | to_json }}
+  register: ceph_config_verify
   when:
     - inventory_hostname in groups['ceph_bootstrap']
-    - item.current | float != item.value | float
+    - ceph_config_changes.rm | default([]) | length > 0
+  changed_when: false
+
+- name: Remove superseded Ceph config entries
+  ansible.builtin.command:
+    argv: ["ceph", "config", "rm", "{{ item.section }}", "{{ item.name }}"]
+  loop: "{{ ceph_config_changes.rm | default([]) }}"
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - ceph_config_verify is succeeded
   loop_control:
-    label: "{{ item.key }}"
+    label: "{{ item.section }}/{{ item.name }} (was {{ item.current }})"
   changed_when: true
 
 # --- Crash daemon ---


### PR DESCRIPTION
Ceph cluster config is declared as one layered map rather than a scalar per
option. `ceph_config_defaults` (role) merges with `ceph_config_cluster` and
`ceph_config_host` (group\_vars) through `combine(recursive=True)`, and a key is
anything `ceph config set` takes as its `<who>`, so per-device-class and
per-host tuning is `osd/class:hdd` or `osd/host:<node>` rather than new Ansible
machinery -- Ceph already resolves those most-specific-first, and cephadm uses
the same mechanism for its per-host `osd_memory_target` autotune. Converge and
drift now share one diff engine that compares against `ceph config dump` matched
on (section, mask, name). See ansible/ceph/docs/patterns.md.

That last part is the substance. `ceph config get osd <key>` resolves the
section hierarchy, so a value living in `global` reads back identically to one
in `osd` and the idempotency check concludes it has nothing to do. spice's
recovery throttles have therefore sat in `global` since bootstrap while this
role, which claims to own them, never wrote a byte: `osd/osd_max_backfills` is
unset on a 720-OSD production cluster and drift reported OK. `ceph config get`
also rejects masks outright (EINVAL), which would have made every per-class and
per-host setting invisible.

Effective values are unchanged on both clusters. What moves is which section
owns them, so the superseded `global` entries are pruned from an explicit
allowlist -- never "everything the model does not declare", since the mon
database also holds cephadm's per-host masks, the dashboard credentials and the
telemetry channels. The prune is interlocked behind a check that a running OSD
reports the declared values, because the recovery limits are moving under
mclock's gate and a rejected write plus a completed prune would leave them at
the mclock default of 1000 concurrent backfills. A failed check aborts with
`global` still in place, which is the safe state.

The bootstrap spec drops the same tunables so a new cluster stops recreating the
split. Verified harmless: `bluestore_block_db_size` (0) and
`mon_target_pg_per_osd` (100) already match Ceph's compiled defaults, and the
scrub and recovery settings only matter once the cluster holds data, which is
after ceph\_tuning has run.

Drift against spice goes from 2 to 9 on merge. The seven new lines are real and
pre-existing -- four options the model owns but does not yet hold, three
superseded `global` entries -- and clear on the first converge. That converge is
currently blocked by the health gate, which requires HEALTH\_OK or HEALTH\_WARN;
spice is HEALTH\_ERR on pg 2.15e, the stray osd.35 daemon, and five archived RGW
crashes.

- `main` <!-- branch-stack -->
  - \#377 :point\_left:
