### PR TITLE
feat(web): self-serve restic ui

### DIFF
--- a/packages/web/src/lib/components/connections/CreateResticModal.svelte
+++ b/packages/web/src/lib/components/connections/CreateResticModal.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { handleError } from "$lib/utils/handle-error";
+  import {
+    createRestic,
+    type ConnectionResticResponseDto,
+  } from "@futo-org/backups-api-client";
+  import {
+    Field,
+    FormModal,
+    HStack,
+    Input,
+    Select,
+    Stack,
+    Switch,
+    Text,
+  } from "@immich/ui";
+  import { t } from "svelte-i18n-lingui";
+
+  type Props = {
+    onClose: () => void;
+    onCreated: (result: ConnectionResticResponseDto) => void;
+  };
+  let { onClose, onCreated }: Props = $props();
+
+  const lifetimeOptions = [
+    { value: "30d", label: $t`30 days` },
+    { value: "90d", label: $t`90 days` },
+    { value: "365d", label: $t`1 year` },
+  ];
+
+  let name = $state("");
+  let expiresIn = $state("90d");
+  let label = $state("");
+  let worm = $state(false);
+  let pending = $state(false);
+
+  const onSubmit = async () => {
+    if (pending) {
+      return;
+    }
+    pending = true;
+    try {
+      const result = await createRestic({
+        name: name.trim() || undefined,
+        worm,
+        expiresIn,
+        label: label.trim() || undefined,
+      });
+      onCreated(result);
+      onClose();
+    } catch (error) {
+      handleError(error, $t`Failed to create restic backup`);
+    } finally {
+      pending = false;
+    }
+  };
+</script>
+
+<FormModal
+  size="small"
+  title={$t`New restic repository`}
+  submitText={$t`Create`}
+  disabled={pending}
+  {onSubmit}
+  {onClose}
+>
+  <Stack gap={4}>
+    <Field label={$t`Name`} description={$t`A label for this repository.`}>
+      <Input bind:value={name} placeholder={$t`e.g. laptop`} />
+    </Field>
+
+    <Field
+      label={$t`Access key lifetime`}
+      description={$t`How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner.`}
+    >
+      <Select bind:value={expiresIn} options={lifetimeOptions} />
+    </Field>
+
+    <Field
+      label={$t`Key label`}
+      description={$t`Shown in the access-key list.`}
+    >
+      <Input bind:value={label} placeholder={$t`e.g. my laptop`} />
+    </Field>
+
+    <HStack gap={3}>
+      <Switch bind:checked={worm} />
+      <Stack gap={0}>
+        <Text>{$t`Write-once (WORM)`}</Text>
+        <Text size="tiny" color="muted"
+          >{$t`Prevent this repository from being deleted or overwritten.`}</Text
+        >
+      </Stack>
+    </HStack>
+  </Stack>
+</FormModal>

--- a/packages/web/src/lib/components/connections/ManageTokensModal.svelte
+++ b/packages/web/src/lib/components/connections/ManageTokensModal.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { handleError } from "$lib/utils/handle-error";
+  import {
+    createResticUrl,
+    listResticTokens,
+    revoke,
+    type ResticTokenDto,
+  } from "@futo-org/backups-api-client";
+  import {
+    Badge,
+    Button,
+    HStack,
+    LoadingSpinner,
+    modalManager,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    Stack,
+    Text,
+    toastManager,
+  } from "@immich/ui";
+  import { t } from "svelte-i18n-lingui";
+  import ResticResultModal from "./ResticResultModal.svelte";
+
+  type Props = {
+    onClose: () => void;
+    repositoryId: string;
+    repositoryName: string;
+  };
+  let { onClose, repositoryId, repositoryName }: Props = $props();
+
+  let tokens = $state<ResticTokenDto[]>([]);
+  let loading = $state(true);
+  let busy = $state(false);
+
+  const isActive = (token: ResticTokenDto) =>
+    !token.revokedAt && new Date(token.expiresAt).getTime() > Date.now();
+
+  const load = async () => {
+    loading = true;
+    try {
+      tokens = (await listResticTokens(repositoryId)).tokens;
+    } catch (error) {
+      handleError(error, $t`Failed to load access keys`);
+    } finally {
+      loading = false;
+    }
+  };
+
+  const onRevoke = async (jti: string) => {
+    if (busy) {
+      return;
+    }
+    busy = true;
+    try {
+      await revoke(jti);
+      toastManager.info($t`Access key revoked`);
+      await load();
+    } catch (error) {
+      handleError(error, $t`Failed to revoke access key`);
+    } finally {
+      busy = false;
+    }
+  };
+
+  const onRemint = async () => {
+    if (busy) {
+      return;
+    }
+    busy = true;
+    try {
+      const { url } = await createResticUrl(repositoryId, {});
+      await load();
+      modalManager.open(ResticResultModal, { url, repositoryName });
+    } catch (error) {
+      handleError(error, $t`Failed to mint a new access key`);
+    } finally {
+      busy = false;
+    }
+  };
+
+  const formatDate = (value: string) => new Date(value).toLocaleDateString();
+
+  $effect(() => {
+    void load();
+  });
+</script>
+
+<Modal title={$t`Access keys: ${repositoryName}`} icon={false} {onClose}>
+  <ModalBody>
+    {#if loading}
+      <HStack><LoadingSpinner /></HStack>
+    {:else if tokens.length === 0}
+      <Text color="muted">{$t`No access keys yet.`}</Text>
+    {:else}
+      <Stack gap={0} class="divide-y rounded-2xl border overflow-hidden">
+        {#each tokens as token (token.jti)}
+          <HStack class="justify-between p-3">
+            <Stack gap={0}>
+              <Text>{token.label ?? $t`Access key`}</Text>
+              <Text size="tiny" color="muted">
+                {$t`Created ${formatDate(token.createdAt)} · expires ${formatDate(token.expiresAt)}`}
+              </Text>
+            </Stack>
+            {#if isActive(token)}
+              <Button
+                size="tiny"
+                shape="round"
+                color="danger"
+                variant="outline"
+                disabled={busy}
+                onclick={() => onRevoke(token.jti)}>{$t`Revoke`}</Button
+              >
+            {:else}
+              <Badge color="secondary"
+                >{token.revokedAt ? $t`Revoked` : $t`Expired`}</Badge
+              >
+            {/if}
+          </HStack>
+        {/each}
+      </Stack>
+    {/if}
+  </ModalBody>
+  <ModalFooter>
+    <HStack fullWidth gap={2}>
+      <Button shape="round" color="secondary" fullWidth onclick={onClose}
+        >{$t`Close`}</Button
+      >
+      <Button shape="round" fullWidth disabled={busy} onclick={onRemint}
+        >{$t`New access key`}</Button
+      >
+    </HStack>
+  </ModalFooter>
+</Modal>

--- a/packages/web/src/lib/components/connections/NewConnectionModal.svelte
+++ b/packages/web/src/lib/components/connections/NewConnectionModal.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import {
+    CONNECTION_TYPES,
+    type ConnectionTypeMeta,
+  } from "$lib/components/connections/connection-types";
+  import {
+    Badge,
+    Button,
+    Card,
+    CardBody,
+    HStack,
+    Icon,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    Stack,
+    Text,
+  } from "@immich/ui";
+  import { t } from "svelte-i18n-lingui";
+
+  type Props = {
+    onClose: () => void;
+    types: string[];
+    onPick: (type: string) => void;
+  };
+  let { onClose, types, onPick }: Props = $props();
+
+  const shown = $derived(
+    CONNECTION_TYPES.filter((meta) => types.includes(meta.type)),
+  );
+
+  let selected = $state<ConnectionTypeMeta | undefined>(
+    CONNECTION_TYPES.find((meta) => types.includes(meta.type) && meta.addable),
+  );
+
+  const proceed = () => {
+    if (!selected) {
+      return;
+    }
+    onPick(selected.type);
+    onClose();
+  };
+</script>
+
+<Modal title={$t`New connection`} icon={false} {onClose}>
+  <ModalBody>
+    <Stack gap={3}>
+      <Text color="muted"
+        >{$t`Pick what you want to back up. Each connection type works a little differently.`}</Text
+      >
+
+      {#each shown as meta (meta.type)}
+        {@const disabled = !meta.addable}
+        <Card
+          class={disabled
+            ? "opacity-60"
+            : selected?.type === meta.type
+              ? "ring-primary cursor-pointer ring-2"
+              : "cursor-pointer"}
+          onclick={disabled ? undefined : () => (selected = meta)}
+        >
+          <CardBody>
+            <HStack gap={3} class="items-start">
+              <Icon
+                icon={meta.icon}
+                size="1.75em"
+                color={disabled ? "muted" : undefined}
+              />
+              <Stack gap={1}>
+                <HStack gap={2}>
+                  <Text size="large" color={disabled ? "muted" : undefined}
+                    >{meta.label}</Text
+                  >
+                  {#if disabled}
+                    <Badge color="secondary" size="small">{$t`Automatic`}</Badge
+                    >
+                  {/if}
+                </HStack>
+                <Text color="muted">{meta.description}</Text>
+                <Text size="tiny" color="muted">{meta.limitation}</Text>
+              </Stack>
+            </HStack>
+          </CardBody>
+        </Card>
+      {/each}
+    </Stack>
+  </ModalBody>
+  <ModalFooter>
+    <HStack fullWidth gap={2}>
+      <Button shape="round" color="secondary" fullWidth onclick={onClose}
+        >{$t`Cancel`}</Button
+      >
+      <Button
+        shape="round"
+        fullWidth
+        disabled={!selected || !selected.addable}
+        onclick={proceed}>{$t`Continue`}</Button
+      >
+    </HStack>
+  </ModalFooter>
+</Modal>

--- a/packages/web/src/lib/components/connections/ResticResultModal.svelte
+++ b/packages/web/src/lib/components/connections/ResticResultModal.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import {
+    Alert,
+    Button,
+    Code,
+    HStack,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    Stack,
+    Text,
+    toastManager,
+  } from "@immich/ui";
+  import { mdiCheck, mdiContentCopy } from "@mdi/js";
+  import { t } from "svelte-i18n-lingui";
+
+  type Props = {
+    onClose: () => void;
+    url: string;
+    repositoryName: string;
+  };
+  let { onClose, url, repositoryName }: Props = $props();
+
+  const initCommand = $derived(`restic -r "${url}" init`);
+
+  let copied = $state<string | null>(null);
+  let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const copy = async (id: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      copied = id;
+      clearTimeout(copiedTimer);
+      copiedTimer = setTimeout(() => (copied = null), 2000);
+      toastManager.info($t`Copied to clipboard`);
+    } catch {
+      toastManager.danger($t`Couldn't copy. Select the text manually`);
+    }
+  };
+</script>
+
+<Modal title={$t`Restic backup ready`} icon={false} {onClose}>
+  <ModalBody>
+    <Stack gap={5}>
+      <Stack gap={1}>
+        <Text>{$t`Repository`}</Text>
+        <Text size="large">{repositoryName}</Text>
+      </Stack>
+
+      <Stack gap={2}>
+        <HStack class="justify-between">
+          <Text>{$t`Repository URL`}</Text>
+          <Button
+            size="tiny"
+            shape="round"
+            variant="outline"
+            color={copied === "url" ? "success" : "secondary"}
+            leadingIcon={copied === "url" ? mdiCheck : mdiContentCopy}
+            onclick={() => copy("url", url)}
+          >
+            {copied === "url" ? $t`Copied` : $t`Copy`}
+          </Button>
+        </HStack>
+        <Code class="break-all select-all">{url}</Code>
+      </Stack>
+
+      <Stack gap={2}>
+        <HStack class="justify-between">
+          <Text>{$t`Initialize the repository`}</Text>
+          <Button
+            size="tiny"
+            shape="round"
+            variant="outline"
+            color={copied === "cmd" ? "success" : "secondary"}
+            leadingIcon={copied === "cmd" ? mdiCheck : mdiContentCopy}
+            onclick={() => copy("cmd", initCommand)}
+          >
+            {copied === "cmd" ? $t`Copied` : $t`Copy`}
+          </Button>
+        </HStack>
+        <Code class="break-all select-all">{initCommand}</Code>
+      </Stack>
+
+      <Alert color="warning" title={$t`Choose a strong repository password`}>
+        {$t`restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered.`}
+      </Alert>
+    </Stack>
+  </ModalBody>
+  <ModalFooter>
+    <Button shape="round" fullWidth onclick={onClose}>{$t`Done`}</Button>
+  </ModalFooter>
+</Modal>

--- a/packages/web/src/lib/components/connections/connection-types.ts
+++ b/packages/web/src/lib/components/connections/connection-types.ts
@@ -1,4 +1,4 @@
-import { mdiImageMultiple } from '@mdi/js';
+import { mdiFolderNetwork, mdiImageMultiple } from '@mdi/js';
 
 export type ConnectionTypeMeta = {
   type: string;
@@ -18,5 +18,15 @@ export const CONNECTION_TYPES: ConnectionTypeMeta[] = [
     limitation:
       'Added automatically when you connect FUTO Backups from the Immich app; not created here.',
     addable: false,
+  },
+  {
+    type: 'restic',
+    label: 'Restic',
+    icon: mdiFolderNetwork,
+    description:
+      'Back up any files with restic. Create a repository and get a URL to point restic at.',
+    limitation:
+      'No client telemetry; we only see stored size, not backup runs.',
+    addable: true,
   },
 ];

--- a/packages/web/src/locales/en.po
+++ b/packages/web/src/locales/en.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "{0} objects"
-#~ msgstr "{0} objects"
+msgid "{0} objects"
+msgstr "{0} objects"
 
 #: src/routes/dashboard/connections/+page.svelte
 msgid "{0} repositories"
@@ -26,72 +26,72 @@ msgstr "{0} repositories"
 #~ msgstr "{num, plural, one {# item} other {# items}}"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "1 year"
-#~ msgstr "1 year"
+msgid "1 year"
+msgstr "1 year"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "30 days"
-#~ msgstr "30 days"
+msgid "30 days"
+msgstr "30 days"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "90 days"
-#~ msgstr "90 days"
+msgid "90 days"
+msgstr "90 days"
 
 #: src/routes/dashboard/connections/+page.svelte
 #~ msgid "A connection is a client that backs up this account — an Immich instance or a restic repository."
 #~ msgstr "A connection is a client that backs up this account — an Immich instance or a restic repository."
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "A label for this repository."
-#~ msgstr "A label for this repository."
+msgid "A label for this repository."
+msgstr "A label for this repository."
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Access key"
-#~ msgstr "Access key"
+msgid "Access key"
+msgstr "Access key"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Access key lifetime"
-#~ msgstr "Access key lifetime"
+msgid "Access key lifetime"
+msgstr "Access key lifetime"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Access key revoked"
-#~ msgstr "Access key revoked"
+msgid "Access key revoked"
+msgstr "Access key revoked"
 
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "Access keys"
-#~ msgstr "Access keys"
+msgid "Access keys"
+msgstr "Access keys"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
 #~ msgid "Access keys — {0}"
 #~ msgstr "Access keys — {0}"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Access keys: {0}"
-#~ msgstr "Access keys: {0}"
+msgid "Access keys: {0}"
+msgstr "Access keys: {0}"
 
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "Add {0} connection"
-#~ msgstr "Add {0} connection"
+msgid "Add {0} connection"
+msgstr "Add {0} connection"
 
 #: src/lib/components/connections/NewConnectionModal.svelte
-#~ msgid "Automatic"
-#~ msgstr "Automatic"
+msgid "Automatic"
+msgstr "Automatic"
 
 #: src/routes/dashboard/connections/+page.svelte
 msgid "billed"
 msgstr "billed"
 
 #: src/lib/components/connections/NewConnectionModal.svelte
-#~ msgid "Cancel"
-#~ msgstr "Cancel"
+msgid "Cancel"
+msgstr "Cancel"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Choose a strong repository password"
-#~ msgstr "Choose a strong repository password"
+msgid "Choose a strong repository password"
+msgstr "Choose a strong repository password"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Close"
-#~ msgstr "Close"
+msgid "Close"
+msgstr "Close"
 
 #: src/routes/dashboard/connections/+page.svelte
 #: src/routes/dashboard/connections/+page.svelte
@@ -106,23 +106,24 @@ msgstr "Connections"
 msgid "Connections are the sources of data that back up to us. Right now, that's mostly Immich."
 msgstr "Connections are the sources of data that back up to us. Right now, that's mostly Immich."
 
+#: src/lib/components/connections/NewConnectionModal.svelte
 #: src/routes/login/invite/+page.svelte
 msgid "Continue"
 msgstr "Continue"
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Copied"
-#~ msgstr "Copied"
+msgid "Copied"
+msgstr "Copied"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Copied to clipboard"
-#~ msgstr "Copied to clipboard"
+msgid "Copied to clipboard"
+msgstr "Copied to clipboard"
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Copy"
-#~ msgstr "Copy"
+msgid "Copy"
+msgstr "Copy"
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #~ msgid "Copy command"
@@ -137,64 +138,64 @@ msgstr "Continue"
 #~ msgstr "Couldn't copy — select the text manually"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Couldn't copy. Select the text manually"
-#~ msgstr "Couldn't copy. Select the text manually"
+msgid "Couldn't copy. Select the text manually"
+msgstr "Couldn't copy. Select the text manually"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Create"
-#~ msgstr "Create"
+msgid "Create"
+msgstr "Create"
 
 #: src/routes/dashboard/backups/+page.svelte
 #~ msgid "Create new backup"
 #~ msgstr "Create new backup"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Created {0} · expires {1}"
-#~ msgstr "Created {0} · expires {1}"
+msgid "Created {0} · expires {1}"
+msgstr "Created {0} · expires {1}"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Done"
-#~ msgstr "Done"
+msgid "Done"
+msgstr "Done"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "e.g. laptop"
-#~ msgstr "e.g. laptop"
+msgid "e.g. laptop"
+msgstr "e.g. laptop"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "e.g. my laptop"
-#~ msgstr "e.g. my laptop"
+msgid "e.g. my laptop"
+msgstr "e.g. my laptop"
 
 #: src/routes/login/invite/+page.svelte
 msgid "Enter an invite code to continue."
 msgstr "Enter an invite code to continue."
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Expired"
-#~ msgstr "Expired"
+msgid "Expired"
+msgstr "Expired"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Failed to create restic backup"
-#~ msgstr "Failed to create restic backup"
+msgid "Failed to create restic backup"
+msgstr "Failed to create restic backup"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Failed to load access keys"
-#~ msgstr "Failed to load access keys"
+msgid "Failed to load access keys"
+msgstr "Failed to load access keys"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Failed to mint a new access key"
-#~ msgstr "Failed to mint a new access key"
+msgid "Failed to mint a new access key"
+msgstr "Failed to mint a new access key"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Failed to revoke access key"
-#~ msgstr "Failed to revoke access key"
+msgid "Failed to revoke access key"
+msgstr "Failed to revoke access key"
 
 #: src/routes/+page.svelte
 #~ msgid "From the {0}: {1}"
 #~ msgstr "From the {0}: {1}"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner."
-#~ msgstr "How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner."
+msgid "How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner."
+msgstr "How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner."
 
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "How long the URL stays valid, e.g. 90d. Blank uses the default."
@@ -205,8 +206,8 @@ msgstr "Enter an invite code to continue."
 #~ msgstr "How long the URL stays valid. \"No expiry\" relies on revoking the key instead."
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Initialize the repository"
-#~ msgstr "Initialize the repository"
+msgid "Initialize the repository"
+msgstr "Initialize the repository"
 
 #: src/routes/login/invite/+page.svelte
 #: src/routes/login/invite/+page.svelte
@@ -215,8 +216,8 @@ msgid "Invite code"
 msgstr "Invite code"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Key label"
-#~ msgstr "Key label"
+msgid "Key label"
+msgstr "Key label"
 
 #: src/routes/+page.svelte
 #: src/routes/+page.svelte
@@ -228,17 +229,17 @@ msgid "Logout"
 msgstr "Logout"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Name"
-#~ msgstr "Name"
+msgid "Name"
+msgstr "Name"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "New access key"
-#~ msgstr "New access key"
+msgid "New access key"
+msgstr "New access key"
 
 #: src/lib/components/connections/NewConnectionModal.svelte
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "New connection"
-#~ msgstr "New connection"
+msgid "New connection"
+msgstr "New connection"
 
 #: src/lib/components/connections/CreateResticModal.svelte
 #: src/routes/dashboard/connections/+page.svelte
@@ -246,12 +247,12 @@ msgstr "Logout"
 #~ msgstr "New restic backup"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "New restic repository"
-#~ msgstr "New restic repository"
+msgid "New restic repository"
+msgstr "New restic repository"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "No access keys yet."
-#~ msgstr "No access keys yet."
+msgid "No access keys yet."
+msgstr "No access keys yet."
 
 #: src/routes/dashboard/connections/+page.svelte
 #~ msgid "No connections yet."
@@ -262,56 +263,56 @@ msgstr "Logout"
 #~ msgstr "No expiry"
 
 #: src/lib/components/connections/NewConnectionModal.svelte
-#~ msgid "Pick what you want to back up. Each connection type works a little differently."
-#~ msgstr "Pick what you want to back up. Each connection type works a little differently."
+msgid "Pick what you want to back up. Each connection type works a little differently."
+msgstr "Pick what you want to back up. Each connection type works a little differently."
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Prevent this repository from being deleted or overwritten."
-#~ msgstr "Prevent this repository from being deleted or overwritten."
+msgid "Prevent this repository from being deleted or overwritten."
+msgstr "Prevent this repository from being deleted or overwritten."
 
 #: src/routes/+page.svelte
 #~ msgid "Purchase Immich"
 #~ msgstr "Purchase Immich"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Repository"
-#~ msgstr "Repository"
+msgid "Repository"
+msgstr "Repository"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Repository URL"
-#~ msgstr "Repository URL"
+msgid "Repository URL"
+msgstr "Repository URL"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Restic backup ready"
-#~ msgstr "Restic backup ready"
+msgid "Restic backup ready"
+msgstr "Restic backup ready"
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #~ msgid "restic will ask you to set a password when you initialize. Keep it safe — it encrypts your backups and cannot be recovered."
 #~ msgstr "restic will ask you to set a password when you initialize. Keep it safe — it encrypts your backups and cannot be recovered."
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered."
-#~ msgstr "restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered."
+msgid "restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered."
+msgstr "restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered."
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Revoke"
-#~ msgstr "Revoke"
+msgid "Revoke"
+msgstr "Revoke"
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Revoked"
-#~ msgstr "Revoked"
+msgid "Revoked"
+msgstr "Revoked"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Shown in the access-key list."
-#~ msgstr "Shown in the access-key list."
+msgid "Shown in the access-key list."
+msgstr "Shown in the access-key list."
 
 #: src/lib/components/connections/NewConnectionModal.svelte
 #~ msgid "This connection type can't be added from here — see the note above."
 #~ msgstr "This connection type can't be added from here — see the note above."
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Write-once (WORM)"
-#~ msgstr "Write-once (WORM)"
+msgid "Write-once (WORM)"
+msgstr "Write-once (WORM)"
 
 #: src/routes/login/invite/+page.svelte
 msgid "Your email isn't part of the beta yet."

--- a/packages/web/src/locales/ja.po
+++ b/packages/web/src/locales/ja.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "{0} objects"
-#~ msgstr ""
+msgid "{0} objects"
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
 msgid "{0} repositories"
@@ -26,72 +26,72 @@ msgstr ""
 #~ msgstr "{num, plural, one {# hello} other {# hellos}}"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "1 year"
-#~ msgstr ""
+msgid "1 year"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "30 days"
-#~ msgstr ""
+msgid "30 days"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "90 days"
-#~ msgstr ""
+msgid "90 days"
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
 #~ msgid "A connection is a client that backs up this account — an Immich instance or a restic repository."
 #~ msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "A label for this repository."
-#~ msgstr ""
+msgid "A label for this repository."
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Access key"
-#~ msgstr ""
+msgid "Access key"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Access key lifetime"
-#~ msgstr ""
+msgid "Access key lifetime"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Access key revoked"
-#~ msgstr ""
+msgid "Access key revoked"
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "Access keys"
-#~ msgstr ""
+msgid "Access keys"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
 #~ msgid "Access keys — {0}"
 #~ msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Access keys: {0}"
-#~ msgstr ""
+msgid "Access keys: {0}"
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "Add {0} connection"
-#~ msgstr ""
+msgid "Add {0} connection"
+msgstr ""
 
 #: src/lib/components/connections/NewConnectionModal.svelte
-#~ msgid "Automatic"
-#~ msgstr ""
+msgid "Automatic"
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
 msgid "billed"
 msgstr ""
 
 #: src/lib/components/connections/NewConnectionModal.svelte
-#~ msgid "Cancel"
-#~ msgstr ""
+msgid "Cancel"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Choose a strong repository password"
-#~ msgstr ""
+msgid "Choose a strong repository password"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Close"
-#~ msgstr ""
+msgid "Close"
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
 #: src/routes/dashboard/connections/+page.svelte
@@ -106,23 +106,24 @@ msgstr ""
 msgid "Connections are the sources of data that back up to us. Right now, that's mostly Immich."
 msgstr ""
 
+#: src/lib/components/connections/NewConnectionModal.svelte
 #: src/routes/login/invite/+page.svelte
 msgid "Continue"
 msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Copied"
-#~ msgstr ""
+msgid "Copied"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Copied to clipboard"
-#~ msgstr ""
+msgid "Copied to clipboard"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Copy"
-#~ msgstr ""
+msgid "Copy"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #~ msgid "Copy command"
@@ -137,64 +138,64 @@ msgstr ""
 #~ msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Couldn't copy. Select the text manually"
-#~ msgstr ""
+msgid "Couldn't copy. Select the text manually"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Create"
-#~ msgstr ""
+msgid "Create"
+msgstr ""
 
 #: src/routes/dashboard/backups/+page.svelte
 #~ msgid "Create new backup"
 #~ msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Created {0} · expires {1}"
-#~ msgstr ""
+msgid "Created {0} · expires {1}"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Done"
-#~ msgstr ""
+msgid "Done"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "e.g. laptop"
-#~ msgstr ""
+msgid "e.g. laptop"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "e.g. my laptop"
-#~ msgstr ""
+msgid "e.g. my laptop"
+msgstr ""
 
 #: src/routes/login/invite/+page.svelte
 msgid "Enter an invite code to continue."
 msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Expired"
-#~ msgstr ""
+msgid "Expired"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Failed to create restic backup"
-#~ msgstr ""
+msgid "Failed to create restic backup"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Failed to load access keys"
-#~ msgstr ""
+msgid "Failed to load access keys"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Failed to mint a new access key"
-#~ msgstr ""
+msgid "Failed to mint a new access key"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Failed to revoke access key"
-#~ msgstr ""
+msgid "Failed to revoke access key"
+msgstr ""
 
 #: src/routes/+page.svelte
 #~ msgid "From the {0}: {1}"
 #~ msgstr "{0}! {1}?"
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner."
-#~ msgstr ""
+msgid "How long the URL stays valid (max 1 year). Revoke the key any time to end access sooner."
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "How long the URL stays valid, e.g. 90d. Blank uses the default."
@@ -205,8 +206,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Initialize the repository"
-#~ msgstr ""
+msgid "Initialize the repository"
+msgstr ""
 
 #: src/routes/login/invite/+page.svelte
 #: src/routes/login/invite/+page.svelte
@@ -215,8 +216,8 @@ msgid "Invite code"
 msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Key label"
-#~ msgstr ""
+msgid "Key label"
+msgstr ""
 
 #: src/routes/+page.svelte
 #: src/routes/+page.svelte
@@ -228,17 +229,17 @@ msgid "Logout"
 msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Name"
-#~ msgstr ""
+msgid "Name"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "New access key"
-#~ msgstr ""
+msgid "New access key"
+msgstr ""
 
 #: src/lib/components/connections/NewConnectionModal.svelte
 #: src/routes/dashboard/connections/+page.svelte
-#~ msgid "New connection"
-#~ msgstr ""
+msgid "New connection"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
 #: src/routes/dashboard/connections/+page.svelte
@@ -246,12 +247,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "New restic repository"
-#~ msgstr ""
+msgid "New restic repository"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "No access keys yet."
-#~ msgstr ""
+msgid "No access keys yet."
+msgstr ""
 
 #: src/routes/dashboard/connections/+page.svelte
 #~ msgid "No connections yet."
@@ -262,56 +263,56 @@ msgstr ""
 #~ msgstr ""
 
 #: src/lib/components/connections/NewConnectionModal.svelte
-#~ msgid "Pick what you want to back up. Each connection type works a little differently."
-#~ msgstr ""
+msgid "Pick what you want to back up. Each connection type works a little differently."
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Prevent this repository from being deleted or overwritten."
-#~ msgstr ""
+msgid "Prevent this repository from being deleted or overwritten."
+msgstr ""
 
 #: src/routes/+page.svelte
 #~ msgid "Purchase Immich"
 #~ msgstr "Hello Immich"
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Repository"
-#~ msgstr ""
+msgid "Repository"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Repository URL"
-#~ msgstr ""
+msgid "Repository URL"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "Restic backup ready"
-#~ msgstr ""
+msgid "Restic backup ready"
+msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
 #~ msgid "restic will ask you to set a password when you initialize. Keep it safe — it encrypts your backups and cannot be recovered."
 #~ msgstr ""
 
 #: src/lib/components/connections/ResticResultModal.svelte
-#~ msgid "restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered."
-#~ msgstr ""
+msgid "restic will ask you to set a password when you initialize. Keep it safe: it encrypts your backups and cannot be recovered."
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Revoke"
-#~ msgstr ""
+msgid "Revoke"
+msgstr ""
 
 #: src/lib/components/connections/ManageTokensModal.svelte
-#~ msgid "Revoked"
-#~ msgstr ""
+msgid "Revoked"
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Shown in the access-key list."
-#~ msgstr ""
+msgid "Shown in the access-key list."
+msgstr ""
 
 #: src/lib/components/connections/NewConnectionModal.svelte
 #~ msgid "This connection type can't be added from here — see the note above."
 #~ msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
-#~ msgid "Write-once (WORM)"
-#~ msgstr ""
+msgid "Write-once (WORM)"
+msgstr ""
 
 #: src/routes/login/invite/+page.svelte
 msgid "Your email isn't part of the beta yet."

--- a/packages/web/src/routes/dashboard/connections/+page.svelte
+++ b/packages/web/src/routes/dashboard/connections/+page.svelte
@@ -1,21 +1,55 @@
 <script lang="ts">
-  import { CONNECTION_TYPES } from "$lib/components/connections/connection-types";
-  import { type ConnectionDto } from "@futo-org/backups-api-client";
+  import { invalidateAll } from "$app/navigation";
+  import {
+    CONNECTION_TYPES,
+    type ConnectionTypeMeta,
+  } from "$lib/components/connections/connection-types";
+  import CreateResticModal from "$lib/components/connections/CreateResticModal.svelte";
+  import ManageTokensModal from "$lib/components/connections/ManageTokensModal.svelte";
+  import NewConnectionModal from "$lib/components/connections/NewConnectionModal.svelte";
+  import ResticResultModal from "$lib/components/connections/ResticResultModal.svelte";
+  import {
+    type ConnectionDto,
+    type ConnectionResticResponseDto,
+    type RepositoryWithMetricsDto,
+  } from "@futo-org/backups-api-client";
   import {
     Badge,
+    Button,
     Card,
+    CardBody,
     CardHeader,
     CardTitle,
     FormatBytes,
     Heading,
     HStack,
     Icon,
+    modalManager,
     Stack,
     Text,
   } from "@immich/ui";
+  import { mdiKeyChain, mdiPlus } from "@mdi/js";
   import { t } from "svelte-i18n-lingui";
 
   const { data } = $props();
+
+  const canRestic = $derived(
+    data.user?.features?.["connection-restic"] === true,
+  );
+
+  const visibleTypes = $derived(
+    CONNECTION_TYPES.filter((meta) => meta.type !== "restic" || canRestic),
+  );
+
+  const reposByConnection = $derived.by(() => {
+    const map = new Map<string, RepositoryWithMetricsDto[]>();
+    for (const repo of data.repositories) {
+      const list = map.get(repo.connectionId) ?? [];
+      list.push(repo);
+      map.set(repo.connectionId, list);
+    }
+    return map;
+  });
 
   const connectionsByType = $derived.by(() => {
     const map = new Map<string, ConnectionDto[]>();
@@ -27,6 +61,32 @@
     return map;
   });
 
+  const startCreate = (type: string) => {
+    if (type === "restic") {
+      modalManager.open(CreateResticModal, { onCreated });
+    }
+  };
+
+  const onCreated = (result: ConnectionResticResponseDto) => {
+    void invalidateAll();
+    modalManager.open(ResticResultModal, {
+      url: result.url,
+      repositoryName: result.repository.name,
+    });
+  };
+
+  const openNewConnection = () =>
+    modalManager.open(NewConnectionModal, {
+      types: visibleTypes.map((meta) => meta.type),
+      onPick: startCreate,
+    });
+
+  const openTokens = (repo: RepositoryWithMetricsDto) =>
+    modalManager.open(ManageTokensModal, {
+      repositoryId: repo.id,
+      repositoryName: repo.name,
+    });
+
   const typeColor = (type: string) =>
     type === "immich" ? "primary" : "success";
 </script>
@@ -35,18 +95,36 @@
 >
 
 <Stack gap={5}>
-  <Heading tag="h1" size="small">{$t`Connections`}</Heading>
+  <HStack class="justify-between">
+    <Heading tag="h1" size="small">{$t`Connections`}</Heading>
+    <Button shape="round" leadingIcon={mdiPlus} onclick={openNewConnection}
+      >{$t`New connection`}</Button
+    >
+  </HStack>
 
   <Text color="muted"
     >{$t`Connections are the sources of data that back up to us. Right now, that's mostly Immich.`}</Text
   >
 
-  {#each CONNECTION_TYPES as meta (meta.type)}
+  {#each visibleTypes as meta (meta.type)}
     {@const connections = connectionsByType.get(meta.type) ?? []}
     <Stack gap={2}>
-      <HStack gap={2}>
-        <Icon icon={meta.icon} />
-        <Heading size="tiny">{meta.label}</Heading>
+      <HStack class="justify-between">
+        <HStack gap={2}>
+          <Icon icon={meta.icon} />
+          <Heading size="tiny">{meta.label}</Heading>
+        </HStack>
+        {#if meta.addable}
+          <Button
+            size="tiny"
+            shape="round"
+            variant="outline"
+            leadingIcon={mdiPlus}
+            onclick={() => startCreate(meta.type)}
+          >
+            {$t`Add ${meta.label} connection`}
+          </Button>
+        {/if}
       </HStack>
 
       {#if connections.length === 0}
@@ -54,6 +132,7 @@
       {/if}
 
       {#each connections as connection (connection.id)}
+        {@const repos = reposByConnection.get(connection.id) ?? []}
         <Card>
           <CardHeader>
             <HStack class="justify-between">
@@ -70,6 +149,39 @@
               </Text>
             </HStack>
           </CardHeader>
+          {#if meta.addable && repos.length > 0}
+            <CardBody>
+              <Stack
+                gap={0}
+                class="divide-y rounded-2xl border overflow-hidden"
+              >
+                {#each repos as repo (repo.id)}
+                  <HStack class="justify-between p-3">
+                    <Stack gap={0}>
+                      <Text>{repo.name}</Text>
+                      {#if repo.meter}
+                        <Text size="tiny" color="muted">
+                          <FormatBytes bytes={repo.meter.sizeBytes} /> · {$t`${
+                            repo.meter.objectCount
+                          } objects`}
+                        </Text>
+                      {/if}
+                    </Stack>
+                    <Button
+                      size="tiny"
+                      shape="round"
+                      variant="outline"
+                      color="secondary"
+                      onclick={() => openTokens(repo)}
+                    >
+                      <Icon icon={mdiKeyChain} />
+                      {$t`Access keys`}
+                    </Button>
+                  </HStack>
+                {/each}
+              </Stack>
+            </CardBody>
+          {/if}
         </Card>
       {/each}
     </Stack>

--- a/packages/yucca-sdk/orchestration-ui/src/lib/services/repository.service.ts
+++ b/packages/yucca-sdk/orchestration-ui/src/lib/services/repository.service.ts
@@ -38,6 +38,9 @@ export const repositoryKeys = {
     ['repositories', id, 'check-import', backendId] as const,
 };
 
+const isBackupRepository = (repository: LocalRepositoryDto) =>
+  (repository as { connectionType?: string }).connectionType !== 'restic';
+
 export const useRepositories = (initialData?: LocalRepositoryDto[]) =>
   createQuery(
     () => ({
@@ -45,8 +48,12 @@ export const useRepositories = (initialData?: LocalRepositoryDto[]) =>
       queryFn: () =>
         getProvider()
           .getRepositories()
-          .then(({ repositories }) => repositories),
-      initialData,
+          .then(({ repositories }) =>
+            repositories.filter((repository) => isBackupRepository(repository)),
+          ),
+      initialData: initialData?.filter((repository) =>
+        isBackupRepository(repository),
+      ),
     }),
     () => queryClient,
   );


### PR DESCRIPTION
Self-serve restic UI, split out of the connections web PR so the connections UI can ship without restic.

Stack (bottom to top):

1. feat/conn-1-flags
2. feat/conn-2-connections
3. feat/conn-3-billing
4. feat/conn-6-web (connections UI, restic-free)
5. feat/conn-7-devstack
6. feat/conn-4-revocation (#392)
7. feat/conn-5-restic (#394)
8. **feat/conn-restic-web** (this PR)

Restores the restic modals (create / result / manage-tokens), the New-connection flow, the restic connection type, and the orchestrator restic-repo filter, on top of the self-serve restic API in #394.

- `main` <!-- branch-stack -->
  - \#415
    - \#416
      - \#392
        - \#394
          - \#412 :point\_left:
