### PR TITLE
fix(ceph): skip the dpkg unhold on nodes where the package is absent

### DIFF
--- a/ansible/ceph/roles/fluentbit/molecule/default/verify.yml
+++ b/ansible/ceph/roles/fluentbit/molecule/default/verify.yml
@@ -140,6 +140,9 @@
         # Chain validation alone accepts any trusted cert for any name.
         - '^[[:space:]]*tls\.verify_hostname[[:space:]]+on$'
         - '^[[:space:]]*compress[[:space:]]+zstd$'
+        # Silences the per-flush ack without hiding failures, which out_http
+        # logs at error/warn.
+        - '^[[:space:]]*log_level[[:space:]]+warn$'
         - '^[[:space:]]*Format[[:space:]]+json_lines$'
 
     - name: Verify the URI carries the VictoriaLogs field mapping

--- a/ansible/ceph/roles/fluentbit/tasks/main.yml
+++ b/ansible/ceph/roles/fluentbit/tasks/main.yml
@@ -53,10 +53,15 @@
   failed_when: false
 
 - name: Unhold fluent-bit only when the pinned version differs (keeps converge clean)
+  # rc != 0 means dpkg has never seen the package. That is every fresh node.
+  # dpkg_selections fails hard on an unknown package, and there is no hold to
+  # release before the first install, so skip it there.
   ansible.builtin.dpkg_selections:
     name: fluent-bit
     selection: install
-  when: (ceph_fluentbit_installed.stdout | default('')) != ceph_fluentbit_version
+  when:
+    - ceph_fluentbit_installed.rc == 0
+    - ceph_fluentbit_installed.stdout != ceph_fluentbit_version
 
 - name: Install Fluent Bit at the pinned version
   ansible.builtin.apt:

--- a/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
+++ b/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
@@ -52,6 +52,12 @@
     Json_date_format         iso8601
     Json_date_key            date
     compress                 zstd
+    # Per-plugin level, not the service level. out_http logs every successful
+    # flush at info (http.c:348) and every non-2xx at error (http.c:326), with a
+    # warn when it drops a 4xx chunk (http.c:331). Raising just this plugin to
+    # warn silences the acks, which are ~4% of everything we ship, and keeps all
+    # failure signal. The agent still logs at info everywhere else.
+    log_level                warn
     # Retry forever, so Fluent Bit never discards a chunk for running out of
     # retries: an overlay flap queues to disk. The queue is still bounded. At
     # total_limit_size Fluent Bit drops its oldest chunks to make room.

--- a/ansible/ceph/roles/netbird/tasks/main.yml
+++ b/ansible/ceph/roles/netbird/tasks/main.yml
@@ -38,10 +38,15 @@
   failed_when: false
 
 - name: Unhold netbird only when the pinned version differs (keeps converge clean)
+  # rc != 0 means dpkg has never seen the package. That is every fresh node.
+  # dpkg_selections fails hard on an unknown package, and there is no hold to
+  # release before the first install, so skip it there.
   ansible.builtin.dpkg_selections:
     name: netbird
     selection: install
-  when: (ceph_netbird_installed.stdout | default('')) != ceph_netbird_version
+  when:
+    - ceph_netbird_installed.rc == 0
+    - ceph_netbird_installed.stdout != ceph_netbird_version
 
 - name: Install NetBird at the pinned version
   ansible.builtin.apt:


### PR DESCRIPTION
The `fluentbit` and `netbird` roles both fail on a node that has never had the package installed. `dpkg-query` exits 1 and prints nothing, the version comparison reads that empty string as a mismatch, and `dpkg_selections` is then asked to release a hold on a package dpkg has never seen:

```
fatal: [spice-ceph-adelia]: FAILED! => Failed to find package 'fluent-bit' to perform selection 'install'
```

Gating on the exit code as well as the version skips the unhold where there is no hold to release. `rc` is the only signal that separates "dpkg has never seen this package" from "dpkg knows it and it currently has no version", which is why the stdout comparison alone could not get this right.

- `when: (x.stdout | default('')) != x_version` -> `when: [x.rc == 0, x.stdout != x_version]`
- applied to `roles/fluentbit/tasks/main.yml` and `roles/netbird/tasks/main.yml`

Found by the fluentbit canary on spice-ceph-adelia. `netbird` carries the same condition and has never hit it because netbird was already installed fleet-wide when that role landed, but a reimaged node would fail enrollment the same way.

Verified on adelia: the canary now completes, fluent-bit installs and starts, and logs arrive in o11y tagged `cluster=spice`.

- `main` <!-- branch-stack -->
  - \#403 :point\_left:
