### PR TITLE
fix(ceph): align the spice mclock model with the live cluster

### DIFF
--- a/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
+++ b/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
@@ -51,22 +51,22 @@ clusters = {
     # upgrade or the deadlock returns silently.
     # https://www.mail-archive.com/ceph-users@ceph.io/msg28007.html
     #
-    # osd_scrub_cost, osd_deep_scrub_stride and the custom mclock profile are
-    # provisional: measured gains were inside noise, under conditions that no
-    # longer apply. Drop them once the cluster is quiet enough to A/B properly,
-    # the profile first (it makes us owner of the client/recovery reservations).
+    # osd_scrub_cost and osd_deep_scrub_stride are provisional: measured gains
+    # were inside noise, under conditions that no longer apply. Drop them once
+    # the cluster is quiet enough to A/B properly. The custom mclock profile
+    # from the same incident is already gone: the cluster runs `balanced` (set
+    # live; the old model still said custom and would have re-imposed it on
+    # converge). balanced owns the scheduler reservations, so no _res overrides.
     ceph_config = {
       global = {
         osd_deep_scrub_interval = "2419200" # 28 days
       }
       osd = {
-        osd_scrub_disable_reservation_queuing           = "true"
-        osd_max_scrubs                                  = "6"
-        osd_scrub_cost                                  = "50"      # provisional
-        osd_deep_scrub_stride                           = "2097152" # provisional, 2 MiB
-        osd_mclock_profile                              = "custom"  # provisional
-        osd_mclock_scheduler_background_recovery_res    = "0.2"
-        osd_mclock_scheduler_background_best_effort_res = "0.3"
+        osd_scrub_disable_reservation_queuing = "true"
+        osd_max_scrubs                        = "6"
+        osd_scrub_cost                        = "50"      # provisional
+        osd_deep_scrub_stride                 = "2097152" # provisional, 2 MiB
+        osd_mclock_profile                    = "balanced"
       }
     }
     hosts = [


### PR DESCRIPTION
Verifying #410's model against the live cluster found drift the old committed vars.yml already carried: spice runs `osd_mclock_profile = balanced` (set live during the scrub incident wind-down, tracked nowhere), while the model still declared the provisional `custom` profile plus its two `_res` reservations. Left alone, the next converge would have re-imposed `custom` on the prod scheduler as a side effect.

The model now says what is live:

- `osd_mclock_profile custom -> balanced` (matches the explicit live entry)
- `osd_mclock_scheduler_background_recovery_res` / `_best_effort_res` dropped (only meaningful under `custom`; absent live)
- `osd_scrub_cost` and `osd_deep_scrub_stride` stay, verified live on a running OSD, still marked provisional

Diffed against `ceph config dump` after the edit: the model and the cluster now match on every declared key, so the next converge is a no-op.

- `main` <!-- branch-stack -->
  - \#411 :point\_left:
