### PR TITLE
feat(yucca): self-serve restic

### DIFF
--- a/packages/e2e/test/yucca-api.spec.ts
+++ b/packages/e2e/test/yucca-api.spec.ts
@@ -123,7 +123,7 @@ describe('Repository', () => {
   });
 
   it('should generate usable URL for restic', async () => {
-    const { url } = await createResticUrl(repository.id, requestOpts);
+    const { url } = await createResticUrl(repository.id, {}, requestOpts);
     await init().repository(url).insecureNoPassword().run();
   });
 });

--- a/packages/yucca-api-client/openapi-specs.json
+++ b/packages/yucca-api-client/openapi-specs.json
@@ -193,6 +193,37 @@
         ]
       }
     },
+    "/api/connections/restic": {
+      "post": {
+        "operationId": "createRestic",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectionResticRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionResticResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Connection"
+        ]
+      }
+    },
     "/api/connections/{id}": {
       "patch": {
         "operationId": "updateConnection",
@@ -592,6 +623,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResticUrlRequestDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",
@@ -606,6 +647,59 @@
         },
         "tags": [
           "Repository"
+        ]
+      }
+    },
+    "/api/repository/{id}/restic-tokens": {
+      "get": {
+        "operationId": "listResticTokens",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResticTokenListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Repository"
+        ]
+      }
+    },
+    "/api/restic-tokens/{jti}": {
+      "delete": {
+        "operationId": "revoke",
+        "parameters": [
+          {
+            "name": "jti",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "ResticToken"
         ]
       }
     }
@@ -873,6 +967,139 @@
           "connection"
         ]
       },
+      "ConnectionResticRequestDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Repository name (defaults to a generated one)."
+          },
+          "worm": {
+            "type": "boolean",
+            "description": "Enable write-once (WORM) on the repository."
+          },
+          "expiresIn": {
+            "type": "string",
+            "description": "Token lifetime (e.g. \"90d\"), capped at RESTIC_JWT_MAX_EXPIRES_IN."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human label for the minted access key."
+          }
+        }
+      },
+      "RepositoryMetricsDto": {
+        "type": "object",
+        "properties": {
+          "lastBackup": {
+            "type": "string"
+          },
+          "lastSuccessfulBackup": {
+            "type": "string"
+          },
+          "lastBackupDuration": {
+            "type": "number"
+          },
+          "sizeBytes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "sizeBytes"
+        ]
+      },
+      "RepositoryMeterDto": {
+        "type": "object",
+        "properties": {
+          "sizeBytes": {
+            "type": "number"
+          },
+          "objectCount": {
+            "type": "number"
+          },
+          "lastUpdated": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sizeBytes",
+          "objectCount"
+        ]
+      },
+      "RepositoryWithMetricsDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "worm": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "siteCode": {
+            "type": "string",
+            "nullable": true,
+            "description": "Stable internal site code the repository lives in"
+          },
+          "storageClusterCode": {
+            "type": "string",
+            "nullable": true,
+            "description": "Stable, globally unique internal storage cluster code"
+          },
+          "connectionId": {
+            "type": "string"
+          },
+          "connectionType": {
+            "type": "string"
+          },
+          "metrics": {
+            "$ref": "#/components/schemas/RepositoryMetricsDto"
+          },
+          "meter": {
+            "$ref": "#/components/schemas/RepositoryMeterDto"
+          }
+        },
+        "required": [
+          "id",
+          "worm",
+          "name",
+          "siteCode",
+          "storageClusterCode",
+          "connectionId",
+          "connectionType",
+          "metrics"
+        ]
+      },
+      "ConnectionResticResponseDto": {
+        "type": "object",
+        "properties": {
+          "connection": {
+            "$ref": "#/components/schemas/ConnectionDto"
+          },
+          "repository": {
+            "$ref": "#/components/schemas/RepositoryWithMetricsDto"
+          },
+          "url": {
+            "type": "string",
+            "description": "rest: URL with the embedded restic JWT."
+          },
+          "jti": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "connection",
+          "repository",
+          "url",
+          "jti",
+          "expiresAt"
+        ]
+      },
       "ConnectionUpdateRequestDto": {
         "type": "object",
         "properties": {
@@ -1004,95 +1231,15 @@
           "site": {
             "type": "string",
             "description": "Internal site code from /meta; defaults to default_site"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "Owned connection to create the repository under (defaults to the session/default connection)."
           }
         },
         "required": [
           "name",
           "worm"
-        ]
-      },
-      "RepositoryMetricsDto": {
-        "type": "object",
-        "properties": {
-          "lastBackup": {
-            "type": "string"
-          },
-          "lastSuccessfulBackup": {
-            "type": "string"
-          },
-          "lastBackupDuration": {
-            "type": "number"
-          },
-          "sizeBytes": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "sizeBytes"
-        ]
-      },
-      "RepositoryMeterDto": {
-        "type": "object",
-        "properties": {
-          "sizeBytes": {
-            "type": "number"
-          },
-          "objectCount": {
-            "type": "number"
-          },
-          "lastUpdated": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "sizeBytes",
-          "objectCount"
-        ]
-      },
-      "RepositoryWithMetricsDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "worm": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": "string"
-          },
-          "siteCode": {
-            "type": "string",
-            "nullable": true,
-            "description": "Stable internal site code the repository lives in"
-          },
-          "storageClusterCode": {
-            "type": "string",
-            "nullable": true,
-            "description": "Stable, globally unique internal storage cluster code"
-          },
-          "connectionId": {
-            "type": "string"
-          },
-          "connectionType": {
-            "type": "string"
-          },
-          "metrics": {
-            "$ref": "#/components/schemas/RepositoryMetricsDto"
-          },
-          "meter": {
-            "$ref": "#/components/schemas/RepositoryMeterDto"
-          }
-        },
-        "required": [
-          "id",
-          "worm",
-          "name",
-          "siteCode",
-          "storageClusterCode",
-          "connectionId",
-          "connectionType",
-          "metrics"
         ]
       },
       "RepositoryCreateResponseDto": {
@@ -1153,15 +1300,92 @@
           "repository"
         ]
       },
+      "ResticUrlRequestDto": {
+        "type": "object",
+        "properties": {
+          "expiresIn": {
+            "type": "string",
+            "description": "Token lifetime (e.g. \"90d\"). Revocable connection types only; defaults to RESTIC_JWT_EXPIRES_IN, capped at RESTIC_JWT_MAX_EXPIRES_IN."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human label for this access key (shown in the token list)."
+          }
+        }
+      },
       "RepositoryCreateResticUrlDto": {
         "type": "object",
         "properties": {
           "url": {
+            "type": "string",
+            "description": "rest: URL with the embedded restic JWT; paste into `restic -r`."
+          },
+          "jti": {
+            "type": "string",
+            "description": "The minted token id, for revocation."
+          },
+          "expiresAt": {
             "type": "string"
           }
         },
         "required": [
-          "url"
+          "url",
+          "jti",
+          "expiresAt"
+        ]
+      },
+      "ResticTokenDto": {
+        "type": "object",
+        "properties": {
+          "jti": {
+            "type": "string"
+          },
+          "repositoryId": {
+            "type": "string"
+          },
+          "connectionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "mintedBy": {
+            "type": "string",
+            "description": "'user' or 'admin'"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresAt": {
+            "type": "string"
+          },
+          "revokedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "jti",
+          "repositoryId",
+          "mintedBy",
+          "expiresAt",
+          "createdAt"
+        ]
+      },
+      "ResticTokenListResponseDto": {
+        "type": "object",
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResticTokenDto"
+            }
+          }
+        },
+        "required": [
+          "tokens"
         ]
       }
     }

--- a/packages/yucca-api-client/src/fetch-client.ts
+++ b/packages/yucca-api-client/src/fetch-client.ts
@@ -80,6 +80,48 @@ export type ConnectionCreateRequestDto = {
 export type ConnectionResponseDto = {
     connection: ConnectionDto;
 };
+export type ConnectionResticRequestDto = {
+    /** Repository name (defaults to a generated one). */
+    name?: string;
+    /** Enable write-once (WORM) on the repository. */
+    worm?: boolean;
+    /** Token lifetime (e.g. "90d"), capped at RESTIC_JWT_MAX_EXPIRES_IN. */
+    expiresIn?: string;
+    /** Human label for the minted access key. */
+    label?: string;
+};
+export type RepositoryMetricsDto = {
+    lastBackup?: string;
+    lastSuccessfulBackup?: string;
+    lastBackupDuration?: number;
+    sizeBytes: number;
+};
+export type RepositoryMeterDto = {
+    sizeBytes: number;
+    objectCount: number;
+    lastUpdated?: string;
+};
+export type RepositoryWithMetricsDto = {
+    id: string;
+    worm: boolean;
+    name: string;
+    /** Stable internal site code the repository lives in */
+    siteCode: string | null;
+    /** Stable, globally unique internal storage cluster code */
+    storageClusterCode: string | null;
+    connectionId: string;
+    connectionType: string;
+    metrics: RepositoryMetricsDto;
+    meter?: RepositoryMeterDto;
+};
+export type ConnectionResticResponseDto = {
+    connection: ConnectionDto;
+    repository: RepositoryWithMetricsDto;
+    /** rest: URL with the embedded restic JWT. */
+    url: string;
+    jti: string;
+    expiresAt: string;
+};
 export type ConnectionUpdateRequestDto = {
     name: string;
 };
@@ -117,30 +159,8 @@ export type RepositoryCreateRequestDto = {
     worm: boolean;
     /** Internal site code from /meta; defaults to default_site */
     site?: string;
-};
-export type RepositoryMetricsDto = {
-    lastBackup?: string;
-    lastSuccessfulBackup?: string;
-    lastBackupDuration?: number;
-    sizeBytes: number;
-};
-export type RepositoryMeterDto = {
-    sizeBytes: number;
-    objectCount: number;
-    lastUpdated?: string;
-};
-export type RepositoryWithMetricsDto = {
-    id: string;
-    worm: boolean;
-    name: string;
-    /** Stable internal site code the repository lives in */
-    siteCode: string | null;
-    /** Stable, globally unique internal storage cluster code */
-    storageClusterCode: string | null;
-    connectionId: string;
-    connectionType: string;
-    metrics: RepositoryMetricsDto;
-    meter?: RepositoryMeterDto;
+    /** Owned connection to create the repository under (defaults to the session/default connection). */
+    connectionId?: string;
 };
 export type RepositoryCreateResponseDto = {
     repository: RepositoryWithMetricsDto;
@@ -158,8 +178,32 @@ export type RepositoryUpdateRequestDto = {
 export type RepositoryUpdateResponseDto = {
     repository: RepositoryWithMetricsDto;
 };
+export type ResticUrlRequestDto = {
+    /** Token lifetime (e.g. "90d"). Revocable connection types only; defaults to RESTIC_JWT_EXPIRES_IN, capped at RESTIC_JWT_MAX_EXPIRES_IN. */
+    expiresIn?: string;
+    /** Human label for this access key (shown in the token list). */
+    label?: string;
+};
 export type RepositoryCreateResticUrlDto = {
+    /** rest: URL with the embedded restic JWT; paste into `restic -r`. */
     url: string;
+    /** The minted token id, for revocation. */
+    jti: string;
+    expiresAt: string;
+};
+export type ResticTokenDto = {
+    jti: string;
+    repositoryId: string;
+    connectionId?: string | null;
+    /** 'user' or 'admin' */
+    mintedBy: string;
+    label?: string | null;
+    expiresAt: string;
+    revokedAt?: string | null;
+    createdAt: string;
+};
+export type ResticTokenListResponseDto = {
+    tokens: ResticTokenDto[];
 };
 export function getAuth(opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
@@ -225,6 +269,16 @@ export function createConnection(connectionCreateRequestDto: ConnectionCreateReq
         ...opts,
         method: "POST",
         body: connectionCreateRequestDto
+    })));
+}
+export function createRestic(connectionResticRequestDto: ConnectionResticRequestDto, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: ConnectionResticResponseDto;
+    }>("/api/connections/restic", oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: connectionResticRequestDto
     })));
 }
 export function updateConnection(id: string, connectionUpdateRequestDto: ConnectionUpdateRequestDto, opts?: Oazapfts.RequestOpts) {
@@ -330,12 +384,27 @@ export function deleteRepository(id: string, opts?: Oazapfts.RequestOpts) {
         method: "DELETE"
     }));
 }
-export function createResticUrl(id: string, opts?: Oazapfts.RequestOpts) {
+export function createResticUrl(id: string, resticUrlRequestDto: ResticUrlRequestDto, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: RepositoryCreateResticUrlDto;
-    }>(`/api/repository/${encodeURIComponent(id)}/restic`, {
+    }>(`/api/repository/${encodeURIComponent(id)}/restic`, oazapfts.json({
         ...opts,
-        method: "POST"
+        method: "POST",
+        body: resticUrlRequestDto
+    })));
+}
+export function listResticTokens(id: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: ResticTokenListResponseDto;
+    }>(`/api/repository/${encodeURIComponent(id)}/restic-tokens`, {
+        ...opts
+    }));
+}
+export function revoke(jti: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchText(`/api/restic-tokens/${encodeURIComponent(jti)}`, {
+        ...opts,
+        method: "DELETE"
     }));
 }

--- a/packages/yucca-api/package.json
+++ b/packages/yucca-api/package.json
@@ -35,6 +35,7 @@
     "kysely": "catalog:",
     "kysely-postgres-js": "catalog:",
     "luxon": "catalog:",
+    "ms": "catalog:",
     "nestjs-kysely": "catalog:",
     "openid-client": "catalog:",
     "postgres": "catalog:",

--- a/packages/yucca-api/src/app.module.ts
+++ b/packages/yucca-api/src/app.module.ts
@@ -4,11 +4,12 @@ import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
 import { KyselyModule } from 'nestjs-kysely';
 import { AuthController } from './controllers/auth.controller';
-import { MetaController } from './controllers/meta.controller';
 import { ConnectionController } from './controllers/connection.controller';
 import { IntrospectionController } from './controllers/introspection.controller';
+import { MetaController } from './controllers/meta.controller';
 import { MetricsController } from './controllers/metrics.controller';
 import { RepositoryController } from './controllers/repository.controller';
+import { ResticTokenController } from './controllers/resticToken.controller';
 import { env } from './env';
 import { AuthGuard } from './middleware/auth.guard';
 import { ConnectionRepository } from './repositories/connection.repository';
@@ -29,10 +30,11 @@ import { UserAllowlistRepository } from './repositories/userAllowlist.repository
 import { AuthService } from './services/auth.service';
 import { ConnectionService } from './services/connection.service';
 import { DatabaseService } from './services/database.service';
-import { MetaService } from './services/meta.service';
 import { IntrospectionService } from './services/introspection.service';
+import { MetaService } from './services/meta.service';
 import { MetricsService } from './services/metrics.service';
 import { RepositoryService } from './services/repository.service';
+import { ResticTokenService } from './services/resticToken.service';
 import { TopologyService } from './services/topology.service';
 import { getKyselyConfig } from './utils/database';
 
@@ -52,6 +54,7 @@ export const controllers = [
   IntrospectionController,
   MetricsController,
   RepositoryController,
+  ResticTokenController,
 ];
 
 export const providers = [
@@ -60,10 +63,8 @@ export const providers = [
   StorageRepository,
   TopologyRepository,
   SettingsRepository,
-  ConnectionRepository,
   DatabaseRepository,
-  ResticTokenRepository,
-  RevocationRepository,
+  ConnectionRepository,
   CryptoRepository,
   OidcRepository,
   UserRepository,
@@ -71,15 +72,18 @@ export const providers = [
   RepositoryRepository,
   RepositoryMetricsRepository,
   RepositoryMetricsHistoryRepository,
+  ResticTokenRepository,
+  RevocationRepository,
   SessionRepository,
+  ConnectionService,
+  IntrospectionService,
   DatabaseService,
   MetaService,
   TopologyService,
   MetricsService,
   RepositoryService,
+  ResticTokenService,
   AuthService,
-  ConnectionService,
-  IntrospectionService,
   { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },
   { provide: APP_GUARD, useClass: AuthGuard },
 ];

--- a/packages/yucca-api/src/controllers/connection.controller.ts
+++ b/packages/yucca-api/src/controllers/connection.controller.ts
@@ -6,6 +6,8 @@ import {
   ConnectionCreateRequestDto,
   ConnectionListResponseDto,
   ConnectionResponseDto,
+  ConnectionResticRequestDto,
+  ConnectionResticResponseDto,
   ConnectionUpdateRequestDto,
 } from 'src/dto/connection.dto';
 import { Auth, AuthRoute } from 'src/middleware/auth.guard';
@@ -27,6 +29,13 @@ export class ConnectionController {
   @ApiOkResponse({ type: ConnectionResponseDto })
   createConnection(@Auth() auth: AuthDto, @Body() dto: ConnectionCreateRequestDto): Promise<ConnectionResponseDto> {
     return this.connections.create(auth, dto);
+  }
+
+  @Post('/restic')
+  @AuthRoute()
+  @ApiOkResponse({ type: ConnectionResticResponseDto })
+  createRestic(@Auth() auth: AuthDto, @Body() dto: ConnectionResticRequestDto): Promise<ConnectionResticResponseDto> {
+    return this.connections.createRestic(auth, dto);
   }
 
   @Patch('/:id')

--- a/packages/yucca-api/src/controllers/repository.controller.ts
+++ b/packages/yucca-api/src/controllers/repository.controller.ts
@@ -9,6 +9,8 @@ import {
   RepositoryListResponseDto,
   RepositoryUpdateRequestDto,
   RepositoryUpdateResponseDto,
+  ResticTokenListResponseDto,
+  ResticUrlRequestDto,
 } from 'src/dto/repository.dto';
 import { Auth, AuthRoute } from 'src/middleware/auth.guard';
 import { RepositoryService } from 'src/services/repository.service';
@@ -59,8 +61,19 @@ export class RepositoryController {
   @Post('/:id/restic')
   @AuthRoute()
   @ApiOkResponse({ type: RepositoryCreateResticUrlDto })
-  async createResticUrl(@Auth() auth: AuthDto, @Param('id') id: string): Promise<RepositoryCreateResticUrlDto> {
-    return this.repository.createUrl(auth, id);
+  async createResticUrl(
+    @Auth() auth: AuthDto,
+    @Param('id') id: string,
+    @Body() dto: ResticUrlRequestDto,
+  ): Promise<RepositoryCreateResticUrlDto> {
+    return this.repository.createUrl(auth, id, dto);
+  }
+
+  @Get('/:id/restic-tokens')
+  @AuthRoute()
+  @ApiOkResponse({ type: ResticTokenListResponseDto })
+  listResticTokens(@Auth() auth: AuthDto, @Param('id') id: string): Promise<ResticTokenListResponseDto> {
+    return this.repository.listResticTokens(auth, id);
   }
 
   @Delete('/:id')

--- a/packages/yucca-api/src/controllers/resticToken.controller.ts
+++ b/packages/yucca-api/src/controllers/resticToken.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Delete, HttpCode, HttpStatus, Param } from '@nestjs/common';
+import { AuthDto } from 'src/dto/auth.dto';
+import { Auth, AuthRoute } from 'src/middleware/auth.guard';
+import { ResticTokenService } from 'src/services/resticToken.service';
+
+@Controller('/restic-tokens')
+export class ResticTokenController {
+  constructor(private readonly resticTokens: ResticTokenService) {}
+
+  @Delete('/:jti')
+  @AuthRoute()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  revoke(@Auth() auth: AuthDto, @Param('jti') jti: string): Promise<void> {
+    return this.resticTokens.revoke(auth, jti);
+  }
+}

--- a/packages/yucca-api/src/dto/connection.dto.ts
+++ b/packages/yucca-api/src/dto/connection.dto.ts
@@ -1,6 +1,7 @@
 import { ConnectionTypes } from '@common/server';
 import { ApiProperty } from '@nestjs/swagger';
-import { ArrayNotEmpty, IsIn, IsString, IsUUID, MaxLength } from 'class-validator';
+import { ArrayNotEmpty, IsBoolean, IsIn, IsOptional, IsString, IsUUID, Matches, MaxLength } from 'class-validator';
+import { RepositoryWithMetricsDto } from 'src/dto/repository.dto';
 
 export class ConnectionDto {
   @ApiProperty()
@@ -64,4 +65,46 @@ export class ConnectionAdoptRequestDto {
   @ArrayNotEmpty()
   @IsUUID(undefined, { each: true })
   repositoryIds!: string[];
+}
+
+export class ConnectionResticRequestDto {
+  @ApiProperty({ required: false, description: 'Repository name (defaults to a generated one).' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  name?: string;
+
+  @ApiProperty({ required: false, description: 'Enable write-once (WORM) on the repository.' })
+  @IsOptional()
+  @IsBoolean()
+  worm?: boolean;
+
+  @ApiProperty({ required: false, description: 'Token lifetime (e.g. "90d"), capped at RESTIC_JWT_MAX_EXPIRES_IN.' })
+  @IsOptional()
+  @MaxLength(20)
+  @Matches(/^\d+\s*(ms|s|m|h|d|w|y)$/i, { message: 'expiresIn must be a duration like "30d", "12h"' })
+  expiresIn?: string;
+
+  @ApiProperty({ required: false, description: 'Human label for the minted access key.' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  label?: string;
+}
+
+export class ConnectionResticResponseDto {
+  @ApiProperty()
+  connection!: ConnectionDto;
+
+  @ApiProperty()
+  repository!: RepositoryWithMetricsDto;
+
+  @ApiProperty({ description: 'rest: URL with the embedded restic JWT.' })
+  url!: string;
+
+  @ApiProperty()
+  jti!: string;
+
+  @ApiProperty({ type: 'string' })
+  expiresAt!: Date;
 }

--- a/packages/yucca-api/src/dto/repository.dto.ts
+++ b/packages/yucca-api/src/dto/repository.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString, IsUUID, Matches, MaxLength } from 'class-validator';
 
 export class RepositoryDto {
   @ApiProperty()
@@ -70,6 +70,14 @@ export class RepositoryCreateRequestDto {
   @IsOptional()
   @IsString()
   site?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Owned connection to create the repository under (defaults to the session/default connection).',
+  })
+  @IsOptional()
+  @IsUUID()
+  connectionId?: string;
 }
 
 export class RepositoryCreateResponseDto {
@@ -104,7 +112,62 @@ export class RepositoryUpdateResponseDto {
   repository!: RepositoryWithMetricsDto;
 }
 
+export class ResticUrlRequestDto {
+  @ApiProperty({
+    required: false,
+    description:
+      'Token lifetime (e.g. "90d"). Revocable connection types only; defaults to RESTIC_JWT_EXPIRES_IN, capped at RESTIC_JWT_MAX_EXPIRES_IN.',
+  })
+  @IsOptional()
+  @MaxLength(20)
+  @Matches(/^\d+\s*(ms|s|m|h|d|w|y)$/i, { message: 'expiresIn must be a duration like "30d", "12h"' })
+  expiresIn?: string;
+
+  @ApiProperty({ required: false, description: 'Human label for this access key (shown in the token list).' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  label?: string;
+}
+
 export class RepositoryCreateResticUrlDto {
-  @ApiProperty()
+  @ApiProperty({ description: 'rest: URL with the embedded restic JWT; paste into `restic -r`.' })
   url!: string;
+
+  @ApiProperty({ description: 'The minted token id, for revocation.' })
+  jti!: string;
+
+  @ApiProperty({ type: 'string' })
+  expiresAt!: Date;
+}
+
+export class ResticTokenDto {
+  @ApiProperty()
+  jti!: string;
+
+  @ApiProperty()
+  repositoryId!: string;
+
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  connectionId!: string | null;
+
+  @ApiProperty({ description: "'user' or 'admin'" })
+  mintedBy!: string;
+
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  label!: string | null;
+
+  @ApiProperty({ type: 'string' })
+  expiresAt!: Date;
+
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  revokedAt!: Date | null;
+
+  @ApiProperty({ type: 'string' })
+  createdAt!: Date;
+}
+
+export class ResticTokenListResponseDto {
+  @ApiProperty({ type: [ResticTokenDto] })
+  tokens!: ResticTokenDto[];
 }

--- a/packages/yucca-api/src/env.ts
+++ b/packages/yucca-api/src/env.ts
@@ -49,6 +49,17 @@ const schema = z.object({
   LEGACY_SITE_CODE: z.string(),
   LEGACY_STORAGE_CLUSTER_CODE: z.string(),
 
+  RESTIC_JWT_EXPIRES_IN: z
+    .string()
+    .regex(/^\d+\s*(ms|s|m|h|d|w|y)$/i, 'Expected a duration like "90d", "8760h"')
+    .default('90d')
+    .transform((value): StringValue => value as StringValue),
+  RESTIC_JWT_MAX_EXPIRES_IN: z
+    .string()
+    .regex(/^\d+\s*(ms|s|m|h|d|w|y)$/i, 'Expected a duration like "365d"')
+    .default('365d')
+    .transform((value): StringValue => value as StringValue),
+
   TOKEN_INTROSPECTION_SECRET: z.string().optional(),
 
   REDIS_URL: z.string().optional(),

--- a/packages/yucca-api/src/repositories/connection.repository.ts
+++ b/packages/yucca-api/src/repositories/connection.repository.ts
@@ -55,6 +55,19 @@ export class ConnectionRepository {
       .executeTakeFirst();
   }
 
+  async getOrCreateByType(userId: string, type: string, name: string) {
+    const existing = await this.db
+      .selectFrom('connections')
+      .selectAll()
+      .where('userId', '=', userId)
+      .where('type', '=', type)
+      .orderBy('createdAt', 'asc')
+      .orderBy('id', 'asc')
+      .executeTakeFirst();
+
+    return existing ?? (await this.create({ userId, type, name }));
+  }
+
   async getOrCreateDefault(userId: string) {
     const existing = await this.db
       .selectFrom('connections')

--- a/packages/yucca-api/src/repositories/resticToken.repository.ts
+++ b/packages/yucca-api/src/repositories/resticToken.repository.ts
@@ -34,6 +34,15 @@ export class ResticTokenRepository {
       .executeTakeFirst();
   }
 
+  getByRepository(repositoryId: string) {
+    return this.db
+      .selectFrom('resticTokens')
+      .select(['jti', 'repositoryId', 'connectionId', 'mintedBy', 'label', 'expiresAt', 'revokedAt', 'createdAt'])
+      .where('repositoryId', '=', repositoryId)
+      .orderBy('createdAt', 'desc')
+      .execute();
+  }
+
   getActiveByRepository(repositoryId: string) {
     return this.db
       .selectFrom('resticTokens')

--- a/packages/yucca-api/src/services/connection.service.ts
+++ b/packages/yucca-api/src/services/connection.service.ts
@@ -6,13 +6,18 @@ import {
   ConnectionCreateRequestDto,
   ConnectionListResponseDto,
   ConnectionResponseDto,
+  ConnectionResticRequestDto,
+  ConnectionResticResponseDto,
   ConnectionUpdateRequestDto,
 } from 'src/dto/connection.dto';
 import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { ResticTokenRepository } from 'src/repositories/resticToken.repository';
 import { RevocationRepository } from 'src/repositories/revocation.repository';
+import { RepositoryService } from 'src/services/repository.service';
 import { FeatureNotEnabledException } from 'src/utils/exceptions';
+
+const RESTIC_TYPE = 'restic';
 
 @Injectable({ scope: Scope.REQUEST })
 export class ConnectionService {
@@ -21,6 +26,7 @@ export class ConnectionService {
     private readonly repositories: RepositoryRepository,
     private readonly resticTokens: ResticTokenRepository,
     private readonly revocation: RevocationRepository,
+    private readonly repositoryService: RepositoryService,
   ) {}
 
   async list(auth: AuthDto): Promise<ConnectionListResponseDto> {
@@ -54,6 +60,50 @@ export class ConnectionService {
     }
     const connection = await this.connections.create({ userId: auth.id, type: dto.type, name: dto.name });
     return { connection: { ...connection, repositoryCount: 0, sizeBytes: 0, objectCount: 0, billableBytes: 0 } };
+  }
+
+  async createRestic(auth: AuthDto, dto: ConnectionResticRequestDto): Promise<ConnectionResticResponseDto> {
+    const flag = connectionTypeFlag(RESTIC_TYPE);
+    if (flag && !auth.features[flag]) {
+      throw new FeatureNotEnabledException(flag);
+    }
+
+    const connection = await this.connections.getOrCreateByType(auth.id, RESTIC_TYPE, 'Restic');
+
+    const repository = await this.repositoryService.create(auth, {
+      name: dto.name ?? `restic-${new Date().toISOString().slice(0, 10)}`,
+      worm: dto.worm ?? false,
+      connectionId: connection.id,
+    });
+
+    let minted: { url: string; jti: string; expiresAt: Date };
+    try {
+      minted = await this.repositoryService.createUrl(auth, repository.id, {
+        expiresIn: dto.expiresIn,
+        label: dto.label,
+      });
+    } catch (error) {
+      await this.repositories.delete(repository.id).catch(() => {});
+      throw error;
+    }
+    const { url, jti, expiresAt } = minted;
+
+    const rows = await this.connections.getByUserWithRepositoryCounts(auth.id);
+    const row = rows.find((r) => r.id === connection.id);
+
+    return {
+      connection: {
+        ...connection,
+        repositoryCount: Number(row?.repositoryCount ?? 1),
+        sizeBytes: Number(row?.sizeBytes ?? 0),
+        objectCount: Number(row?.objectCount ?? 0),
+        billableBytes: Number(row?.billableBytes ?? 0),
+      },
+      repository,
+      url,
+      jti,
+      expiresAt,
+    };
   }
 
   async update(auth: AuthDto, id: string, dto: ConnectionUpdateRequestDto) {

--- a/packages/yucca-api/src/services/repository.service.spec.ts
+++ b/packages/yucca-api/src/services/repository.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { AuthDto } from 'src/dto/auth.dto';
+import { env } from 'src/env';
 import { RepositoryService } from 'src/services/repository.service';
 import { Mocks, newMocks } from '../../test/mocks';
 
@@ -67,7 +68,7 @@ describe(RepositoryService.name, () => {
   });
 
   describe('createUrl', () => {
-    it('mints a URL and records the restic token', async () => {
+    it('mints a URL from the site rest_url with a storageCluster claim', async () => {
       mocks.repository.get.mockResolvedValue({
         id: repoId,
         userId: auth.id,
@@ -83,25 +84,21 @@ describe(RepositoryService.name, () => {
       mocks.jwt.decode.mockReturnValue({ exp: 1_700_000_000 });
       mocks.resticTokens.create.mockResolvedValue({} as never);
 
-      const { url } = await sut.createUrl(auth, repoId);
+      const { url, jti } = await sut.createUrl(auth, repoId);
 
       expect(mocks.topology.getSite).toHaveBeenCalledWith('father');
-      expect(mocks.jwt.signAsync).toHaveBeenCalledWith({
-        user: auth.id,
-        repository: repoId,
-        writeOnce: true,
-        storageCluster: 'father-spice',
-        jti: 'jti-x',
-        connection: 'immich',
-      });
-      expect(mocks.resticTokens.create).toHaveBeenCalledWith({
-        jti: 'jti-x',
-        repositoryId: repoId,
-        userId: auth.id,
-        connectionId: 'conn',
-        mintedBy: 'user',
-        expiresAt: new Date(1_700_000_000 * 1000),
-      });
+      expect(mocks.jwt.signAsync).toHaveBeenCalledWith(
+        {
+          user: auth.id,
+          repository: repoId,
+          writeOnce: true,
+          storageCluster: 'father-spice',
+          jti: 'jti-x',
+          connection: 'immich',
+        },
+        { expiresIn: env.JWT_EXPIRES_IN },
+      );
+      expect(jti).toBe('jti-x');
       expect(url).toBe(`rest:https://restic:signed-token@rest.htz-fsn1.backups.futo.cloud/${repoId}`);
     });
   });

--- a/packages/yucca-api/src/services/repository.service.ts
+++ b/packages/yucca-api/src/services/repository.service.ts
@@ -1,14 +1,18 @@
+import { connectionTypeFlag, isRevocableConnectionType } from '@common/server';
 import { WideContextRepository } from '@common/server/otel';
 import { BadRequestException, Injectable, Scope, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import ms, { StringValue } from 'ms';
 import { AuthDto } from 'src/dto/auth.dto';
-import { RepositoryCreateRequestDto, RepositoryUpdateRequestDto } from 'src/dto/repository.dto';
+import { RepositoryCreateRequestDto, RepositoryUpdateRequestDto, ResticUrlRequestDto } from 'src/dto/repository.dto';
+import { env } from 'src/env';
 import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { ResticTokenRepository } from 'src/repositories/resticToken.repository';
 import { RevocationRepository } from 'src/repositories/revocation.repository';
 import { TopologyRepository } from 'src/repositories/topology.repository';
+import { FeatureNotEnabledException } from 'src/utils/exceptions';
 
 @Injectable({ scope: Scope.REQUEST })
 export class RepositoryService {
@@ -23,20 +27,41 @@ export class RepositoryService {
     private readonly revocation: RevocationRepository,
   ) {}
 
+  private requireTypeFlag(auth: AuthDto, connectionType: string) {
+    const flag = connectionTypeFlag(connectionType);
+    if (flag && !auth.features[flag]) {
+      throw new FeatureNotEnabledException(flag);
+    }
+  }
+
   async create(auth: AuthDto, { site: siteCode, ...dto }: RepositoryCreateRequestDto) {
     const site = this.topology.getSite(siteCode);
     const cluster = this.topology.getActiveCluster(site);
 
-    let connectionId = auth.connectionId;
-    if (!connectionId) {
-      const connection = await this.connection.getOrCreateDefault(auth.id);
-      connectionId = connection.id;
+    const { connectionId: requestedConnectionId, ...values } = dto;
+
+    let connection: { id: string; type: string };
+    if (requestedConnectionId) {
+      const owned = await this.connection.getById(requestedConnectionId);
+      if (!owned || owned.userId !== auth.id) {
+        throw new UnauthorizedException();
+      }
+      connection = owned;
+    } else if (auth.connectionId) {
+      const bound = await this.connection.getById(auth.connectionId);
+      if (!bound) {
+        throw new UnauthorizedException();
+      }
+      connection = bound;
+    } else {
+      connection = await this.connection.getOrCreateDefault(auth.id);
     }
+    this.requireTypeFlag(auth, connection.type);
 
     return this.repositoryRepository.create({
       userId: auth.id,
-      connectionId,
-      ...dto,
+      connectionId: connection.id,
+      ...values,
       siteCode: site.code,
       storageClusterCode: cluster.code,
     });
@@ -65,28 +90,42 @@ export class RepositoryService {
     return { repository: await this.repositoryRepository.update(id, dto) };
   }
 
-  async createUrl(auth: AuthDto, id: string) {
+  async createUrl(auth: AuthDto, id: string, opts: ResticUrlRequestDto = {}) {
     const repository = await this.get(auth, id);
+    this.requireTypeFlag(auth, repository.connectionType);
+
+    const revocable = isRevocableConnectionType(repository.connectionType);
+    if (!revocable && opts.expiresIn) {
+      throw new BadRequestException(
+        `Custom expiresIn requires a revocable connection type; ${repository.connectionType} tokens cannot be revoked`,
+      );
+    }
+    const expiresIn = revocable ? this.resolveExpiresIn(opts.expiresIn) : env.JWT_EXPIRES_IN;
 
     const site = this.topology.getSite(repository.siteCode);
     const jti = this.crypto.randomUUID();
-    const token = await this.jwt.signAsync({
-      user: auth.id,
-      repository: repository.id,
-      writeOnce: repository.worm,
-      storageCluster: repository.storageClusterCode,
-      jti,
-      connection: repository.connectionType,
-    });
+    const token = await this.jwt.signAsync(
+      {
+        user: auth.id,
+        repository: repository.id,
+        writeOnce: repository.worm,
+        storageCluster: repository.storageClusterCode,
+        jti,
+        connection: repository.connectionType,
+      },
+      { expiresIn },
+    );
 
     const { exp } = this.jwt.decode<{ exp: number }>(token);
+    const expiresAt = new Date(exp * 1000);
     await this.resticTokens.create({
       jti,
       repositoryId: repository.id,
       userId: auth.id,
       connectionId: repository.connectionId,
       mintedBy: 'user',
-      expiresAt: new Date(exp * 1000),
+      label: opts.label ?? null,
+      expiresAt,
     });
 
     this.wideContext.addContext('repositoryId', repository.id);
@@ -96,7 +135,22 @@ export class RepositoryService {
     url.password = token;
     url.pathname = repository.id;
 
-    return { url: `rest:${url.href}` };
+    return { url: `rest:${url.href}`, jti, expiresAt };
+  }
+
+  private resolveExpiresIn(requested?: string): StringValue {
+    if (!requested) {
+      return env.RESTIC_JWT_EXPIRES_IN;
+    }
+    if (ms(requested as StringValue) > ms(env.RESTIC_JWT_MAX_EXPIRES_IN)) {
+      throw new BadRequestException(`expiresIn exceeds the ${env.RESTIC_JWT_MAX_EXPIRES_IN} cap`);
+    }
+    return requested as StringValue;
+  }
+
+  async listResticTokens(auth: AuthDto, id: string) {
+    await this.get(auth, id); // owner check
+    return { tokens: await this.resticTokens.getByRepository(id) };
   }
 
   async delete(auth: AuthDto, id: string) {

--- a/packages/yucca-api/src/services/resticToken.service.ts
+++ b/packages/yucca-api/src/services/resticToken.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { AuthDto } from 'src/dto/auth.dto';
+import { ResticTokenRepository } from 'src/repositories/resticToken.repository';
+import { RevocationRepository } from 'src/repositories/revocation.repository';
+
+@Injectable()
+export class ResticTokenService {
+  constructor(
+    private readonly resticTokens: ResticTokenRepository,
+    private readonly revocation: RevocationRepository,
+  ) {}
+
+  async revoke(auth: AuthDto, jti: string): Promise<void> {
+    const token = await this.resticTokens.get(jti);
+    if (!token || token.userId !== auth.id) {
+      throw new NotFoundException(`No restic token with jti ${jti}`);
+    }
+
+    await this.resticTokens.revoke(jti, `user:${auth.id}`);
+    await this.revocation.invalidateVerdict(jti);
+  }
+}

--- a/packages/yucca-api/test/introspection.integration-spec.ts
+++ b/packages/yucca-api/test/introspection.integration-spec.ts
@@ -8,7 +8,6 @@ import { controllers, imports, providers } from '../src/app.module';
 import { newMetricServiceMock } from './mocks';
 import { testUtils } from './testUtils';
 
-// The service-to-service token introspection michael calls on cache miss.
 describe('IntrospectionController (e2e)', () => {
   let app: INestApplication<App>;
   let user: { id: string };
@@ -41,15 +40,13 @@ describe('IntrospectionController (e2e)', () => {
   });
 
   const mintToken = async () => {
-    const connection = await testUtils.createConnection(user.id, 'restic', 'manual');
-    const repository = await testUtils.createRepositoryForConnection(user.id, connection.id);
+    await testUtils.setFeatureOverride(user.id, 'connection-restic', true);
     const { body } = await request(app.getHttpServer())
-      .post(`/api/repository/${repository.id}/restic`)
+      .post('/api/connections/restic')
       .set('Cookie', cookie())
+      .send({})
       .expect(201);
-    const jwt = new URL((body.url as string).slice('rest:'.length)).password;
-    const claims = JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString()) as { jti: string };
-    return { jti: claims.jti, repository };
+    return body as { jti: string; repository: { id: string } };
   };
 
   const introspect = (jti: string, withSecret = secret) =>
@@ -68,7 +65,7 @@ describe('IntrospectionController (e2e)', () => {
     const { body: live } = await introspect(jti).expect(200);
     expect(live).toEqual({ active: true });
 
-    await testUtils.revokeResticToken(jti);
+    await request(app.getHttpServer()).delete(`/api/restic-tokens/${jti}`).set('Cookie', cookie()).expect(204);
 
     const { body: revoked } = await introspect(jti).expect(200);
     expect(revoked).toEqual({ active: false });

--- a/packages/yucca-api/test/repository.integration-spec.ts
+++ b/packages/yucca-api/test/repository.integration-spec.ts
@@ -138,7 +138,21 @@ describe('RepositoryController (e2e)', () => {
         url: expect.stringMatching(
           /^rest:http:\/\/restic:[\w-]*\.[\w-]*\.[\w-]*@[\w.:]+\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/?$/,
         ),
+        jti: expect.any(String),
+        expiresAt: expect.any(String),
       });
+
+      const hours = (new Date(body.expiresAt as string).getTime() - Date.now()) / 3_600_000;
+      expect(hours).toBeGreaterThan(23);
+      expect(hours).toBeLessThan(25);
+    });
+
+    it('rejects a custom expiresIn for a non-revocable (immich) repository', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/repository/${repository.id}/restic`)
+        .set('Cookie', `yucca-access-token=${session.accessToken}`)
+        .send({ expiresIn: '30d' })
+        .expect(400);
     });
 
     it('embeds jti + connection claims and records the token', async () => {

--- a/packages/yucca-api/test/restic.integration-spec.ts
+++ b/packages/yucca-api/test/restic.integration-spec.ts
@@ -1,0 +1,226 @@
+import { MetricService } from '@common/server/otel';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Redis } from 'ioredis';
+import { env } from 'src/env';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { controllers, imports, providers } from '../src/app.module';
+import { newMetricServiceMock } from './mocks';
+import { testUtils } from './testUtils';
+
+const decodeClaims = (jwt: string): Record<string, unknown> =>
+  JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString());
+
+const verdictKey = (jti: string) => `yucca:michael:verdict:${jti}`;
+
+const connectRedis = async (): Promise<Redis | null> => {
+  if (!env.REDIS_URL) {
+    return null;
+  }
+  const client = new Redis(env.REDIS_URL, { maxRetriesPerRequest: 1, connectTimeout: 1000, lazyConnect: true });
+  try {
+    await client.connect();
+    await client.ping();
+    return client;
+  } catch {
+    client.disconnect();
+    return null;
+  }
+};
+
+describe('Self-serve restic (e2e)', () => {
+  let app: INestApplication<App>;
+  let user: { id: string };
+  let session: { accessToken: string };
+  let redis: Redis | null;
+
+  const cookie = () => `yucca-access-token=${session.accessToken}`;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports,
+      controllers,
+      providers: [MetricService, ...providers],
+    })
+      .overrideProvider(MetricService)
+      .useValue(newMetricServiceMock())
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('/api');
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    await testUtils.resetDatabase();
+    ({ user, session } = await testUtils.createUser());
+    redis = await connectRedis();
+  });
+
+  afterEach(async () => {
+    redis?.disconnect();
+    await app.close();
+  });
+
+  describe('POST /connections/restic', () => {
+    it('403s without the connection-restic flag', async () => {
+      await request(app.getHttpServer()).post('/api/connections/restic').set('Cookie', cookie()).send({}).expect(403);
+    });
+
+    it('creates a connection + repository + long-lived URL in one shot', async () => {
+      await testUtils.setFeatureOverride(user.id, 'connection-restic', true);
+
+      const { body } = await request(app.getHttpServer())
+        .post('/api/connections/restic')
+        .set('Cookie', cookie())
+        .send({ name: 'laptop', expiresIn: '30d', label: 'my laptop' })
+        .expect(201);
+
+      expect(body.connection).toMatchObject({ type: 'restic', repositoryCount: 1 });
+      expect(body.repository).toMatchObject({ name: 'laptop', connectionType: 'restic' });
+      expect(body.url).toMatch(/^rest:/);
+      expect(body.jti).toEqual(expect.any(String));
+
+      const jwt = new URL(body.url.slice('rest:'.length)).password;
+      expect(decodeClaims(decodeURIComponent(jwt))).toMatchObject({
+        user: user.id,
+        repository: body.repository.id,
+        connection: 'restic',
+        jti: body.jti,
+      });
+
+      const days = (new Date(body.expiresAt).getTime() - Date.now()) / 86_400_000;
+      expect(days).toBeGreaterThan(29.9);
+      expect(days).toBeLessThan(30.1);
+
+      const { body: second } = await request(app.getHttpServer())
+        .post('/api/connections/restic')
+        .set('Cookie', cookie())
+        .send({ name: 'desktop' })
+        .expect(201);
+      expect(second.connection.id).toBe(body.connection.id);
+      expect(second.connection.repositoryCount).toBe(2);
+    });
+
+    it('rejects a TTL above the cap', async () => {
+      await testUtils.setFeatureOverride(user.id, 'connection-restic', true);
+
+      await request(app.getHttpServer())
+        .post('/api/connections/restic')
+        .set('Cookie', cookie())
+        .send({ expiresIn: '400d' })
+        .expect(400);
+    });
+
+    it('defaults to the long-lived restic TTL (revocable type)', async () => {
+      await testUtils.setFeatureOverride(user.id, 'connection-restic', true);
+
+      const { body } = await request(app.getHttpServer())
+        .post('/api/connections/restic')
+        .set('Cookie', cookie())
+        .send({})
+        .expect(201);
+
+      const days = (new Date(body.expiresAt).getTime() - Date.now()) / 86_400_000;
+      expect(days).toBeGreaterThan(89.9);
+      expect(days).toBeLessThan(90.1);
+    });
+  });
+
+  describe('token management', () => {
+    const createRestic = async () => {
+      await testUtils.setFeatureOverride(user.id, 'connection-restic', true);
+      const { body } = await request(app.getHttpServer())
+        .post('/api/connections/restic')
+        .set('Cookie', cookie())
+        .send({ label: 'first' })
+        .expect(201);
+      return body;
+    };
+
+    it('lists a repository’s tokens and revokes them (owner-scoped)', async () => {
+      const created = await createRestic();
+
+      const { body: list } = await request(app.getHttpServer())
+        .get(`/api/repository/${created.repository.id}/restic-tokens`)
+        .set('Cookie', cookie())
+        .expect(200);
+      expect(list.tokens).toEqual([
+        expect.objectContaining({ jti: created.jti, label: 'first', mintedBy: 'user', revokedAt: null }),
+      ]);
+
+      if (redis) {
+        await redis.set(verdictKey(created.jti), '1', 'EX', 300);
+      }
+
+      await request(app.getHttpServer())
+        .delete(`/api/restic-tokens/${created.jti}`)
+        .set('Cookie', cookie())
+        .expect(204);
+
+      const row = await testUtils.getResticToken(created.jti);
+      expect(row!.revokedAt).not.toBeNull();
+      expect(row!.revokedBy).toBe(`user:${user.id}`);
+      if (redis) {
+        expect(await redis.exists(verdictKey(created.jti))).toBe(0);
+      }
+
+      await request(app.getHttpServer())
+        .delete(`/api/restic-tokens/${created.jti}`)
+        .set('Cookie', cookie())
+        .expect(204);
+    });
+
+    it('deleting a repository invalidates its cached verdicts', async () => {
+      const created = await createRestic();
+      if (redis) {
+        await redis.set(verdictKey(created.jti), '1', 'EX', 300);
+      }
+
+      await request(app.getHttpServer())
+        .delete(`/api/repository/${created.repository.id}`)
+        .set('Cookie', cookie())
+        .expect(200);
+
+      if (redis) {
+        expect(await redis.exists(verdictKey(created.jti))).toBe(0);
+      }
+    });
+
+    it('a false override is a kill-switch for new credentials (mint 403s, revoke still works)', async () => {
+      const created = await createRestic();
+
+      await testUtils.setFeatureOverride(user.id, 'connection-restic', false);
+
+      await request(app.getHttpServer())
+        .post(`/api/repository/${created.repository.id}/restic`)
+        .set('Cookie', cookie())
+        .send({})
+        .expect(403);
+
+      await request(app.getHttpServer())
+        .delete(`/api/restic-tokens/${created.jti}`)
+        .set('Cookie', cookie())
+        .expect(204);
+    });
+
+    it("404s revoking another user's token without leaking it", async () => {
+      const created = await createRestic();
+      const other = await testUtils.createUser('other', 'other@example.com', 'other-sub');
+
+      if (redis) {
+        await redis.set(verdictKey(created.jti), '1', 'EX', 300);
+      }
+
+      await request(app.getHttpServer())
+        .delete(`/api/restic-tokens/${created.jti}`)
+        .set('Cookie', `yucca-access-token=${other.session.accessToken}`)
+        .expect(404);
+
+      if (redis) {
+        expect(await redis.exists(verdictKey(created.jti))).toBe(1);
+        await redis.del(verdictKey(created.jti));
+      }
+    });
+  });
+});

--- a/packages/yucca-api/test/testUtils.ts
+++ b/packages/yucca-api/test/testUtils.ts
@@ -20,6 +20,7 @@ function getDb() {
 export const testUtils = {
   resetDatabase: async () => {
     const db = getDb();
+    await db.deleteFrom('resticTokens').execute();
     await db.deleteFrom('repositories').execute();
     await db.deleteFrom('sessions').execute();
     await db.deleteFrom('connections').execute();
@@ -77,6 +78,18 @@ export const testUtils = {
     };
   },
 
+  expireResticToken: async (jti: string) => {
+    await getDb()
+      .updateTable('resticTokens')
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where('jti', '=', jti)
+      .execute();
+  },
+
+  getResticToken: (jti: string) => {
+    return getDb().selectFrom('resticTokens').selectAll().where('jti', '=', jti).executeTakeFirst();
+  },
+
   createConnection: (userId: string, type: string, name: string) => {
     const db = getDb();
     return new ConnectionRepository(db).create({ userId, type, name });
@@ -90,26 +103,6 @@ export const testUtils = {
   ) => {
     const db = getDb();
     return new RepositoryRepository(db).create({ name, worm, userId, connectionId });
-  },
-
-  getResticToken: (jti: string) => {
-    return getDb().selectFrom('resticTokens').selectAll().where('jti', '=', jti).executeTakeFirst();
-  },
-
-  expireResticToken: async (jti: string) => {
-    await getDb()
-      .updateTable('resticTokens')
-      .set({ expiresAt: new Date(Date.now() - 1000) })
-      .where('jti', '=', jti)
-      .execute();
-  },
-
-  revokeResticToken: async (jti: string, revokedBy = 'test-admin') => {
-    await getDb()
-      .updateTable('resticTokens')
-      .set({ revokedAt: new Date(), revokedBy })
-      .where('jti', '=', jti)
-      .execute();
   },
 
   setFeatureOverride: (userId: string, flag: string, value: boolean, setBy = 'test-admin') => {

--- a/packages/yucca-sdk/orchestration-api/src/backends/yucca.backend.ts
+++ b/packages/yucca-sdk/orchestration-api/src/backends/yucca.backend.ts
@@ -68,7 +68,7 @@ export class YuccaBackend extends Backend {
   }
 
   async getResticEndpoint(id: string) {
-    const { url } = await createResticUrl(id, await this.getRequestOptions());
+    const { url } = await createResticUrl(id, {}, await this.getRequestOptions());
     return url;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,6 +883,9 @@ importers:
       luxon:
         specifier: 'catalog:'
         version: 3.7.2
+      ms:
+        specifier: 'catalog:'
+        version: 2.1.3
       nestjs-kysely:
         specifier: 'catalog:'
         version: 3.1.2(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(kysely@0.28.2)(reflect-metadata@0.2.2)


### PR DESCRIPTION
one call creates connection + repository + a long-lived rest: url; users manage their own access keys

- `main` <!-- branch-stack -->
  - \#415
    - \#416
      - \#392
        - \#394 :point\_left:
          - \#412
