### PR TITLE
fix(ceph): repair the monitoring path from spec apply to Zulip message

### DIFF
--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -50,8 +50,20 @@ ceph_bind_networks:
 # incoming webhook whose alertmanager integration accepts the standard webhook
 # payload; it carries an API key, so it lives in 1Password and arrives through
 # secrets.yml.tpl rather than being written here.
+#
+# The URL carries `desc=description`, set on the 1Password item. Zulip's
+# alertmanager integration renders one field per alert and defaults it to
+# `alertname`. Without the parameter every alert arrives as a bare identifier,
+# with no host and no value. `description` is the only field that names a host.
 ceph_alertmanager_webhook_urls:
   - "{{ vault_alertmanager_webhook_url }}"
+# Without this the URL above is inert. Someone repaired the route tree by hand on
+# the live cluster and the repair was tracked nowhere until 2026-07-31, so a
+# reprovision would have come up with alert delivery silently dead.
+ceph_alertmanager_fix_route_tree: true
+# Companion to `desc=description`: without it CephPGsUnclean, CephPGsInactive
+# and CephPoolGrowthWarning render as `ec:16+4`.
+ceph_prometheus_drop_description_label: true
 # Bond of the two 25G NICs, LACP to match the leaf ae<k> aggregate (cluster-fabric).
 bond_mode: "802.3ad"
 # COEXISTENCE: keep the 1G WAN (oob_nic) on ifupdown exactly as installimage set

--- a/ansible/ceph/roles/ceph_deploy/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_deploy/defaults/main.yml
@@ -119,3 +119,35 @@ ceph_rgw_ingress_count: 3
 # verify.yml warns that alert delivery is not configured. TODO(operator): set the
 # destination for spice.
 ceph_alertmanager_webhook_urls: []
+
+# Repair cephadm's alertmanager route tree so `default_webhook_urls` is live.
+#
+# WHY: upstream's 'ceph-dashboard' child route carries no matchers, so it
+# matches every alert. Its `continue: true` is emitted only inside the
+# snmp_gateway_urls conditional. Alertmanager falls back to the parent receiver
+# only when no child matched. On a cluster with no SNMP gateway, every alert
+# therefore stops at 'ceph-dashboard' and never reaches 'default', which is
+# where the webhooks above land. Notifications report success; nothing arrives.
+#
+# Required whenever ceph_alertmanager_webhook_urls is non-empty, because without
+# it that setting is inert. It stays a separate flag because it rewrites a
+# cephadm-managed config, so setting a webhook URL never rewrites that config on
+# its own.
+ceph_alertmanager_fix_route_tree: false
+
+# Drop the `description` label from alerts before they reach alertmanager.
+#
+# WHY: `ceph_pool_metadata` carries a label named `description`, whose value is
+# the pool's EC profile (`ec:16+4`, `replica:3`). Three rules join that metric
+# with group_left and inherit the label: CephPGsUnclean, CephPGsInactive,
+# CephPoolGrowthWarning. Zulip's alertmanager integration resolves its `desc`
+# field against labels first and annotations second. With `desc=description`
+# those three alerts render as the string `ec:16+4` instead of their annotation.
+#
+# The label is incidental pool metadata. Nothing routes, silences or groups on
+# it. This relabels alerts only, so the metric keeps the label and dashboards
+# are unaffected.
+#
+# Only meaningful when the receiver resolves annotations by name. Harmless
+# otherwise, but defaults false so no cluster changes alert content implicitly.
+ceph_prometheus_drop_description_label: false

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -82,14 +82,27 @@
     - inventory_hostname in groups['ceph_bootstrap']
     - (ceph_bind_networks | default([]) | length) > 0
       or (ceph_alertmanager_webhook_urls | default([]) | length) > 0
+  register: monitoring_spec_render
 
+# `ceph orch apply -i` exits 0 even when the mgr rejects the spec, so rc alone
+# proves nothing. cephadm parses every document in the file before it applies
+# any of them, so one rejected document discards the whole apply. The result is
+# a silent no-op that reads as a successful converge. Seen 2026-07-31: a
+# `networks:` key on the ceph-exporter document failed the apply while the play
+# reported ok, so an updated alertmanager webhook URL never reached the cluster.
 - name: Apply monitoring service spec
   ansible.builtin.command: ceph orch apply -i /etc/ceph/monitoring-spec.yaml
   when:
     - inventory_hostname in groups['ceph_bootstrap']
     - (ceph_bind_networks | default([]) | length) > 0
       or (ceph_alertmanager_webhook_urls | default([]) | length) > 0
+  register: monitoring_spec_apply
   changed_when: false
+  failed_when:
+    - monitoring_spec_apply.rc != 0
+      or 'Error' in (monitoring_spec_apply.stderr | default(''))
+      or 'Invalid argument' in (monitoring_spec_apply.stderr | default(''))
+      or 'Error' in (monitoring_spec_apply.stdout | default(''))
 
 # --- Step 2.6: Pin the mgr dashboard + prometheus module bind to the fabric ---
 #
@@ -162,6 +175,182 @@
     - (ceph_bind_networks | default([]) | length) > 0
   register: mgr_module_bind
   changed_when: "'CHANGED' in (mgr_module_bind.stdout | default(''))"
+
+# --- Step 2.7: Monitoring config overrides (derived from the shipped template) ---
+#
+# cephadm renders every monitoring config from a Jinja template.
+# TemplateMgr.render() reads the mon config-key store at
+# mgr/cephadm/services/<path> before the packaged template (cephadm/template.py:
+# `store_name = name.rstrip('.j2')`). cephadm renders a stored value as Jinja
+# with the same context, so an override keeps the dynamic parts intact: service
+# discovery URLs, TLS branches, fsid.
+#
+# These overrides are derived, not pinned. The task reads the template that the
+# running mgr ships and injects a small block at an asserted anchor. It does not
+# commit a copy of the upstream file. A committed copy goes stale on every Ceph
+# upgrade and someone has to re-diff it by hand. Deriving picks up an upgraded
+# template on the next converge. The cost is a dependency on an anchor string,
+# so each injection asserts its anchor and fails the play rather than storing a
+# config built on a guess.
+#
+# Two overrides, independently gated. Each flag's default carries the why:
+# ceph_alertmanager_fix_route_tree, ceph_prometheus_drop_description_label.
+- name: Derive and store the cephadm monitoring config overrides
+  ansible.builtin.shell: |
+    set -o pipefail
+    python3 - <<'PYEOF'
+    import json, os, subprocess, sys, tempfile
+
+    TEMPLATE_DIR = "/usr/share/ceph/mgr/cephadm/templates/services"
+
+    # `config-key get` may not round-trip a trailing newline. Compare on a
+    # normalized form, or every converge reports a spurious change.
+    def norm(s):
+        return s.rstrip("\n")
+
+    # Each override: the cephadm template path, the anchor we inject after, the
+    # text to inject, and a sanity predicate over the upstream source. The
+    # predicate guards against a future Ceph release having already made the
+    # change, which would otherwise double up.
+    OVERRIDES = []
+
+    if {{ ceph_alertmanager_fix_route_tree | bool | ternary('True', 'False') }}:
+        OVERRIDES.append({
+            "service": "alertmanager",
+            "template": "alertmanager/alertmanager.yml.j2",
+            "key": "mgr/cephadm/services/alertmanager/alertmanager.yml",
+            "anchor": "      receiver: 'ceph-dashboard'\n",
+            "inject": (
+                "      continue: true\n"
+                "    - group_by: ['alertname']\n"
+                "      group_wait: 10s\n"
+                "      group_interval: 10s\n"
+                "      repeat_interval: 1h\n"
+                "      receiver: 'default'\n"
+            ),
+            # Upstream routes to 'default' exactly once (the parent receiver).
+            # A second occurrence means upstream already added the sibling.
+            "expect": lambda src: src.count("receiver: 'default'") == 1,
+            "expect_msg": ("upstream already routes to 'default' more than once; "
+                           "the route-tree bug may be fixed upstream"),
+        })
+
+    if {{ ceph_prometheus_drop_description_label | bool | ternary('True', 'False') }}:
+        OVERRIDES.append({
+            "service": "prometheus",
+            "template": "prometheus/prometheus.yml.j2",
+            "key": "mgr/cephadm/services/prometheus/prometheus.yml",
+            "anchor": "\nalerting:\n",
+            "inject": (
+                "  alert_relabel_configs:\n"
+                "    # yucca: ceph_pool_metadata carries a `description` label (the\n"
+                "    # EC profile) that shadows the same-named annotation in any\n"
+                "    # receiver that resolves by field name.\n"
+                "    - regex: 'description'\n"
+                "      action: labeldrop\n"
+            ),
+            "expect": lambda src: "alert_relabel_configs" not in src,
+            "expect_msg": "upstream already defines alert_relabel_configs; merge by hand",
+        })
+
+    if not OVERRIDES:
+        print("ok (no overrides enabled)")
+        raise SystemExit(0)
+
+    fsid = subprocess.check_output(["ceph", "fsid"]).decode().strip()
+    mgrs = json.loads(subprocess.check_output(
+        ["ceph", "orch", "ps", "--daemon-type", "mgr", "--format", "json"]))
+    active = [d for d in mgrs if d.get("is_active")] or mgrs
+    container = "ceph-%s-mgr-%s" % (fsid, active[0]["daemon_id"].replace(".", "-"))
+
+    changed = []
+    for o in OVERRIDES:
+        upstream = subprocess.check_output([
+            "podman", "exec", container, "cat",
+            "%s/%s" % (TEMPLATE_DIR, o["template"]),
+        ]).decode()
+
+        n = upstream.count(o["anchor"])
+        if n != 1:
+            sys.stderr.write(
+                "ERROR: %s: expected exactly 1 anchor in the shipped template, "
+                "found %d. Upstream layout changed; review before re-running.\n"
+                % (o["service"], n))
+            raise SystemExit(1)
+        if not o["expect"](upstream):
+            sys.stderr.write("ERROR: %s: %s\n" % (o["service"], o["expect_msg"]))
+            raise SystemExit(1)
+
+        desired = upstream.replace(o["anchor"], o["anchor"] + o["inject"], 1)
+        current = subprocess.run(
+            ["ceph", "config-key", "get", o["key"]],
+            capture_output=True).stdout.decode()
+
+        if norm(current) == norm(desired):
+            continue
+
+        # `ceph config-key set <key>` does not read stdin. Given no value
+        # argument it stores an empty value and exits 0. That silently deletes
+        # the override and drops cephadm back to the packaged template. Pass the
+        # value with `-i <file>`.
+        with tempfile.NamedTemporaryFile("w", suffix=".j2", delete=False) as fh:
+            fh.write(desired)
+            tmp = fh.name
+        try:
+            subprocess.run(["ceph", "config-key", "set", o["key"], "-i", tmp],
+                           check=True)
+        finally:
+            os.unlink(tmp)
+
+        # Read back. An override that silently failed to store is worse than no
+        # override: cephadm falls back to upstream and the repair disappears
+        # with the play still reporting success.
+        back = subprocess.run(
+            ["ceph", "config-key", "get", o["key"]],
+            capture_output=True).stdout.decode()
+        if norm(back) != norm(desired):
+            sys.stderr.write(
+                "ERROR: %s: stored %d bytes but read back %d. The override did "
+                "not persist; cephadm will use the packaged template.\n"
+                % (o["service"], len(desired), len(back)))
+            raise SystemExit(1)
+
+        changed.append(o["service"])
+
+    print("CHANGED " + " ".join(changed) if changed else "ok")
+    PYEOF
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - (ceph_alertmanager_fix_route_tree | bool)
+      or (ceph_prometheus_drop_description_label | bool)
+  register: monitoring_overrides
+  changed_when: "'CHANGED' in (monitoring_overrides.stdout | default(''))"
+  tags: [alert_rendering]
+
+# cephadm only re-renders a monitoring config when it redeploys the daemon, so
+# the config-key writes above are inert until each daemon is redeployed. Gated on
+# that specific service having changed, so a steady-state converge bounces
+# nothing and a prometheus-only change does not interrupt alert delivery.
+#
+# alertmanager also redeploys when the service spec itself changed. cephadm saves
+# a new spec but does NOT redeploy on a `user_data` change -- the webhook URL is
+# not part of the daemon's dependency hash, so the running alertmanager keeps
+# serving the old config indefinitely. Observed 2026-07-31: spec saved at
+# 19:04:12, daemon still 15m old and still rendering the previous URL six minutes
+# later. Without this, changing the receiver URL is a no-op until something else
+# happens to bounce the daemon.
+- name: Redeploy monitoring daemons whose override or spec changed
+  ansible.builtin.command: "ceph orch redeploy {{ item }}"
+  loop: "{{ ['alertmanager', 'prometheus'] }}"
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - item in (monitoring_overrides.stdout | default(''))
+      or (item == 'alertmanager'
+          and (monitoring_spec_render.changed | default(false)))
+  changed_when: true
+  tags: [alert_rendering]
 
 # --- Step 3: Configure dashboard integrations ---
 # The dashboard runs on the active mgr and reaches these services on the fabric;

--- a/ansible/ceph/roles/ceph_deploy/templates/monitoring-spec.yaml.j2
+++ b/ansible/ceph/roles/ceph_deploy/templates/monitoring-spec.yaml.j2
@@ -65,12 +65,16 @@ networks:
 {% endfor %}
 {% endif %}
 ---
+# Do not add `networks:` here. ceph-exporter is the one monitoring service whose
+# spec class does not accept it:
+#   CephExporterSpec  networks=False
+#   MonitoringSpec / AlertManagerSpec / PrometheusSpec / GrafanaSpec  networks=True
+# cephadm parses every document in this file before it applies any of them, so a
+# `networks` key on this document fails the whole apply with
+#   ServiceSpec: __init__() got an unexpected keyword argument 'networks'
+# and updates no service in the file. `ceph orch apply -i` still exits 0, so only
+# the mgr log records the failure. See the failed_when on the apply task in
+# tasks/monitoring.yml.
 service_type: ceph-exporter
 placement:
   host_pattern: '*'
-{% if ceph_bind_networks | default([]) | length > 0 %}
-networks:
-{% for net in ceph_bind_networks %}
-  - {{ net }}
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
Ceph alerts now reach Zulip carrying their `description` annotation rather than a bare alert name, so a message names the host that failed and the values behind it. Two role flags hold this declaratively: `ceph_alertmanager_fix_route_tree` repairs cephadm's route tree, without which `default_webhook_urls` never fires and notifications report success while nothing arrives, and `ceph_prometheus_drop_description_label` drops the `ceph_pool_metadata` label that would otherwise shadow the annotation on CephPGsUnclean, CephPGsInactive and CephPoolGrowthWarning. Both derive their override from the template the running mgr ships instead of committing a copy, so a Ceph upgrade is picked up on the next converge rather than going stale.

This also repairs a silent failure further up the same path: a `networks:` key on the ceph-exporter document made `ceph orch apply -i` reject the whole file while still exiting 0, so monitoring spec changes had not been reaching the cluster at all. `CephExporterSpec` is the one monitoring spec class that does not accept `networks`. The apply task now fails the play when the mgr rejects a spec, and the config-key write reads its value back rather than trusting an exit code.

All of it is already applied on spice, so this is the repo catching up to the cluster.

- `main` <!-- branch-stack -->
  - \#408 :point\_left:
