### PR TITLE
fix(ceph): quiet the fluent-bit per-flush ack without hiding failures

### DIFF
--- a/ansible/ceph/roles/fluentbit/molecule/default/verify.yml
+++ b/ansible/ceph/roles/fluentbit/molecule/default/verify.yml
@@ -140,6 +140,9 @@
         # Chain validation alone accepts any trusted cert for any name.
         - '^[[:space:]]*tls\.verify_hostname[[:space:]]+on$'
         - '^[[:space:]]*compress[[:space:]]+zstd$'
+        # Silences the per-flush ack without hiding failures, which out_http
+        # logs at error/warn.
+        - '^[[:space:]]*log_level[[:space:]]+warn$'
         - '^[[:space:]]*Format[[:space:]]+json_lines$'
 
     - name: Verify the URI carries the VictoriaLogs field mapping

--- a/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
+++ b/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
@@ -52,6 +52,12 @@
     Json_date_format         iso8601
     Json_date_key            date
     compress                 zstd
+    # Per-plugin level, not the service level. out_http logs every successful
+    # flush at info (http.c:348) and every non-2xx at error (http.c:326), with a
+    # warn when it drops a 4xx chunk (http.c:331). Raising just this plugin to
+    # warn silences the acks, which are ~4% of everything we ship, and keeps all
+    # failure signal. The agent still logs at info everywhere else.
+    log_level                warn
     # Retry forever, so Fluent Bit never discards a chunk for running out of
     # retries: an overlay flap queues to disk. The queue is still bounded. At
     # total_limit_size Fluent Bit drops its oldest chunks to make room.


### PR DESCRIPTION
The http output logs every successful flush at info, so each node shipped a steady `vmauth.o11y.futo.network:443, HTTP status=200` line and then shipped that line too. Across the four canary nodes it was about 4% of everything reaching o11y, and on a quiet OSD node it is most of what that node sends.

Raising the level on that one plugin silences the acks and keeps every failure signal: `out_http` logs 200-205 at info (`http.c:348`), any non-2xx at error (`http.c:326`), and warns when it drops a 4xx chunk (`http.c:331`). The service stays at info, so the input, the filters and startup are unaffected, and nothing changes about which logs get collected.

- `[OUTPUT]` gains `log_level warn` (per-plugin, not `[SERVICE] Log_Level`)
- molecule asserts the setting so it cannot regress

Measured on the four canary nodes before and after: fluent-bit's share of shipped lines went 4% -> 0.3%, and flush acks in a 60s post-restart window went to zero.

Stacked on #403, which those same nodes also need.

- `main` <!-- branch-stack -->
  - \#403
    - \#405 :point\_left:
