### PR TITLE
docs(ceph): treat the spice 1G WAN default route as permanent

### DIFF
--- a/ansible/ceph/README.md
+++ b/ansible/ceph/README.md
@@ -187,10 +187,11 @@ cluster's stack under `tf/deployment/<partition>/<region>/ceph/`, then run
 - **Single-network topology on sietch**: public = cluster network (both
   `10.10.10.0/24`). spice splits them across fabric VLANs -- public
   `10.40.20.0/23` on VLAN 120, cluster `10.40.22.0/23` on VLAN 122 at MTU 9000.
-- **spice still routes over its 1G WAN**: the default route and the ansible/SSH
-  path are the 1G `enp197s0`, not the 25G bond. Ceph itself never touches it
-  (daemons are pinned to the fabric networks), but a WAN outage still costs
-  reachability.
+- **spice reachability depends on its 1G WAN**: the default route and the
+  ansible/SSH path are the 1G `enp197s0`, not the 25G bond. The split is
+  deliberate -- Ceph never touches the WAN (daemons are pinned to the fabric
+  networks), and a networkd error on the fabric cannot cost access to a node --
+  but a WAN outage costs reachability.
 - **Self-signed TLS**: RGW clients need `--no-verify-ssl`, on both clusters.
 - **`ops` user is password-only**: no SSH keys installed; password sourced from 1P. Intended as an interactive console or recovery account, not for automation.
 - **DNS not managed**: `s3.<domain>` and `*.s3.<domain>` records must exist externally.

--- a/ansible/ceph/docs/architecture.md
+++ b/ansible/ceph/docs/architecture.md
@@ -49,8 +49,8 @@ External dependencies are minimal and explicit:
   is the only remote hands short of a support ticket.
 - **NetBird overlay** -- spice nodes are enrolled peers. Human SSH is
   SSO-gated through NetBird's own server; CI reaches the nodes over the
-  overlay. Ansible still connects over the WAN address, which holds the
-  default route.
+  overlay. Ansible connects over the WAN address, which holds the default
+  route.
 
 ---
 

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -47,11 +47,10 @@ ceph_bind_networks:
   - "{{ public_network }}"
 
 # Alert delivery. Without a receiver the ~89 Prometheus rules fire into
-# alertmanager's null route, which is how osd.35's failing disk and two degraded
-# bonds all went unnoticed until a scrub tripped HEALTH_ERR (2026-07-27). The URL
-# is a Zulip incoming webhook whose alertmanager integration accepts the standard
-# webhook payload; it carries an API key, so it lives in 1Password and arrives
-# through secrets.yml.tpl rather than being written here.
+# alertmanager's null route and nothing reaches an operator. The URL is a Zulip
+# incoming webhook whose alertmanager integration accepts the standard webhook
+# payload; it carries an API key, so it lives in 1Password and arrives through
+# secrets.yml.tpl rather than being written here.
 ceph_alertmanager_webhook_urls:
   - "{{ vault_alertmanager_webhook_url }}"
 # Bond of the two 25G NICs, LACP to match the leaf ae<k> aggregate (cluster-fabric).

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -18,11 +18,10 @@ cluster_domain: prod.fsn1.htz.futo.cloud
 # 10.40.22.<host_index> (host_index from spice-hosts.yaml; gateway .1 = leaf IRB).
 # A third fabric VLAN, FSN1-C1-HOST-MGMT (124, 10.40.24.0/24), is the in-band
 # host-management path: the leaf trunks it to every server bond and the fabric
-# advertises 10.40.24.0/24 into the NetBird overlay, so it is the intended
-# ansible/SSH reach once the WAN is retired.
-# The DEFAULT ROUTE stays on the 1G WAN for now (Hetzner gateway); ansible reaches
-# nodes over their WAN address until the fabric is cut over. Revisit if/when the
-# default route moves off the WAN (to Ceph Public or Host-Mgmt).
+# advertises 10.40.24.0/24 into the NetBird overlay, so hosts answer on the
+# overlay as well as on their WAN address.
+# The DEFAULT ROUTE stays on the 1G WAN (Hetzner gateway); the fabric never
+# carries it. Ansible reaches nodes over their WAN address.
 public_network: 10.40.20.0/23     # VLAN 120 (Ceph Public)
 cluster_network: 10.40.22.0/23    # VLAN 122 (Ceph Private)
 # Per-host Ceph BIND address on the fabric public VLAN. Derived from host_index the
@@ -59,8 +58,8 @@ bond_mode: "802.3ad"
 # it (static IP + default route), and let networkd manage ONLY the bond + VLANs.
 # The WAN is never migrated, so a networkd error can't cost us the reachability
 # link (the painbox failure). networkd's commit leaves networking.service enabled
-# and an Unmanaged=yes guard fences oob_nic off. Flip to true only if the default
-# route ever moves onto the fabric and the WAN is retired.
+# and an Unmanaged=yes guard fences oob_nic off. This stays false -- the WAN keeps
+# the default route.
 networkd_replace_ifupdown: false
 # Enable the networkd role (defaults false, so it is a no-op unless set). spice's
 # 25G fabric bond + VLANs are networkd-managed, so a reprovisioned node must bring
@@ -73,7 +72,7 @@ networkd_enabled: true
 bond_interfaces:
   - enp193s0f0
   - enp193s0f1
-# 1G WAN (igb, PCI 0000:c5:00.0); holds the default route until the fabric cutover.
+# 1G WAN (igb, PCI 0000:c5:00.0); holds the default route.
 oob_nic: enp197s0
 fabric_public_vlan: 120
 fabric_private_vlan: 122
@@ -88,8 +87,7 @@ chrony_ntp_servers:
 
 # Tagged VLAN sub-interfaces on the 25G LACP bond (consumed by the networkd role).
 # Addresses derive from host_index; masks match each network (public/private /23,
-# host-mgmt /24). No Gateway here -- the default route stays on the 1G WAN until
-# fabric cutover.
+# host-mgmt /24). No Gateway here -- the default route stays on the 1G WAN.
 # Jumbo (MTU 9000) is enabled on VLAN 122 (Ceph PRIVATE / OSD replication) ONLY.
 # That is a closed, homogeneous, all-under-our-control path where jumbo's packet/
 # interrupt savings on replication+recovery actually pay off. VLAN 120 (Ceph public,

--- a/ansible/ceph/roles/ceph_deploy/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_deploy/defaults/main.yml
@@ -44,7 +44,7 @@ ceph_mgr_count: 3
 # default raises "HostVarsVars object has no attribute ceph_service_ip" and aborts
 # the deploy), whereas group_vars resolve through hostvars per host. spice sets it
 # to the fabric ceph_public_ip; sietch (flat) to bond_ip. It is NOT the ansible/SSH
-# connection address (that stays bond_ip / ansible_host until the WAN is retired).
+# connection address (that is bond_ip / ansible_host).
 #
 # CIDR(s) cephadm restricts daemon binds to, injected as the `networks:` field of
 # the RGW + monitoring service specs. mon/mgr/OSD already bind per public_network/

--- a/ansible/ceph/roles/networkd/templates/bond-vlan.network.j2
+++ b/ansible/ceph/roles/networkd/templates/bond-vlan.network.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 # L3 on {{ networkd_bond_name }}.{{ vlan.id }}: {{ vlan.address }}
-# Gateway .1 is the leaf IRB, but the default route stays on the 1G WAN until the
-# fabric cutover, so no Gateway (no default route) is set here.
+# Gateway .1 is the leaf IRB, but the default route belongs to the WAN NIC, so
+# this file sets no Gateway.
 
 [Match]
 Name={{ networkd_bond_name }}.{{ vlan.id }}

--- a/ansible/ceph/roles/networkd/templates/bond0.network.j2
+++ b/ansible/ceph/roles/networkd/templates/bond0.network.j2
@@ -15,10 +15,10 @@ LinkLocalAddressing=no
 IPv6AcceptRA=no
 
 [Link]
-# The fabric is NOT the boot-critical path -- the 1G WAN carries connectivity
-# until cutover, and the leaf may not have LACP up yet -- so a carrier-less bond
-# must not stall boot via systemd-networkd-wait-online. (The VLAN sub-interfaces
-# are RequiredForOnline=no too.) Raise to 'carrier' after the fabric is cut over.
+# The fabric is NOT the boot-critical path -- the WAN carries connectivity, and
+# the leaf may not have LACP up yet -- so a carrier-less bond must not stall boot
+# via systemd-networkd-wait-online. (The VLAN sub-interfaces are
+# RequiredForOnline=no too.)
 RequiredForOnline=no
 {% else %}
 # Bond L3: {{ bond_ip }}/24 via {{ gateway }}


### PR DESCRIPTION
The 1G WAN holds spice's default route permanently. There is no fabric cutover, so the network comments and docs stop describing one: the 25G bond carries Ceph and host-management traffic only, `RequiredForOnline` stays `no`, and `networkd_replace_ifupdown` stays `false`. The alertmanager comment separately drops a resolved incident it had been carrying. Comments and prose only, no settings change. See `ansible/ceph/README.md` and `ansible/ceph/docs/hardware.md`.

- `main` <!-- branch-stack -->
  - \#388 :point\_left:
