### PR TITLE
fix(ceph): deliver alertmanager alerts to the configured receiver

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/files/alertmanager.yml.j2
+++ b/ansible/ceph/roles/ceph_deploy/files/alertmanager.yml.j2
@@ -1,0 +1,78 @@
+# LOCAL OVERRIDE of cephadm's alertmanager.yml.j2, stored in the mon config-key
+# store at mgr/cephadm/services/alertmanager/alertmanager.yml.
+#
+# WHY: upstream's route tree makes `default_webhook_urls` dead config. The
+# 'ceph-dashboard' child route carries NO matchers, so it matches every alert,
+# and its `continue: true` is emitted ONLY inside the `snmp_gateway_urls`
+# conditional. Alertmanager returns the parent node only when NO child matched,
+# so with no SNMP gateway every alert stops at 'ceph-dashboard' and the
+# 'default' receiver -- the one operator webhooks land in -- never fires.
+# Symptom: notifications succeed, nothing reaches the operator.
+#
+# FIX: give 'ceph-dashboard' an unconditional `continue: true` and add an
+# explicit sibling route to 'default'. Both then receive every alert. Note that
+# `continue: true` ALONE is not sufficient: the parent receiver is still skipped
+# once any child matches, which is why the sibling is required.
+#
+# Re-check on every Ceph upgrade -- this pins a copy of an upstream template.
+# Diff against the shipped one:
+#   podman exec <mgr> cat /usr/share/ceph/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
+# {{ cephadm_managed }}
+# See https://prometheus.io/docs/alerting/configuration/ for documentation.
+
+global:
+  resolve_timeout: 5m
+{% if not secure %}
+  http_config:
+    tls_config:
+{% if security_enabled %}
+      ca_file: root_cert.pem
+      cert_file: alertmanager.crt
+      key_file: alertmanager.key
+{% else %}
+      insecure_skip_verify: true
+{% endif %}
+{% endif %}
+
+route:
+  receiver: 'default'
+  routes:
+    - group_by: ['alertname']
+      group_wait: 10s
+      group_interval: 10s
+      repeat_interval: 1h
+      receiver: 'ceph-dashboard'
+      continue: true
+    - group_by: ['alertname']
+      group_wait: 10s
+      group_interval: 10s
+      repeat_interval: 1h
+      receiver: 'default'
+{% if snmp_gateway_urls %}
+      continue: true
+    - receiver: 'snmp-gateway'
+      repeat_interval: 1h
+      group_interval: 10s
+      group_by: ['alertname']
+      match_re:
+        oid: "(1.3.6.1.4.1.50495.).*"
+{% endif %}
+
+receivers:
+- name: 'default'
+  webhook_configs:
+{% for url in default_webhook_urls %}
+  - url: '{{ url }}'
+{% endfor %}
+- name: 'ceph-dashboard'
+  webhook_configs:
+{% for url in dashboard_urls %}
+  - url: '{{ url }}/api/prometheus_receiver'
+{% endfor %}
+{% if snmp_gateway_urls %}
+- name: 'snmp-gateway'
+  webhook_configs:
+{% for url in snmp_gateway_urls %}
+  - url: '{{ url }}'
+{% endfor %}
+{% endif %}

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -91,6 +91,68 @@
       or (ceph_alertmanager_webhook_urls | default([]) | length) > 0
   changed_when: false
 
+# --- Step 2.55: Correct the alertmanager route tree ---
+#
+# Without this the webhook configured above is never reached. cephadm's shipped
+# alertmanager.yml.j2 gives the 'ceph-dashboard' child route no matchers, so it
+# matches every alert, and emits its `continue: true` only when an SNMP gateway
+# is configured. Alertmanager dispatches to the parent's receiver ONLY when no
+# child matched, so every alert terminates at 'ceph-dashboard' and 'default' --
+# where default_webhook_urls land -- never fires. Notifications report success
+# the whole time, so the failure is silent.
+#
+# cephadm renders service configs through a template that first checks the mon
+# config-key store (mgr/cephadm/<name minus .j2>), falling back to the packaged
+# one. Storing a corrected copy there is the supported override; see the header
+# of files/alertmanager.yml.j2 for the diff against upstream.
+#
+# Gated on a webhook actually being configured: a cluster with no receiver has
+# nothing to deliver and is left on the stock template.
+- name: Stage corrected alertmanager config template
+  ansible.builtin.copy:
+    src: alertmanager.yml.j2
+    dest: /etc/ceph/alertmanager.yml.j2
+    owner: root
+    group: root
+    mode: '0644'
+  register: alertmanager_template_file
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - (ceph_alertmanager_webhook_urls | default([]) | length) > 0
+
+# check-then-set: config-key set always "succeeds", so compare first or every
+# run reports changed and a real drift is invisible.
+- name: Read the stored alertmanager config template
+  ansible.builtin.command: >
+    ceph config-key get mgr/cephadm/services/alertmanager/alertmanager.yml
+  register: alertmanager_template_stored
+  changed_when: false
+  failed_when: false
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - (ceph_alertmanager_webhook_urls | default([]) | length) > 0
+
+- name: Store the corrected alertmanager config template
+  ansible.builtin.command: >
+    ceph config-key set mgr/cephadm/services/alertmanager/alertmanager.yml
+    -i /etc/ceph/alertmanager.yml.j2
+  register: alertmanager_template_set
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - (ceph_alertmanager_webhook_urls | default([]) | length) > 0
+    - (alertmanager_template_stored.stdout | default('')) !=
+      (lookup('ansible.builtin.file', role_path ~ '/files/alertmanager.yml.j2'))
+  changed_when: true
+
+# Only on a real change: cephadm re-renders the config at redeploy, so without
+# this the corrected template sits unused until some other event triggers one.
+- name: Redeploy alertmanager to pick up the corrected template
+  ansible.builtin.command: ceph orch redeploy alertmanager
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - alertmanager_template_set is changed
+  changed_when: true
+
 # --- Step 2.6: Pin the mgr dashboard + prometheus module bind to the fabric ---
 #
 # The dashboard (8443) and the prometheus mgr module (9283) run INSIDE the active


### PR DESCRIPTION
Ceph alerts reach the configured receiver. They did not before: cephadm's
shipped `alertmanager.yml.j2` gives the `ceph-dashboard` child route no
matchers, so it matches every alert, and emits its `continue: true` only when an
SNMP gateway is configured. Alertmanager dispatches to a parent's receiver only
when no child matched, so every alert terminated at `ceph-dashboard` and
`default` -- where `default_webhook_urls` land -- never fired. On spice that
meant 738 notifications delivered with zero failures and nothing reaching an
operator, which is why it went unnoticed.

The corrected template gives `ceph-dashboard` an unconditional `continue: true`
and adds an explicit sibling route to `default`, so both receive every alert.
`continue: true` on its own is not sufficient -- the parent is skipped once any
child matches -- so the sibling route is what actually does the work.

cephadm renders service configs through a template layer that checks the mon
config-key store (`mgr/cephadm/<name minus .j2>`) before falling back to the
packaged file, so the corrected copy is stored there rather than patched on
disk, and survives a daemon redeploy. It is a pinned copy of an upstream
template: the file header carries the command to diff it against the shipped one
on a Ceph upgrade.

Gated on a webhook actually being configured, so a cluster with no receiver
keeps the stock template untouched. Check-then-set, with the redeploy fired only
on a real change, since cephadm re-renders the config at redeploy and the stored
template would otherwise sit unused. Verified a no-op against spice, whose live
template already matches this file.

- `main` <!-- branch-stack -->
  - \#404 :point\_left:
