### PR TITLE
fix(yuctl): pin op reads to the team-futo 1Password account

### DIFF
--- a/packages/yuctl/README.md
+++ b/packages/yuctl/README.md
@@ -121,6 +121,14 @@ the repo-wide `op run` convention and interactive desktop-unlock UX. kube/talos
 configs are written to 0600 temp files (`op.ReadToTempFile`) and removed after
 use. Override the binary with `OP_BIN`.
 
+Every `op read` is pinned to an **account** — `--account team-futo`, overridable
+with `OP_ACCOUNT` — because operators typically have more than one account
+signed in and `op`'s *default* account is whatever it feels like: the vault
+lookup then fails, or the desktop app prompts for the wrong account
+(`authorization prompt dismissed`). When `OP_SERVICE_ACCOUNT_TOKEN` is set (CI)
+the flag is dropped: the token already pins the account and `op` rejects both.
+Same convention as `.mise/tasks/*` and the `Tiltfile`.
+
 ## Context
 
 `yuctl select staging@austin` validates the target against discovery and writes

--- a/packages/yuctl/internal/op/op.go
+++ b/packages/yuctl/internal/op/op.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 )
 
+const DefaultAccount = "team-futo"
+
 // Binary is the op CLI executable name; overridable for tests via OP_BIN.
 func binary() string {
 	if v := os.Getenv("OP_BIN"); v != "" {
@@ -22,17 +24,36 @@ func binary() string {
 	return "op"
 }
 
+func account() string {
+	if v := os.Getenv("OP_ACCOUNT"); v != "" {
+		return v
+	}
+	return DefaultAccount
+}
+
+func accountFlag() []string {
+	if os.Getenv("OP_SERVICE_ACCOUNT_TOKEN") != "" {
+		return nil
+	}
+	return []string{"--account", account()}
+}
+
 // Read resolves a single `op://...` reference to its plaintext value via
 // `op read`. The trailing newline op prints is trimmed.
 func Read(ctx context.Context, ref string) (string, error) {
 	if !strings.HasPrefix(ref, "op://") {
 		return "", fmt.Errorf("not an op:// reference: %q", ref)
 	}
-	cmd := exec.CommandContext(ctx, binary(), "read", "--no-newline", ref)
+	args := append([]string{"read", "--no-newline"}, accountFlag()...)
+	cmd := exec.CommandContext(ctx, binary(), append(args, ref)...)
 	cmd.Stderr = os.Stderr
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
+		if flag := accountFlag(); flag != nil {
+			return "", fmt.Errorf("op read %s (account %s — unlock 1Password and approve the prompt, "+
+				"or set OP_ACCOUNT): %w", ref, flag[1], err)
+		}
 		return "", fmt.Errorf("op read %s: %w", ref, err)
 	}
 	return out.String(), nil

--- a/packages/yuctl/internal/op/op_test.go
+++ b/packages/yuctl/internal/op/op_test.go
@@ -1,0 +1,92 @@
+package op
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func fakeOp(t *testing.T) (argvFile string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX-only")
+	}
+	dir := t.TempDir()
+	argvFile = filepath.Join(dir, "argv")
+	bin := filepath.Join(dir, "op")
+	script := "#!/bin/sh\nfor a in \"$@\"; do echo \"$a\" >> " + argvFile + "; done\nprintf 's3cret'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OP_BIN", bin)
+	return argvFile
+}
+
+func readArgv(t *testing.T, path string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("stub op recorded no argv: %v", err)
+	}
+	return strings.Split(strings.TrimSuffix(string(b), "\n"), "\n")
+}
+
+func TestReadPassesDefaultAccount(t *testing.T) {
+	argvFile := fakeOp(t)
+	t.Setenv("OP_ACCOUNT", "")
+	t.Setenv("OP_SERVICE_ACCOUNT_TOKEN", "")
+
+	got, err := Read(context.Background(), "op://yucca_tf/TF_STATE_S3_ACCESS_KEY/password")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != "s3cret" {
+		t.Errorf("Read = %q, want %q", got, "s3cret")
+	}
+
+	argv := readArgv(t, argvFile)
+	want := []string{"read", "--no-newline", "--account", DefaultAccount,
+		"op://yucca_tf/TF_STATE_S3_ACCESS_KEY/password"}
+	if strings.Join(argv, " ") != strings.Join(want, " ") {
+		t.Errorf("argv = %v, want %v", argv, want)
+	}
+}
+
+func TestReadHonoursOPAccountOverride(t *testing.T) {
+	argvFile := fakeOp(t)
+	t.Setenv("OP_ACCOUNT", "other.1password.com")
+	t.Setenv("OP_SERVICE_ACCOUNT_TOKEN", "")
+
+	if _, err := Read(context.Background(), "op://v/i/f"); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	argv := readArgv(t, argvFile)
+	if strings.Join(argv, " ") != "read --no-newline --account other.1password.com op://v/i/f" {
+		t.Errorf("argv = %v, want the OP_ACCOUNT override", argv)
+	}
+}
+
+func TestReadOmitsAccountUnderServiceAccountToken(t *testing.T) {
+	argvFile := fakeOp(t)
+	t.Setenv("OP_ACCOUNT", "team-futo")
+	t.Setenv("OP_SERVICE_ACCOUNT_TOKEN", "ops_token")
+
+	if _, err := Read(context.Background(), "op://v/i/f"); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	argv := readArgv(t, argvFile)
+	for _, a := range argv {
+		if a == "--account" {
+			t.Fatalf("argv = %v, want no --account under a service-account token", argv)
+		}
+	}
+}
+
+func TestReadRejectsNonReference(t *testing.T) {
+	if _, err := Read(context.Background(), "/etc/passwd"); err == nil {
+		t.Fatal("Read accepted a non-op:// reference")
+	}
+}


### PR DESCRIPTION
`op read` ran without `--account`, so on a machine with several 1Password accounts signed in it hit the wrong one — `yuctl select` died with `authorization prompt dismissed`. Pins the account (`OP_ACCOUNT`, default `team-futo`) like the rest of the repo does, dropping the flag under `OP_SERVICE_ACCOUNT_TOKEN` since op rejects both.

- `main` <!-- branch-stack -->
  - \#409 :point\_left:
