### PR TITLE
feat(ceph): move the ceph config model into terraform, deep scrub interval to global

### DIFF
--- a/ansible/ceph/.gitignore
+++ b/ansible/ceph/.gitignore
@@ -5,21 +5,22 @@ ansible.*.log
 .ansible/
 .ansible_facts_cache/
 
-# Transient outputs — benchmark results, hardware inventory snapshots, backups, exports
+# Transient outputs: benchmark results, hardware inventory snapshots, backups, exports
 bench/
 hardware/
 backups/
 exports/
 
-# TF-generated artifacts — do not commit; re-render with `tofu apply` in tf/deployment/<partition>/<region>/ceph/
+# TF-generated artifacts; do not commit. Re-render with `tofu apply` in tf/deployment/<partition>/<region>/ceph/
 # Inventories are region-scoped with a friendly cluster leaf: inventories/<partition>-<region>/<cluster>/
 inventories/*/*/inventory.ini
 inventories/*/*/inventory-provision.ini
 inventories/*/*/inventory-destroy.ini
 inventories/*/*/secrets.yml.tpl
 inventories/*/*/group_vars/all/operators.yml
+inventories/*/*/group_vars/all/ceph-config.generated.yml
 
-# host_vars IS committed (per-node hardware facts — stable, part of the inventory
+# host_vars IS committed (per-node hardware facts are stable, part of the inventory
 # source of truth). Operator-local overrides use host_vars/*.local.yml if needed.
 inventories/*/*/host_vars/*.local.yml
 

--- a/ansible/ceph/docs/architecture.md
+++ b/ansible/ceph/docs/architecture.md
@@ -247,8 +247,24 @@ to whichever worktree applied last. `scripts/render-inventories.sh <partition>
 | `inventory-destroy.ini`                    | Destroy-mode inventory (same credentials; separate file as a speed bump)                 |
 | `inventory-provision.ini`                  | Provisioning inventory (only when `provision_profile != null`; uses live-image creds; the profile names the template, not the output) |
 | `secrets.yml.tpl`                          | `vault_*: op://<vault>/<CLUSTER>_CEPH_*/password` pointers, consumed by `op inject -f`   |
+| `group_vars/all/ceph-config.generated.yml` | `ceph_config_cluster` + `ceph_config_host` for `ceph_tuning`, from the cluster's `ceph_config` and its hosts' `ceph_config` |
+| `group_vars/all/operators.yml`             | `ops_authorized_keys` from the identity registry                                          |
 
-All four are in `ansible/ceph/.gitignore` for every cluster. Re-render with
+All of them are in `ansible/ceph/.gitignore` for every cluster.
+
+`ceph-config.generated.yml` lands in the same directory as the committed
+`vars.yml`, which is the same split `ansible/mgmt` uses (`users.generated.yml`
+beside `main.yml`) and `kubernetes/` uses (`cluster-settings.generated.yaml`
+beside `cluster-settings.yaml`): TF owns desired state, the committed file holds
+what TF has no opinion about.
+
+That split is load-bearing rather than stylistic. Ansible reads **every** file in
+`group_vars/all/` and merges them per key, last file wins, with no deep merge
+(default `hash_behaviour = replace`) -- and files load alphabetically, so
+`vars.yml` sorts after `ceph-config.generated.yml`. A `ceph_config_cluster` left
+behind in `vars.yml` would take the whole map and the rendered file would stop
+having any effect, silently. The two keys are owned by TF exclusively; `vars.yml`
+carries a pointer comment where the block used to be. Re-render with
 `mise run tf:apply` followed by `scripts/render-inventories.sh` for the
 partition + region you applied (`staging austin`, `prod htz-fsn1`). The script
 is read-only against state, so the apply has to come first for the `render`
@@ -514,6 +530,9 @@ inventories/
     inventory.ini                     TF-generated, gitignored
     inventory-destroy.ini             TF-generated, gitignored
     secrets.yml.tpl                   TF-generated, gitignored
+    group_vars/all/ceph-config.generated.yml
+                                      TF-generated, gitignored; ceph_config_cluster
+                                      + ceph_config_host for the ceph_tuning model
     group_vars/all/vars.yml           committed; carries the fabric VLANs, the
                                       EC profile, and the shared OSD device map
     host_vars/                        48 files, committed
@@ -556,6 +575,10 @@ flowchart TB
 - **group_vars/all/vars.yml** sets cluster-wide values: network topology,
   Ceph release, RGW config, monitoring ports, plus the `vault_*` ->
   consumable-name aliases (`ops_password: "{{ vault_ops_password }}"`).
+- **group_vars/all/ceph-config.generated.yml** (TF-rendered) carries
+  `ceph_config_cluster` and `ceph_config_host` -- the `ceph config set` desired
+  state. Same precedence tier as `vars.yml`; the two never name the same key,
+  because group_vars merging is last-file-wins per key rather than deep.
 - **host_vars** provides per-node physical topology.
 - **extra-vars from @tmpfile** carries op-injected `vault_ops_password`,
   `vault_ceph_dashboard_password`, `vault_grafana_admin_password`,

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -261,63 +261,14 @@ ceph_hdd_osds:
 ceph_ssd_osds:
   - { lv: vg0/ssd-osd }
 
-# === Ceph config overrides (see roles/ceph_tuning/defaults for the model) ===
+# === Ceph config overrides ===
 #
-# --- Deep scrub interval: 7 days -> 28 days ---
-# The role default (7d) is unachievable at this size and was never close. Deep
-# scrubbing 1.1 PiB inside the 02:00-06:00 window needs ~12 GB/s sustained, or
-# ~18 MB/s per HDD every night without pause. At 28 days it is ~3.1 GB/s over
-# 112 hours of window, about 4.6 MB/s per disk, which the fleet does comfortably.
+# Moved. Terraform renders `ceph_config_cluster` and `ceph_config_host` into
+# group_vars/all/ceph-config.generated.yml from clusters.auto.tfvars; edit it
+# there, then scripts/render-inventories.sh prod htz-fsn1.
 #
-# The consequence of the old value was not slow scrubbing, it was permanent
-# overrun: a PG past its deadline scrubs regardless of the window, so 2139 of
-# 4096 PGs were overdue and scrubbing around the clock, and the cluster ran
-# 1626 concurrent scrubs that mostly could not finish. Raising the interval put
-# the overdue count to zero immediately -- the work was not drained, it stopped
-# being demanded. Health warnings still fire at 1.75x the interval
-# (mon_warn_pg_not_deep_scrubbed_ratio), so ~49 days.
-#
-# osd_scrub_max_interval (shallow) stays at the 7-day default: shallow scrub is
-# cheap and keeps a weekly consistency signal.
-#
-# --- Scrub reservation and scheduling ---
-# Since 19.2.0 a replica QUEUES a scrub reservation request instead of denying
-# it when at capacity. With EC 16+4 a scrub needs 20 shard reservations at once,
-# and the cluster has 672x6 = 4032 remote slots, so only ~212 PGs can hold a
-# full set. The rest acquire partial sets and wait forever. Measured on
-# 2026-07-29: of 40 sampled PGs in "scrubbing" state, 37 were still reserving
-# and had issued no reads -- disks sat at 4-8% utilisation while 1565 PGs
-# claimed to be scrubbing. disable_reservation_queuing restores pre-Squid
-# grant-or-fail, so a primary that cannot assemble 20 backs off and frees what
-# it holds. Concurrency converged from 1565 to ~190.
-#
-# UPSTREAM REMOVES THIS OPTION IN THE NEXT RELEASE (its own config help says so).
-# Re-check on any Ceph upgrade: if it disappears, the deadlock returns silently.
-# Context: https://www.mail-archive.com/ceph-users@ceph.io/msg28007.html
-#
-# osd_max_scrubs is load-bearing BECAUSE of the above: under grant-or-fail it
-# sets sustainable concurrency directly (672*6/19 ~ 212 PGs; at the default 3 it
-# would be ~106). It did nothing while queuing was enabled.
-#
-# --- Provisional, kept pending evidence ---
-# osd_scrub_cost is upstream's recommended fix for mclock costing each scrub op
-# at 50 MiB against a 150 MiB/s budget. Measured effect here was +4.5%, inside
-# noise. osd_deep_scrub_stride and the custom mclock profile likewise showed
-# small gains under conditions that no longer apply. All three are kept for now
-# rather than reverted mid-incident; they are candidates to drop once the
-# cluster is quiet enough to A/B them properly. The custom profile is the one to
-# revisit first -- it makes us the owner of the client and recovery reservations
-# too, which the built-in profiles would otherwise manage.
-ceph_config_cluster:
-  osd:
-    osd_deep_scrub_interval: 2419200          # 28 days
-    osd_scrub_disable_reservation_queuing: true
-    osd_max_scrubs: 6
-    osd_scrub_cost: 50                        # provisional
-    osd_deep_scrub_stride: 2097152            # provisional, 2 MiB
-    osd_mclock_profile: custom                # provisional
-    osd_mclock_scheduler_background_recovery_res: 0.2
-    osd_mclock_scheduler_background_best_effort_res: 0.3
+# Do NOT reintroduce either key here: group_vars merges per key, last file
+# wins, and vars.yml sorts after the generated file.
 
 # === RGW ===
 # EC 16+4, HOST failure domain -- capacity-max profile (80% usable, m=4) for the

--- a/ansible/ceph/roles/ceph_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/defaults/main.yml
@@ -29,6 +29,12 @@ ceph_telemetry_enabled: true
 ceph_config_defaults:
   global:
     mon_target_pg_per_osd: 100
+    # `global`, not `osd`: the active mgr emits PG_NOT_DEEP_SCRUBBED from its
+    # own copy of this option, so an `osd` entry moves the OSD schedule and
+    # leaves the health check warning against the old interval. A cluster that
+    # widens this overrides it here, in `global`.
+    # docs.ceph.com/en/tentacle/rados/operations/health-checks/
+    osd_deep_scrub_interval: 604800
   osd:
     # Recovery/backfill. Conservative values sized for a small cluster on a
     # shared network; a cluster with a dedicated replication fabric should raise
@@ -43,10 +49,9 @@ ceph_config_defaults:
     # not prune the superseded `global` entries until the running OSD values are
     # confirmed, so a rejected write cannot quietly uncap backfill.
     osd_mclock_override_recovery_settings: true
-    # Scrub window -- 2-6 AM, deep scrub weekly.
+    # Scrub window -- 2-6 AM. osd_deep_scrub_interval lives in `global` above.
     osd_scrub_begin_hour: 2
     osd_scrub_end_hour: 6
-    osd_deep_scrub_interval: 604800
     # BlueStore block.db: 0 means use the entire LV.
     bluestore_block_db_size: 0
 
@@ -86,6 +91,10 @@ ceph_config_prune:
   - {section: global, name: osd_recovery_max_active}
   - {section: global, name: osd_recovery_sleep_hdd}
   - {section: global, name: osd_max_backfills}
+  # osd_deep_scrub_interval moved to `global`. Unlike the three above, a leftover
+  # here DOES change behaviour: `osd` is more specific, so it would hold the OSDs
+  # on the old interval. Set runs before rm, so the value never dips.
+  - {section: osd, name: osd_deep_scrub_interval}
 
 # Log rotation retention (days)
 ceph_log_retention_days: 30

--- a/ansible/ceph/roles/ceph_tuning/tasks/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/tasks/main.yml
@@ -39,6 +39,21 @@
 # `float` filter returns 0.0 for anything non-numeric -- which would read
 # "balanced" and "high_recovery_ops" as equal.
 
+# A render that predates the TF ceph_config model lacks the generated file;
+# the model would then fall back to role defaults and REVERT cluster tuning
+# (e.g. spice's deep scrub interval back to 7d). Fail instead of converging.
+- name: Require the TF-rendered ceph config (guards against a stale render)
+  ansible.builtin.assert:
+    that: >-
+      lookup('ansible.builtin.file',
+             inventory_dir ~ '/group_vars/all/ceph-config.generated.yml',
+             errors='ignore') is truthy
+    fail_msg: >-
+      {{ inventory_dir }}/group_vars/all/ceph-config.generated.yml is missing.
+      Re-render: scripts/render-inventories.sh <partition> <region>
+      (after the stack has been applied).
+  when: inventory_hostname in groups['ceph_bootstrap']
+
 - name: Merge Ceph config layers
   ansible.builtin.set_fact:
     ceph_config_effective: >-

--- a/ansible/ceph/scripts/preflight.sh
+++ b/ansible/ceph/scripts/preflight.sh
@@ -4,7 +4,7 @@
 # resolves via op inject, SSH connectivity, Python on targets.
 #
 # Target inventory + secrets template are located via CEPH_ENV (path to
-# the TF-rendered inventory file — TF is the authoritative source of
+# the TF-rendered inventory file; TF is the authoritative source of
 # cluster identity, declared in tf/deployment/<partition>/<region>/ceph/clusters.auto.tfvars).
 set -euo pipefail
 
@@ -60,6 +60,7 @@ echo "--- Controller ---"
 check "ansible-play.sh wrapper executable" test -x scripts/ansible-play.sh
 check "Inventory file (TF-rendered) present" test -f "$INV"
 check "Secrets template (TF-rendered) present" test -f "$TEMPLATE"
+check "Ceph config (TF-rendered) present" test -f "${INV_DIR}/group_vars/all/ceph-config.generated.yml"
 check "SSH private key exists" test -f "$SSH_KEY"
 check "SSH public key exists" test -f "${SSH_KEY}.pub"
 check "Ansible installed" ansible --version
@@ -107,8 +108,8 @@ echo ""
 echo "=== Results ==="
 echo "  Passed: $PASS  Failed: $FAIL  Warnings: $WARN"
 if [ "$FAIL" -gt 0 ]; then
-  echo "  Pre-flight FAILED — fix issues above before proceeding."
+  echo "  Pre-flight FAILED: fix issues above before proceeding."
   exit 1
 else
-  echo "  Pre-flight OK — safe to proceed."
+  echo "  Pre-flight OK: safe to proceed."
 fi

--- a/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
+++ b/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
@@ -31,6 +31,44 @@ clusters = {
     # SPICE_CEPH_ALERTMANAGER_WEBHOOK_URL is provisioned out of band (Zulip
     # incoming webhook) and referenced, never generated. See secrets.tf.
     alertmanager_webhook = true
+
+    # === Ceph config (-> group_vars/all/ceph-config.generated.yml) ===
+    # Desired state for `ceph config set`, merged over the ceph_tuning defaults.
+    #
+    # Deep scrub at 7d (the role default) is unachievable at this size: the
+    # 02:00-06:00 window cannot carry it, so PGs ran permanently overdue and
+    # scrubbed around the clock. 28d fits. Shallow scrub stays at 7d.
+    #
+    # `global`, not `osd`: the active mgr emits PG_NOT_DEEP_SCRUBBED from its own
+    # copy, so an `osd` entry leaves the check on the 7-day default. It lived in
+    # `osd` until 2026-08-03 and warned at 12.25 days with nothing overdue.
+    #
+    # Since 19.2.0 a replica queues a scrub reservation instead of denying it.
+    # EC 16+4 needs 20 shard reservations at once against 4032 remote slots, so
+    # most PGs hold partial sets and wait forever. disable_reservation_queuing
+    # restores grant-or-fail; osd_max_scrubs only means anything once it does.
+    # UPSTREAM REMOVES THAT OPTION IN THE NEXT RELEASE -- re-check on any Ceph
+    # upgrade or the deadlock returns silently.
+    # https://www.mail-archive.com/ceph-users@ceph.io/msg28007.html
+    #
+    # osd_scrub_cost, osd_deep_scrub_stride and the custom mclock profile are
+    # provisional: measured gains were inside noise, under conditions that no
+    # longer apply. Drop them once the cluster is quiet enough to A/B properly,
+    # the profile first (it makes us owner of the client/recovery reservations).
+    ceph_config = {
+      global = {
+        osd_deep_scrub_interval = "2419200" # 28 days
+      }
+      osd = {
+        osd_scrub_disable_reservation_queuing           = "true"
+        osd_max_scrubs                                  = "6"
+        osd_scrub_cost                                  = "50"      # provisional
+        osd_deep_scrub_stride                           = "2097152" # provisional, 2 MiB
+        osd_mclock_profile                              = "custom"  # provisional
+        osd_mclock_scheduler_background_recovery_res    = "0.2"
+        osd_mclock_scheduler_background_best_effort_res = "0.3"
+      }
+    }
     hosts = [
       { name = "adelia", bond_ip = "178.63.139.248", bootstrap = true, roles = ["mon", "mgr", "osd", "rgw"] }, # srv 3008187 host_index 4  MON
       { name = "alexus", bond_ip = "178.63.139.254", roles = ["osd", "rgw"] },                                 # srv 3008189 host_index 5

--- a/tf/deployment/prod/htz-fsn1/ceph/main.tf
+++ b/tf/deployment/prod/htz-fsn1/ceph/main.tf
@@ -16,6 +16,7 @@ module "cluster" {
   provision_profile = each.value.provision_profile
 
   alertmanager_webhook = each.value.alertmanager_webhook
+  ceph_config          = each.value.ceph_config
 
   # Password items (<CLUSTER>_CEPH_*) are created at the stack level in
   # secrets.tf (mirrors tf/deployment/staging/talos), using this module's

--- a/tf/deployment/prod/htz-fsn1/ceph/variables.tf
+++ b/tf/deployment/prod/htz-fsn1/ceph/variables.tf
@@ -14,11 +14,16 @@ variable "clusters" {
     # the cluster's alertmanager gets a real receiver. See the ceph-cluster
     # module's alertmanager_webhook variable.
     alertmanager_webhook = optional(bool, false)
+    # -> group_vars/all/ceph-config.generated.yml (`ceph_config_cluster`).
+    # See the ceph-cluster module's ceph_config variable.
+    ceph_config = optional(map(map(string)), {})
     hosts = list(object({
       name      = optional(string)
       bond_ip   = string
       bootstrap = optional(bool, false)
       roles     = optional(list(string), ["mon", "mgr", "osd", "rgw"])
+      # -> `<section>/host:<hostname>` in ceph_config_host.
+      ceph_config = optional(map(map(string)), {})
     }))
   }))
 }

--- a/tf/deployment/staging/austin/ceph/main.tf
+++ b/tf/deployment/staging/austin/ceph/main.tf
@@ -14,6 +14,7 @@ module "cluster" {
   hosts            = each.value.hosts
 
   provision_profile = each.value.provision_profile
+  ceph_config       = each.value.ceph_config
 
   # Password items (<CLUSTER>_CEPH_*) are created at the stack level in
   # secrets.tf (mirrors tf/deployment/staging/talos), using this module's

--- a/tf/deployment/staging/austin/ceph/variables.tf
+++ b/tf/deployment/staging/austin/ceph/variables.tf
@@ -10,11 +10,16 @@ variable "clusters" {
     ansible_ssh_key   = string
     vault             = optional(string, "Yucca")
     provision_profile = optional(string)
+    # -> group_vars/all/ceph-config.generated.yml (`ceph_config_cluster`).
+    # Empty for sietch today; the schema mirrors prod/htz-fsn1.
+    ceph_config = optional(map(map(string)), {})
     hosts = list(object({
       name      = optional(string)
       bond_ip   = string
       bootstrap = optional(bool, false)
       roles     = optional(list(string), ["mon", "mgr", "osd", "rgw"])
+      # -> `<section>/host:<hostname>` in ceph_config_host.
+      ceph_config = optional(map(map(string)), {})
     }))
   }))
 }

--- a/tf/shared/modules/ceph-cluster/main.tf
+++ b/tf/shared/modules/ceph-cluster/main.tf
@@ -42,8 +42,18 @@ locals {
       roles          = h.roles
       hostname_short = "${var.cluster_name}-${var.role_in_hostname}-${module.names.resolved[i]}"
       fqdn           = "${var.cluster_name}-${var.role_in_hostname}-${module.names.resolved[i]}.${var.domain}"
+      ceph_config    = h.ceph_config
     }
   ]
+
+  # Per-host config -> `<section>/host:<hostname>`, the form `ceph config set`
+  # takes. Composed here so a tfvars entry names the host, not the mask syntax.
+  ceph_config_host = merge([
+    for h in local.hosts_computed : {
+      for section, options in h.ceph_config :
+      "${section}/host:${h.hostname_short}" => options
+    }
+  ]...)
 
   bootstrap_host = (
     length([for h in local.hosts_computed : h if h.bootstrap]) > 0

--- a/tf/shared/modules/ceph-cluster/rendering.tf
+++ b/tf/shared/modules/ceph-cluster/rendering.tf
@@ -1,22 +1,22 @@
-# Rendered Ansible artifacts (inventory files + secrets template).
+# Rendered Ansible artifacts (inventory files, secrets template, ceph config).
 #
 # These are exposed as module OUTPUTS (`rendered_files` / `inventory_dirname`),
-# NOT written by tofu via `local_file`. A local wrapper —
-# ansible/ceph/scripts/render-inventories.sh — reads the output and writes the
+# NOT written by tofu via `local_file`. A local wrapper
+# (ansible/ceph/scripts/render-inventories.sh) reads the output and writes the
 # files into the operator's own checkout.
 #
 # WHY: `local_file` stores the destination filename in state. With a shared
 # remote backend that path is machine/checkout-specific, so it coupled the
 # state to whichever git worktree last ran apply (get_repo_root() resolves to
 # the *worktree* root). Any apply from a different checkout then saw the
-# filename change and force-replaced every file — destroying the previous
+# filename change and force-replaced every file, destroying the previous
 # worktree's rendered files and rebinding shared state to the new path.
 # Keeping rendered content in outputs (and writing it locally) removes
 # filesystem paths from shared state entirely.
 
 locals {
   # Inventory directory name: <partition>-<region>/<cluster> (e.g. staging-austin/sietch).
-  # Region-scoped dir + friendly cluster leaf — matches the committed Ansible
+  # Region-scoped dir + friendly cluster leaf, matching the committed Ansible
   # inventory layout (ansible/ceph/inventories/<partition>-<region>/<cluster>/).
   inventory_dirname = "${var.partition}-${var.region}/${var.cluster_name}"
 
@@ -30,12 +30,27 @@ locals {
     ansible_ssh_key  = var.ansible_ssh_key
   }
 
+  # Encoded here, not in the template: `yamlencode` inside a heredoc defeats
+  # `tofu fmt`'s brace counting and it reindents the rest of the block.
+  _ceph_config_yaml = yamlencode({
+    ceph_config_cluster = var.ceph_config
+    ceph_config_host    = local.ceph_config_host
+  })
+
   # filename => rendered content. inventory-provision.ini is only produced when
   # a provision_profile is set (e.g., sietch's debian-live; installimage-provisioned clusters are null).
+  # ceph-config.generated.yml sits beside the committed vars.yml, same split as
+  # ansible/mgmt's users.generated.yml and kubernetes/'s cluster-settings.
   rendered_files = merge(
     {
       "inventory.ini"         = templatefile("${path.module}/templates/inventory.ini.tftpl", local._inventory_template_vars)
       "inventory-destroy.ini" = templatefile("${path.module}/templates/inventory-destroy.ini.tftpl", local._inventory_template_vars)
+      "group_vars/all/ceph-config.generated.yml" = templatefile("${path.module}/templates/ceph-config.generated.yml.tftpl", {
+        partition    = var.partition
+        region       = var.region
+        cluster_name = var.cluster_name
+        config_yaml  = local._ceph_config_yaml
+      })
       "secrets.yml.tpl" = templatefile("${path.module}/templates/secrets.yml.tpl.tftpl", {
         cluster_name  = var.cluster_name
         vault         = var.vault

--- a/tf/shared/modules/ceph-cluster/templates/ceph-config.generated.yml.tftpl
+++ b/tf/shared/modules/ceph-cluster/templates/ceph-config.generated.yml.tftpl
@@ -1,0 +1,9 @@
+---
+# GENERATED -- do not edit. Source:
+#   tf/deployment/${partition}/${region}/ceph/clusters.auto.tfvars
+# Re-render: mise run tf:apply (CI owns apply), then
+#   ansible/ceph/scripts/render-inventories.sh ${partition} ${region}
+#
+# Do NOT redefine these keys in vars.yml. Ansible merges group_vars per key,
+# last file wins, no deep merge -- and vars.yml sorts after this file.
+${config_yaml}

--- a/tf/shared/modules/ceph-cluster/variables.tf
+++ b/tf/shared/modules/ceph-cluster/variables.tf
@@ -54,12 +54,16 @@ variable "hosts" {
       - bond_ip:    primary IP address ansible connects to
       - bootstrap:  (optional) true for the cephadm bootstrap node; exactly one per cluster
       - roles:      list of Ceph roles (mon, mgr, osd, rgw); informational
+      - ceph_config: (optional) per-host Ceph config keyed by section
+                    ({ osd = { osd_max_backfills = "4" } }); rendered into
+                    ceph_config_host as `<section>/host:<hostname_short>`.
   EOT
   type = list(object({
-    name      = optional(string)
-    bond_ip   = string
-    bootstrap = optional(bool, false)
-    roles     = optional(list(string), ["mon", "mgr", "osd", "rgw"])
+    name        = optional(string)
+    bond_ip     = string
+    bootstrap   = optional(bool, false)
+    roles       = optional(list(string), ["mon", "mgr", "osd", "rgw"])
+    ceph_config = optional(map(map(string)), {})
   }))
 
   validation {
@@ -91,6 +95,25 @@ variable "provision_profile" {
     condition     = var.provision_profile == null || contains(["debian-live"], var.provision_profile)
     error_message = "provision_profile must be null or 'debian-live'."
   }
+}
+
+variable "ceph_config" {
+  description = <<-EOT
+    Cluster-level Ceph config, rendered into
+    group_vars/all/ceph-config.generated.yml as `ceph_config_cluster`, the
+    middle of the three layers roles/ceph_tuning merges.
+
+    Keys are whatever `ceph config set` takes as its <who>: a section
+    (`global`, `osd`), one daemon (`osd.5`), or a section plus a mask
+    (`osd/class:hdd`). Values are strings, because ceph_config_diff.py compares
+    them exact-then-numeric against `ceph config dump`, which reports every
+    option as a string.
+
+    Which section an option goes in is load-bearing, and not always the one its
+    name suggests. See roles/ceph_tuning/defaults/main.yml.
+  EOT
+  type        = map(map(string))
+  default     = {}
 }
 
 variable "name_seed" {


### PR DESCRIPTION
The Ceph config model (`ceph_config_cluster` / `ceph_config_host`) is now declared in the cluster's `clusters.auto.tfvars` and rendered by the ceph-cluster module into `group_vars/all/ceph-config.generated.yml`, beside the committed `vars.yml` -- the same generated/committed split as `ansible/mgmt` and `kubernetes/`. Per-host exceptions are declared on the host entry and the module composes the `<section>/host:<name>` mask keys. Because the model is no longer a committed file, `ceph_tuning` now refuses to converge when the rendered file is absent (a stale render would otherwise revert cluster tuning to role defaults); preflight checks for it too.

The move also fixes a section bug: `osd_deep_scrub_interval` sat in `osd`, but the active mgr emits PG\_NOT\_DEEP\_SCRUBBED from its own copy of the option, so spice warned on 2039 PGs against the 7-day default while the OSDs scrubbed on 28 days and nothing was overdue. The option now lives in `global` (role default and spice override alike), with a prune entry that clears the stale `osd` copy after the set. Already applied to spice by hand on 2026-08-03; the cluster is HEALTH\_OK and the next converge is a no-op for it.

See tf/shared/modules/ceph-cluster/variables.tf (ceph\_config) and ansible/ceph/docs/architecture.md.

<https://claude.ai/code/session_01UXpK3sqBGrsJQFwP6MeXxd>

- `main` <!-- branch-stack -->
  - \#410 :point\_left:
