### PR TITLE
feat(yucca): per-connection billing rollup

### DIFF
--- a/packages/common/src/connections.ts
+++ b/packages/common/src/connections.ts
@@ -11,3 +11,29 @@ export const ConnectionTypeFlags = {
 
 export const connectionTypeFlag = (type: string): string | undefined =>
   (ConnectionTypeFlags as Record<string, string | undefined>)[type];
+
+export type MeteringTier = 'storage' | 'transfer' | 'activity';
+
+export interface ConnectionTypeInfo {
+  meters: readonly MeteringTier[];
+  reportsActivity: boolean;
+  minObjectSizeBytes: number;
+}
+
+const MIB = 1 << 20;
+
+export const ConnectionTypeInfos = {
+  immich: { meters: ['storage', 'transfer', 'activity'], reportsActivity: true, minObjectSizeBytes: 0 },
+  restic: { meters: ['storage', 'transfer'], reportsActivity: false, minObjectSizeBytes: MIB },
+} as const satisfies Record<ConnectionType, ConnectionTypeInfo>;
+
+export const connectionTypeInfo = (type: string): ConnectionTypeInfo | undefined =>
+  (ConnectionTypeInfos as Record<string, ConnectionTypeInfo | undefined>)[type];
+
+export const billableBytes = (type: string, sizeBytes: number, objectCount: number): number => {
+  const min = connectionTypeInfo(type)?.minObjectSizeBytes ?? 0;
+  if (min <= 0) {
+    return sizeBytes;
+  }
+  return Math.max(sizeBytes, objectCount * min);
+};

--- a/packages/yucca-api-client/openapi-specs.json
+++ b/packages/yucca-api-client/openapi-specs.json
@@ -804,6 +804,18 @@
           },
           "repositoryCount": {
             "type": "number"
+          },
+          "sizeBytes": {
+            "type": "number",
+            "description": "Rolled-up storage across this connection’s repositories (RGW size)."
+          },
+          "objectCount": {
+            "type": "number",
+            "description": "Rolled-up object count across this connection’s repositories."
+          },
+          "billableBytes": {
+            "type": "number",
+            "description": "Billed bytes: per-object min-size floor applied (immich exempt)."
           }
         },
         "required": [
@@ -811,7 +823,10 @@
           "type",
           "name",
           "createdAt",
-          "repositoryCount"
+          "repositoryCount",
+          "sizeBytes",
+          "objectCount",
+          "billableBytes"
         ]
       },
       "ConnectionListResponseDto": {

--- a/packages/yucca-api-client/src/fetch-client.ts
+++ b/packages/yucca-api-client/src/fetch-client.ts
@@ -63,6 +63,12 @@ export type ConnectionDto = {
     createdAt: string;
     lastSeenAt?: string | null;
     repositoryCount: number;
+    /** Rolled-up storage across this connection’s repositories (RGW size). */
+    sizeBytes: number;
+    /** Rolled-up object count across this connection’s repositories. */
+    objectCount: number;
+    /** Billed bytes: per-object min-size floor applied (immich exempt). */
+    billableBytes: number;
 };
 export type ConnectionListResponseDto = {
     connections: ConnectionDto[];

--- a/packages/yucca-api/src/dto/connection.dto.ts
+++ b/packages/yucca-api/src/dto/connection.dto.ts
@@ -20,6 +20,15 @@ export class ConnectionDto {
 
   @ApiProperty()
   repositoryCount!: number;
+
+  @ApiProperty({ description: 'Rolled-up storage across this connection’s repositories (RGW size).' })
+  sizeBytes!: number;
+
+  @ApiProperty({ description: 'Rolled-up object count across this connection’s repositories.' })
+  objectCount!: number;
+
+  @ApiProperty({ description: 'Billed bytes: per-object min-size floor applied (immich exempt).' })
+  billableBytes!: number;
 }
 
 export class ConnectionListResponseDto {

--- a/packages/yucca-api/src/repositories/connection.repository.ts
+++ b/packages/yucca-api/src/repositories/connection.repository.ts
@@ -29,7 +29,9 @@ export class ConnectionRepository {
   getByUserWithRepositoryCounts(userId: string) {
     return this.db
       .selectFrom('connections')
+      .leftJoin('connectionMetrics', 'connectionMetrics.connectionId', 'connections.id')
       .selectAll('connections')
+      .select(['connectionMetrics.sizeBytes', 'connectionMetrics.objectCount', 'connectionMetrics.billableBytes'])
       .select((eb) =>
         eb
           .selectFrom('repositories')

--- a/packages/yucca-api/src/schema/index.ts
+++ b/packages/yucca-api/src/schema/index.ts
@@ -1,5 +1,6 @@
 import { Database } from '@immich/sql-tools';
 import { ConnectionTable } from './tables/connection.table';
+import { ConnectionMetricsTable } from './tables/connectionMetrics.table';
 import { RepositoryTable } from './tables/repository.table';
 import { RepositoryMeterTable } from './tables/repositoryMeter.table';
 import { RepositoryMeterHistoryTable } from './tables/repositoryMeterHistory.table';
@@ -17,6 +18,7 @@ export class ImmichDatabase {
     SessionTable,
     UserTable,
     ConnectionTable,
+    ConnectionMetricsTable,
     RepositoryTable,
     RepositoryMetricsTable,
     RepositoryMetricsHistoryTable,
@@ -36,6 +38,7 @@ export interface DB {
   users: UserTable;
   sessions: SessionTable;
   connections: ConnectionTable;
+  connectionMetrics: ConnectionMetricsTable;
   repositories: RepositoryTable;
   repositoryMetrics: RepositoryMetricsTable;
   repositoryMetricsHistory: RepositoryMetricsHistoryTable;

--- a/packages/yucca-api/src/schema/migrations/20260728120000-AddConnectionMetrics.ts
+++ b/packages/yucca-api/src/schema/migrations/20260728120000-AddConnectionMetrics.ts
@@ -1,0 +1,18 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE TABLE "connectionMetrics" (
+  "connectionId" uuid NOT NULL,
+  "sizeBytes" bigint NOT NULL,
+  "objectCount" bigint NOT NULL,
+  "billableBytes" bigint NOT NULL,
+  "repositoryCount" integer NOT NULL,
+  "updatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "connectionMetrics_connectionId_fkey" FOREIGN KEY ("connectionId") REFERENCES "connections" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT "connectionMetrics_pkey" PRIMARY KEY ("connectionId")
+);`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP TABLE "connectionMetrics";`.execute(db);
+}

--- a/packages/yucca-api/src/schema/tables/connectionMetrics.table.ts
+++ b/packages/yucca-api/src/schema/tables/connectionMetrics.table.ts
@@ -1,0 +1,23 @@
+import { Column, ForeignKeyColumn, type Generated, Table } from '@immich/sql-tools';
+import { ConnectionTable } from './connection.table';
+
+@Table({ name: 'connectionMetrics' })
+export class ConnectionMetricsTable {
+  @ForeignKeyColumn(() => ConnectionTable, { primary: true, onUpdate: 'CASCADE', onDelete: 'CASCADE' })
+  connectionId!: string;
+
+  @Column({ type: 'bigint' })
+  sizeBytes!: number;
+
+  @Column({ type: 'bigint' })
+  objectCount!: number;
+
+  @Column({ type: 'bigint' })
+  billableBytes!: number;
+
+  @Column({ type: 'integer' })
+  repositoryCount!: number;
+
+  @Column({ type: 'timestamp with time zone', default: () => 'now()' })
+  updatedAt!: Generated<Date>;
+}

--- a/packages/yucca-api/src/services/connection.service.ts
+++ b/packages/yucca-api/src/services/connection.service.ts
@@ -22,7 +22,13 @@ export class ConnectionService {
   async list(auth: AuthDto): Promise<ConnectionListResponseDto> {
     const rows = await this.connections.getByUserWithRepositoryCounts(auth.id);
     return {
-      connections: rows.map((row) => ({ ...row, repositoryCount: Number(row.repositoryCount ?? 0) })),
+      connections: rows.map((row) => ({
+        ...row,
+        repositoryCount: Number(row.repositoryCount ?? 0),
+        sizeBytes: Number(row.sizeBytes ?? 0),
+        objectCount: Number(row.objectCount ?? 0),
+        billableBytes: Number(row.billableBytes ?? 0),
+      })),
     };
   }
 
@@ -43,7 +49,7 @@ export class ConnectionService {
       throw new FeatureNotEnabledException(flag);
     }
     const connection = await this.connections.create({ userId: auth.id, type: dto.type, name: dto.name });
-    return { connection: { ...connection, repositoryCount: 0 } };
+    return { connection: { ...connection, repositoryCount: 0, sizeBytes: 0, objectCount: 0, billableBytes: 0 } };
   }
 
   async update(auth: AuthDto, id: string, dto: ConnectionUpdateRequestDto) {

--- a/packages/yucca-metrics-worker/src/app.module.ts
+++ b/packages/yucca-metrics-worker/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
 import { KyselyModule } from 'nestjs-kysely';
+import { ConnectionMetricsRepository } from './repositories/connectionMetrics.repository';
 import { MeterRepository } from './repositories/meter.repository';
 import { RepositoryRepository } from './repositories/repository.repository';
 import { RgwFleetRepository } from './repositories/rgwFleet.repository';
@@ -22,6 +23,7 @@ export const providers = [
   RgwFleetRepository,
   MeterRepository,
   RepositoryRepository,
+  ConnectionMetricsRepository,
   MetricsService,
   TopologyService,
   { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },

--- a/packages/yucca-metrics-worker/src/repositories/connectionMetrics.repository.ts
+++ b/packages/yucca-metrics-worker/src/repositories/connectionMetrics.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { Kysely, sql } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { DB } from 'src/schema';
+
+export type ConnectionRollup = {
+  connectionId: string;
+  type: string;
+  sizeBytes: number;
+  objectCount: number;
+  repositoryCount: number;
+};
+
+type ConnectionMetric = {
+  connectionId: string;
+  sizeBytes: number;
+  objectCount: number;
+  billableBytes: number;
+  repositoryCount: number;
+};
+
+@Injectable()
+export class ConnectionMetricsRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
+
+  async getRollups(): Promise<ConnectionRollup[]> {
+    const rows = await this.db
+      .selectFrom('connections')
+      .leftJoin('repositories', 'repositories.connectionId', 'connections.id')
+      .leftJoin('repositoryMeter', 'repositoryMeter.repositoryId', 'repositories.id')
+      .select(({ fn }) => [
+        'connections.id as connectionId',
+        'connections.type as type',
+        fn.coalesce(fn.sum('repositoryMeter.sizeBytes'), sql<string>`0`).as('sizeBytes'),
+        fn.coalesce(fn.sum('repositoryMeter.objectCount'), sql<string>`0`).as('objectCount'),
+        fn.count('repositories.id').as('repositoryCount'),
+      ])
+      .groupBy(['connections.id', 'connections.type'])
+      .execute();
+
+    return rows.map((row) => ({
+      connectionId: row.connectionId,
+      type: row.type,
+      sizeBytes: Number(row.sizeBytes),
+      objectCount: Number(row.objectCount),
+      repositoryCount: Number(row.repositoryCount),
+    }));
+  }
+
+  upsert({ connectionId, sizeBytes, objectCount, billableBytes, repositoryCount }: ConnectionMetric) {
+    return this.db
+      .insertInto('connectionMetrics')
+      .values({ connectionId, sizeBytes, objectCount, billableBytes, repositoryCount, updatedAt: new Date() })
+      .onConflict((oc) =>
+        oc
+          .column('connectionId')
+          .doUpdateSet({ sizeBytes, objectCount, billableBytes, repositoryCount, updatedAt: new Date() }),
+      )
+      .execute();
+  }
+}

--- a/packages/yucca-metrics-worker/src/services/billing.spec.ts
+++ b/packages/yucca-metrics-worker/src/services/billing.spec.ts
@@ -1,0 +1,32 @@
+import { billableBytes } from '@common/server';
+
+const MIB = 1 << 20;
+
+describe('billableBytes (storage-tier billing floor)', () => {
+  it('bills immich at raw size (no per-object floor)', () => {
+    expect(billableBytes('immich', 10 * MIB, 1000)).toBe(10 * MIB);
+    expect(billableBytes('immich', 1024, 500)).toBe(1024);
+  });
+
+  it('floors small restic objects at 1 MiB each', () => {
+    expect(billableBytes('restic', 1024, 100)).toBe(100 * MIB);
+  });
+
+  it('passes restic through when actual size already exceeds the floor', () => {
+    expect(billableBytes('restic', 500 * MIB, 100)).toBe(500 * MIB);
+  });
+
+  it('takes the larger of size and floor at the boundary', () => {
+    expect(billableBytes('restic', 100 * MIB, 100)).toBe(100 * MIB);
+    expect(billableBytes('restic', 100 * MIB + 1, 100)).toBe(100 * MIB + 1);
+  });
+
+  it('treats an empty repository as zero', () => {
+    expect(billableBytes('restic', 0, 0)).toBe(0);
+    expect(billableBytes('immich', 0, 0)).toBe(0);
+  });
+
+  it('treats an unknown type as un-floored (raw size)', () => {
+    expect(billableBytes('mystery', 1024, 100)).toBe(1024);
+  });
+});

--- a/packages/yucca-metrics-worker/src/services/metrics.service.spec.ts
+++ b/packages/yucca-metrics-worker/src/services/metrics.service.spec.ts
@@ -19,6 +19,11 @@ describe(MetricsService.name, () => {
     getGauge: jest.fn((name: string) => (name === 'rgw_repository_size_bytes' ? sizeGauge : objectGauge)),
   };
 
+  const connectionMetrics = {
+    getRollups: jest.fn().mockResolvedValue([]),
+    upsert: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -56,6 +61,7 @@ describe(MetricsService.name, () => {
       fleet as never,
       meter as never,
       repositories as never,
+      connectionMetrics as never,
       metricService as never,
     );
     await service.sync();
@@ -84,6 +90,7 @@ describe(MetricsService.name, () => {
       fleet as never,
       meter as never,
       repositories as never,
+      connectionMetrics as never,
       metricService as never,
     );
 

--- a/packages/yucca-metrics-worker/src/services/metrics.service.ts
+++ b/packages/yucca-metrics-worker/src/services/metrics.service.ts
@@ -1,8 +1,10 @@
+import { billableBytes } from '@common/server';
 import { LoggerRepository, MetricService } from '@common/server/otel';
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Gauge } from '@opentelemetry/api';
 import { env } from 'src/env';
+import { ConnectionMetricsRepository } from 'src/repositories/connectionMetrics.repository';
 import { MeterRepository } from 'src/repositories/meter.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { RgwFleetRepository } from 'src/repositories/rgwFleet.repository';
@@ -11,12 +13,14 @@ import { RgwFleetRepository } from 'src/repositories/rgwFleet.repository';
 export class MetricsService implements OnApplicationBootstrap {
   private readonly repositorySizeBytes: Gauge;
   private readonly repositoryObjectCount: Gauge;
+  private readonly connectionBillableBytes: Gauge;
 
   constructor(
     private logger: LoggerRepository,
     private fleet: RgwFleetRepository,
     private meter: MeterRepository,
     private repositories: RepositoryRepository,
+    private connectionMetrics: ConnectionMetricsRepository,
     metricService: MetricService,
   ) {
     this.repositorySizeBytes = metricService.getGauge('rgw_repository_size_bytes', {
@@ -24,6 +28,9 @@ export class MetricsService implements OnApplicationBootstrap {
     });
     this.repositoryObjectCount = metricService.getGauge('rgw_repository_object_count', {
       description: 'Number of objects in the repository',
+    });
+    this.connectionBillableBytes = metricService.getGauge('connection_billable_bytes', {
+      description: 'Billable bytes rolled up per connection (min-object-size floor applied)',
     });
   }
 
@@ -100,5 +107,27 @@ export class MetricsService implements OnApplicationBootstrap {
         this.logger.error(error, `Failed to sync metrics from RadosGW cluster ${clusterCode}`);
       }
     }
+
+    await this.rollupConnections();
+  }
+
+  private async rollupConnections() {
+    const rollups = await this.connectionMetrics.getRollups();
+
+    for (const { connectionId, type, sizeBytes, objectCount, repositoryCount } of rollups) {
+      const billable = billableBytes(type, sizeBytes, objectCount);
+
+      await this.connectionMetrics.upsert({
+        connectionId,
+        sizeBytes,
+        objectCount,
+        billableBytes: billable,
+        repositoryCount,
+      });
+
+      this.connectionBillableBytes.record(billable, { connectionId, connectionType: type });
+    }
+
+    this.logger.info(`Rolled up ${rollups.length} connections`);
   }
 }


### PR DESCRIPTION
billable bytes per connection with a min-object-size floor for non-immich types

- `main` <!-- branch-stack -->
  - \#389
    - \#390
      - \#391 :point\_left:
        - \#392
          - \#394
            - \#412
