### PR TITLE
chore(dev): reliable local stack (browser login, port-forwards, restic url)

### DIFF
--- a/.mise/tasks/test/integration/k3d
+++ b/.mise/tasks/test/integration/k3d
@@ -64,11 +64,11 @@ else
   echo "==> rook-ceph-object-user-yucca-metrics not found; RGW integration tests will skip"
 fi
 
-# The deployed mock-oidc advertises its in-cluster name as the issuer; the dns
-# preload resolves it to the port-forward for every node process (jest + the
-# apps it boots). Same split-horizon glue as the e2e runner.
-export OIDC_ISSUER=http://yucca-mock-oidc:8092
-export OIDC_DEVICE_ISSUER=http://yucca-mock-oidc:8092
+# The deployed mock-oidc advertises http://oidc.localhost:8092 as its issuer; the
+# dns preload resolves that name to the port-forward for every node process (jest
+# + the apps it boots). Same split-horizon glue as the e2e runner.
+export OIDC_ISSUER=http://oidc.localhost:8092
+export OIDC_DEVICE_ISSUER=http://oidc.localhost:8092
 export NODE_OPTIONS="--require $PWD/packages/e2e/k3d/hostmap.cjs${NODE_OPTIONS:+ ${NODE_OPTIONS}}"
 
 echo "==> run the integration suites"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,23 @@ of truth is the Flux tree under `kubernetes/`, not a separate manifest.
 Forwarded ports: `5173` web · `3020` yucca-api · `3030` yucca-admin-api · `3010` michael ·
 `8092` mock-oidc · `9000` ceph rgw (S3) · `8428` victoria-metrics · `9428` victoria-logs.
 
+**Running integration and e2e locally** (both need Docker/OrbStack running first):
+
+```bash
+# integration: cluster infra only, apps boot on the host against it
+mise k3d:up && mise tilt:ci-infra && mise test:integration:k3d
+
+# e2e: full in-cluster stack, then the jest + playwright suites drive it
+mise k3d:up && mise tilt:ci && mise test:e2e:k3d
+```
+
+`test:integration:k3d` and the e2e `run.sh` port-forward the cluster to the localhost ports the
+suites expect and resolve the `oidc.localhost` issuer via `packages/e2e/k3d/hostmap.cjs` (node) and
+`--host-resolver-rules` (the playwright browser). Notes: a Docker restart leaves a stale RGW whose
+CephObjectStoreUser reconcile fails (`rgw-admin-ops-user` errors); `mise k3d:reset` for a fresh
+cluster is faster than repairing it. The `it-works` playwright test occasionally flakes with a
+transient 500 on the first cold dashboard load; rerun it.
+
 ### Infrastructure (terragrunt / ansible)
 
 ```bash

--- a/Tiltfile
+++ b/Tiltfile
@@ -72,6 +72,22 @@ if DEV_ENV:
     }))
     k8s_resource(objects=['yucca-dev-env:secret'], new_name='dev-env', labels=['helm'])
 
+# CoreDNS rewrite so the cluster resolves the same OIDC issuer name the browser
+# does. The dev issuer is `oidc.localhost` (charts/apps/yucca-api,
+# charts/dev/mock-oidc): browsers map any *.localhost to loopback (RFC 6761, in
+# Chrome/Firefox/Arc/Edge), so no /etc/hosts is needed on the host; here we point
+# the same name at the in-cluster mock so yucca-api's discovery + issuer check
+# agree. k3d/k3s auto-imports the `coredns-custom` ConfigMap (*.override).
+k8s_yaml(encode_yaml({
+    'apiVersion': 'v1',
+    'kind': 'ConfigMap',
+    'metadata': {'name': 'coredns-custom', 'namespace': 'kube-system'},
+    'data': {
+        'oidc.override': 'rewrite name oidc.localhost yucca-mock-oidc.yucca.svc.cluster.local\n',
+    },
+}))
+k8s_resource(objects=['coredns-custom:configmap'], new_name='coredns-oidc', labels=['helm'])
+
 # ---------------------------------------------------------------------------
 # Fleet topology. The real clusters get this ConfigMap from Flux with the
 # per-cluster values substituted in (kubernetes/apps/base/topology); Tilt
@@ -468,16 +484,21 @@ for app in LOCAL_APPS:
 # ---------------------------------------------------------------------------
 local_resource(
     'port-forwards',
+    # Each tunnel runs in a reconnect loop: a raw `kubectl port-forward` dies when
+    # the pod behind the service is replaced (every live_update image rebuild), and
+    # does NOT re-establish itself. The `while` loop reconnects within ~1s, so the
+    # host ports stay up across rebuilds instead of needing a manual restart.
     serve_cmd='''trap 'kill 0' EXIT
-kubectl port-forward -n yucca svc/yucca-api 3020:3020 &
-kubectl port-forward -n yucca svc/yucca-admin-api 3030:3030 &
-kubectl port-forward -n yucca svc/yucca-web 5173:5173 &
-kubectl port-forward -n yucca svc/yucca-meta 8081:8080 &
-kubectl port-forward -n yucca svc/yucca-michael 3010:3010 &
-kubectl port-forward -n yucca svc/yucca-mock-oidc 8092:8092 &
-kubectl port-forward -n rook-ceph svc/rook-ceph-rgw-yucca 9000:80 &
-kubectl port-forward -n yucca svc/victoria-metrics 8428:8428 &
-kubectl port-forward -n yucca svc/victoria-logs 9428:9428 &
+pf() { while true; do kubectl port-forward -n "$1" "svc/$2" "$3" 2>/dev/null; sleep 1; done; }
+pf yucca yucca-api 3020:3020 &
+pf yucca yucca-admin-api 3030:3030 &
+pf yucca yucca-web 5173:5173 &
+pf yucca yucca-meta 8081:8080 &
+pf yucca yucca-michael 3010:3010 &
+pf yucca yucca-mock-oidc 8092:8092 &
+pf rook-ceph rook-ceph-rgw-yucca 9000:80 &
+pf yucca victoria-metrics 8428:8428 &
+pf yucca victoria-logs 9428:9428 &
 wait''',
     resource_deps=['yucca-api', 'yucca-web', 'yucca-michael', 'yucca-mock-oidc', 'yucca-meta'],
     labels=['app'],

--- a/charts/apps/yucca-admin-api/values.yaml
+++ b/charts/apps/yucca-admin-api/values.yaml
@@ -34,8 +34,10 @@ volumeMounts:
 # CNPG-managed postgres Cluster name (shares yucca-api's database)
 postgresClusterName: yucca-db
 
-# OIDC provider in-cluster service (must match the issuer mock-oidc advertises)
-oidcIssuer: http://yucca-mock-oidc:8092
+# Must match the issuer mock-oidc advertises. oidc.localhost resolves to the
+# mock-oidc service in-cluster (coredns rewrite, see Tiltfile) and to loopback in
+# a host browser, so the same issuer string works from both sides.
+oidcIssuer: http://oidc.localhost:8092
 oidcRedirectUri: http://localhost:3030/api/auth/oidc/callback
 oidcLogoutRedirectUri: http://localhost:3030
 

--- a/charts/apps/yucca-api/values.yaml
+++ b/charts/apps/yucca-api/values.yaml
@@ -43,7 +43,7 @@ volumeMounts:
 postgresClusterName: yucca-db
 
 # OIDC provider in-cluster service
-oidcIssuer: http://yucca-mock-oidc:8092
+oidcIssuer: http://oidc.localhost:8092
 oidcRedirectUri: http://localhost:5173/api/auth/oidc/callback
 oidcLogoutRedirectUri: http://localhost:5173
 
@@ -87,7 +87,7 @@ env:
   # Device-flow OIDC (required by yucca-api env schema; points at mock-oidc's
   # registered device client).
   - name: OIDC_DEVICE_ISSUER
-    value: http://yucca-mock-oidc:8092
+    value: http://oidc.localhost:8092
   - name: OIDC_DEVICE_CLIENT_ID
     value: "device client ID"
   - name: OIDC_DEVICE_ALLOW_INSECURE

--- a/charts/dev/mock-oidc/values.yaml
+++ b/charts/dev/mock-oidc/values.yaml
@@ -23,9 +23,9 @@ env:
   - name: PORT
     value: "80"
   # iss claim / discovery base — must match yucca-api's OIDC_ISSUER
-  # (http://yucca-mock-oidc:8092) so issued tokens validate in-cluster.
+  # (http://oidc.localhost:8092) so issued tokens validate in-cluster.
   - name: ISSUER
-    value: http://yucca-mock-oidc:8092
+    value: http://oidc.localhost:8092
   - name: CLIENT_ID
     value: "client ID"
   - name: CLIENT_SECRET

--- a/packages/e2e/k3d/hostmap.cjs
+++ b/packages/e2e/k3d/hostmap.cjs
@@ -1,8 +1,6 @@
-// e2e-against-k3d glue: the deployed yucca-api advertises its OIDC issuer as the
-// in-cluster name http://yucca-mock-oidc:8092. Host-side fetch() (undici) in the
-// jest e2e must resolve that name to the kubectl port-forward on localhost.
+// Resolve the OIDC issuer host to the kubectl port-forward for host-side jest fetch (undici).
 const dns = require('dns');
-const MAP = { 'yucca-mock-oidc': '127.0.0.1' };
+const MAP = { 'oidc.localhost': '127.0.0.1', 'yucca-mock-oidc': '127.0.0.1' };
 const origLookup = dns.lookup;
 dns.lookup = function (hostname, options, callback) {
   if (typeof options === 'function') {

--- a/packages/web/playwright.k3d.config.ts
+++ b/packages/web/playwright.k3d.config.ts
@@ -1,15 +1,13 @@
 import { defineConfig } from '@playwright/test';
 
-// Web e2e against the LOCAL k3d stack (web port-forwarded to :36033). Unlike the
-// default config there is no webServer block — web is already served by the
-// cluster. host-resolver-rules lets the browser reach the in-cluster OIDC issuer
-// host (yucca-mock-oidc) via the kubectl port-forward on localhost. Driven by
-// packages/e2e/k3d/run.sh (mise test:e2e:k3d).
+// host-resolver-rules lets the browser reach the OIDC issuer host via the kubectl port-forward.
 export default defineConfig({
   testDir: 'e2e',
   use: {
     launchOptions: {
-      args: ['--host-resolver-rules=MAP yucca-mock-oidc 127.0.0.1'],
+      args: [
+        '--host-resolver-rules=MAP oidc.localhost 127.0.0.1,MAP yucca-mock-oidc 127.0.0.1',
+      ],
     },
   },
 });


### PR DESCRIPTION
local dev only: oidc.localhost login with no /etc/hosts, self-reconnecting tilt port-forwards, and a host-usable restic endpoint

- \#399 :point\_left: <!-- branch-stack -->
  - \#392
    - \#394
      - \#412
