### PR TITLE
feat(michael): per-client parallelism and latency metrics

### DIFF
--- a/o11y/README.md
+++ b/o11y/README.md
@@ -20,8 +20,8 @@ victoria-logs-collector.
 | --- | --- | --- |
 | `yucca-overview.json` | Single pane of glass: backup data plane + platform | michael OTLP, `ceph_rgw_*`, cadvisor, PVCs, coredns |
 | `yucca-michael.json` | Restic gateway deep dive: HTTP + S3 backend pool + source networks + logs | `http.server.request.*`, `s3.backend.*`, `traffic.*` (OTel, dotted names), VictoriaLogs |
-| `yucca-top-users.json` | Fleet-wide top talkers: storage, traffic, stale backups per user (rows link to the per-user board) | `rgw_repository_*`, `blobs.*`, `user_last_*` (all keyed by user id) |
-| `yucca-per-user.json` | Single-user drill-down: storage, backup health, traffic, logs. Deep-linkable as `/d/yucca-per-user?var-user=<id>` (`yuctl users view-dashboard`) | `rgw_repository_*`, `blobs.*`, `user_*`, VictoriaLogs |
+| `yucca-top-users.json` | Fleet-wide top talkers: storage, traffic, parallelism, stale backups per user (rows link to the per-user board) | `rgw_repository_*`, `blobs.*`, `client.request.*`, `user_last_*` (all keyed by user id) |
+| `yucca-per-user.json` | Single-user drill-down: storage, backup health, traffic, client behaviour, logs. Deep-linkable as `/d/yucca-per-user?var-user=<id>` (`yuctl users view-dashboard`) | `rgw_repository_*`, `blobs.*`, `client.*`, `user_*`, VictoriaLogs |
 | `yucca-spice-rgw-capacity.json` | RGW/pool capacity, S3 perf, OSD/BlueStore internals | `ceph_pool_*`, `ceph_rgw_*`, `ceph_osd_*`, `node_*` |
 | `yucca-spice-ceph-health.json` | Cluster health: quorum, OSDs, PGs, recovery, latency | `ceph_health_*`, `ceph_pg_*`, `ceph_osd_*` |
 | `yucca-spice-nodes.json` | 48-node fleet hotspots: CPU/mem/disk/fabric VLANs | `node_*` (job `ceph-node-exporter`) |
@@ -36,13 +36,29 @@ bytes moved per user/repository/blob-type (`blobs.*`, labels
 `customerId`/`repositoryId`/`type`) and requests per user
 (`http.server.request.{count,errors}` carry `customerId`/`repositoryId` on
 authenticated requests; the duration/TTFB histograms stay route-scoped),
+michael also accumulates per-client request-seconds (`client.request.*`) and a
+per-client concurrency high-water gauge (`client.requests.peak`),
 yucca-metrics-worker gauges authoritative RGW bucket usage every 5 min
 (`rgw_repository_*`), yucca-api / admin-api count every request per handler and
 customer (`api_request_count`, unsampled even though the request log lines are
 sampled), and yucca-api gauges client-reported backup health
 (`user_repository_size`, `user_last_*` — labels `user_id`/`repository_id`).
-Known gaps: no API-side latency histograms, and nothing scrapes CNPG or the
-envoy gateways on father.
+Known gaps: no API-side latency histograms, no per-client retry count (restic
+retries are invisible to michael and the orchestrator's restic wrapper drops
+stderr on success), and nothing scrapes CNPG or the envoy gateways on father.
+
+**Reading the per-client instruments.** `client.request.seconds` is a counter of
+accumulated request-seconds labeled by identity only (`customerId`,
+`repositoryId`, `connection` — no route or status). Its rate IS average
+parallelism, by Little's Law: `rate(client.request.seconds[5m])` is the mean
+number of that client's requests in flight over the window, needing no
+per-client state to compute. Dividing by the matching request rate gives mean
+duration, and `client.request.ttfb_seconds` does the same for time-to-first-byte
+— duration includes streaming the body, so the two diverging is how you tell a
+slow client from a slow backend. `client.requests.peak` covers what an average
+cannot, a client that saturates its `rest.connections` budget in bursts; it is
+per michael replica, so summing across replicas is an upper bound whereas the
+Little's Law average sums exactly.
 
 Source-network inventory (the "Source networks" row on the michael board):
 michael also counts traffic by the CLIENT's autonomous system —

--- a/o11y/dashboards/yucca-per-user.json
+++ b/o11y/dashboards/yucca-per-user.json
@@ -1237,6 +1237,339 @@
         "x": 0,
         "y": 48
       },
+      "id": 26,
+      "panels": [],
+      "title": "Client behaviour (michael restic gateway)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum by (repositoryId) (rate({__name__=\"client.request.seconds\", customerId=~\"$user\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{repositoryId}}"
+        }
+      ],
+      "title": "Average parallelism by repository",
+      "type": "timeseries",
+      "description": "Mean requests in flight, from accumulated request-seconds per second (Little's Law). Compare against the client's restic rest.connections budget."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum by (repositoryId) ({__name__=\"client.requests.peak\", customerId=~\"$user\", cluster=~\"$cluster\"})",
+          "legendFormat": "{{repositoryId}}"
+        }
+      ],
+      "title": "Peak parallelism by repository",
+      "type": "timeseries",
+      "description": "Highest concurrent request count per collection window. Summed across michael replicas, so it is an upper bound when a client spreads its connections; the average above sums exactly."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum by (repositoryId) (rate({__name__=\"client.request.seconds\", customerId=~\"$user\", cluster=~\"$cluster\"}[$__rate_interval]))\n/\nsum by (repositoryId) (rate({__name__=\"http.server.request.count\", customerId=~\"$user\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{repositoryId}}"
+        }
+      ],
+      "title": "Average request duration by repository",
+      "type": "timeseries",
+      "description": "Mean wall-clock per request. Includes streaming the body to the client, so on large blobs this tracks the client's link speed."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "sum by (repositoryId) (rate({__name__=\"client.request.ttfb_seconds\", customerId=~\"$user\", cluster=~\"$cluster\"}[$__rate_interval]))\n/\nsum by (repositoryId) (rate({__name__=\"http.server.request.count\", customerId=~\"$user\", cluster=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{repositoryId}}"
+        }
+      ],
+      "title": "Average time to first byte by repository",
+      "type": "timeseries",
+      "description": "Mean time to first response byte — michael plus RGW latency, without the client's download time. Diverging from duration above means a slow client, not a slow backend."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
       "id": 20,
       "panels": [],
       "title": "API activity (yucca-api / admin-api)",
@@ -1291,7 +1624,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 66
       },
       "id": 21,
       "options": {
@@ -1371,7 +1704,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 66
       },
       "id": 22,
       "options": {
@@ -1407,7 +1740,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 74
       },
       "id": 23,
       "panels": [],
@@ -1427,7 +1760,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 75
       },
       "id": 24,
       "options": {
@@ -1467,7 +1800,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 85
       },
       "id": 25,
       "options": {

--- a/o11y/dashboards/yucca-top-users.json
+++ b/o11y/dashboards/yucca-top-users.json
@@ -883,12 +883,172 @@
       "description": "Control-plane (yucca-api / admin-api) request rate."
     },
     {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "topk(10, sum by (customerId) (rate({__name__=\"client.request.seconds\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "{{customerId}}"
+        }
+      ],
+      "title": "Average parallelism by user (top 10)",
+      "type": "timeseries",
+      "description": "Mean requests in flight per user (Little's Law). The heaviest concurrent clients, which are not necessarily the heaviest by bytes."
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A",
+          "expr": "topk(10, sum by (customerId) (rate({__name__=\"client.request.seconds\", cluster=~\"$cluster\"}[$__rate_interval]))\n/\nsum by (customerId) (rate({__name__=\"http.server.request.count\", customerId!=\"\", cluster=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "{{customerId}}"
+        }
+      ],
+      "title": "Average request duration by user (top 10)",
+      "type": "timeseries",
+      "description": "Users seeing the slowest mean request. Includes body streaming, so a high value can mean a slow client link rather than a slow gateway."
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 53
       },
       "id": 13,
       "panels": [],
@@ -935,7 +1095,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 46
+        "y": 54
       },
       "id": 14,
       "options": {
@@ -1026,7 +1186,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 46
+        "y": 54
       },
       "id": 15,
       "options": {

--- a/packages/michael/internal/metrics/client.go
+++ b/packages/michael/internal/metrics/client.go
@@ -45,16 +45,41 @@ type clientConcurrency struct {
 	lastSeen atomic.Int64 // unix nanos, stamped when a request finishes
 }
 
+// retired marks an entry a collection has taken out of service. It is a state
+// of cur rather than a separate flag so that closing the entry and observing it
+// idle are one atomic step — otherwise a request arriving between the two would
+// be accounted against an entry already on its way out of the map.
+const retired = -1
+
 // enter accounts for a request starting, raising the high-water mark if this
-// request is the most concurrent one yet in the current window.
-func (c *clientConcurrency) enter() {
-	cur := c.cur.Add(1)
+// request is the most concurrent one yet in the current window. It reports
+// false if the entry has been retired, leaving the caller to take a fresh one.
+func (c *clientConcurrency) enter() bool {
+	for {
+		cur := c.cur.Load()
+		if cur == retired {
+			return false
+		}
+		if c.cur.CompareAndSwap(cur, cur+1) {
+			c.raisePeak(cur + 1)
+			return true
+		}
+	}
+}
+
+func (c *clientConcurrency) raisePeak(cur int64) {
 	for {
 		peak := c.peak.Load()
 		if cur <= peak || c.peak.CompareAndSwap(peak, cur) {
 			return
 		}
 	}
+}
+
+// retire closes the entry to new requests, and only succeeds while nothing is
+// outstanding.
+func (c *clientConcurrency) retire() bool {
+	return c.cur.CompareAndSwap(0, retired)
 }
 
 func (c *clientConcurrency) exit(now time.Time) {
@@ -67,14 +92,30 @@ type clientTracker struct {
 }
 
 // enter loads before storing so the hot path is a single map read; the label
-// set is only built when a client is seen for the first time.
+// set is only built when a client is seen for the first time. Losing the race
+// against a collection that retired the entry costs one more iteration, after
+// which the replacement is what every later request shares — the client must
+// not end up split across an orphan and a successor, which would under-report
+// its concurrency.
 func (t *clientTracker) enter(key clientAttrKey) *clientConcurrency {
-	v, ok := t.states.Load(key)
-	if !ok {
-		v, _ = t.states.LoadOrStore(key, &clientConcurrency{attrs: clientAttrs(key)})
+	for {
+		v, ok := t.states.Load(key)
+		if !ok {
+			v, _ = t.states.LoadOrStore(key, newClientConcurrency(key))
+		}
+		state := v.(*clientConcurrency)
+		if state.enter() {
+			return state
+		}
+		t.states.CompareAndSwap(key, state, newClientConcurrency(key))
 	}
-	state := v.(*clientConcurrency)
-	state.enter()
+}
+
+// newClientConcurrency stamps lastSeen so a brand-new entry cannot look idle to
+// a collection landing before its first request is accounted in.
+func newClientConcurrency(key clientAttrKey) *clientConcurrency {
+	state := &clientConcurrency{attrs: clientAttrs(key)}
+	state.lastSeen.Store(time.Now().UnixNano())
 	return state
 }
 
@@ -91,8 +132,13 @@ func (t *clientTracker) observe(o otelmetric.Observer, gauge otelmetric.Int64Obs
 		cur := state.cur.Load()
 		peak := state.peak.Swap(cur)
 
+		// Retire before deleting, and delete only the entry that was retired: a
+		// request arriving in between either wins (retire fails, the entry stays)
+		// or is handed the replacement it swapped in.
 		if cur == 0 && peak == 0 && now.UnixNano()-state.lastSeen.Load() > int64(clientIdleTTL) {
-			t.states.Delete(key)
+			if state.retire() {
+				t.states.CompareAndDelete(key, state)
+			}
 			return true
 		}
 

--- a/packages/michael/internal/metrics/client.go
+++ b/packages/michael/internal/metrics/client.go
@@ -1,0 +1,160 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+// clientIdleTTL bounds how long a client with nothing outstanding is kept in
+// the concurrency tracker. It only has to outlive the gap between collection
+// cycles — a client that comes back before eviction simply reuses its entry.
+const clientIdleTTL = 15 * time.Minute
+
+type clientAttrKey struct{ user, repository, connection string }
+
+// clientAttrs labels a measurement with the request's identity and nothing
+// else — no method, route or status. That is what keeps the per-client
+// instruments at a fixed handful of series per client-repository however
+// restic exercises the API, unlike the request counters which multiply by
+// route and status.
+func clientAttrs(key clientAttrKey) otelmetric.MeasurementOption {
+	return otelmetric.WithAttributeSet(attribute.NewSet(
+		attribute.String("customerId", key.user),
+		attribute.String("repositoryId", key.repository),
+		attribute.String("connection", key.connection),
+	))
+}
+
+// clientConcurrency is one client's outstanding-request accounting: cur is the
+// live count, peak the high-water mark since the last collection.
+//
+// The label set is built once and held here rather than in a cache of its own,
+// so it is reclaimed with the client on idle eviction. A separate cache keyed
+// by identity would instead grow with every client-repository pair the process
+// has ever seen.
+type clientConcurrency struct {
+	attrs    otelmetric.MeasurementOption
+	cur      atomic.Int64
+	peak     atomic.Int64
+	lastSeen atomic.Int64 // unix nanos, stamped when a request finishes
+}
+
+// enter accounts for a request starting, raising the high-water mark if this
+// request is the most concurrent one yet in the current window.
+func (c *clientConcurrency) enter() {
+	cur := c.cur.Add(1)
+	for {
+		peak := c.peak.Load()
+		if cur <= peak || c.peak.CompareAndSwap(peak, cur) {
+			return
+		}
+	}
+}
+
+func (c *clientConcurrency) exit(now time.Time) {
+	c.cur.Add(-1)
+	c.lastSeen.Store(now.UnixNano())
+}
+
+type clientTracker struct {
+	states sync.Map // clientAttrKey -> *clientConcurrency
+}
+
+// enter loads before storing so the hot path is a single map read; the label
+// set is only built when a client is seen for the first time.
+func (t *clientTracker) enter(key clientAttrKey) *clientConcurrency {
+	v, ok := t.states.Load(key)
+	if !ok {
+		v, _ = t.states.LoadOrStore(key, &clientConcurrency{attrs: clientAttrs(key)})
+	}
+	state := v.(*clientConcurrency)
+	state.enter()
+	return state
+}
+
+// observe reports each client's high-water concurrency and arms the next
+// window. The peak resets to the CURRENT outstanding count rather than zero:
+// restic holds its connections open for a whole backup, so a client sitting at
+// N concurrent requests across several collection cycles would otherwise
+// report N once and 0 forever after.
+func (t *clientTracker) observe(o otelmetric.Observer, gauge otelmetric.Int64ObservableGauge, now time.Time) {
+	t.states.Range(func(k, v any) bool {
+		key := k.(clientAttrKey)
+		state := v.(*clientConcurrency)
+
+		cur := state.cur.Load()
+		peak := state.peak.Swap(cur)
+
+		if cur == 0 && peak == 0 && now.UnixNano()-state.lastSeen.Load() > int64(clientIdleTTL) {
+			t.states.Delete(key)
+			return true
+		}
+
+		o.ObserveInt64(gauge, peak, state.attrs)
+		return true
+	})
+}
+
+// clientMetrics measures how each client drives the gateway, as opposed to how
+// the gateway performs per route.
+//
+// Parallelism comes from `seconds` by Little's Law: the rate of accumulated
+// request-seconds over a window IS the mean number of requests in flight, so
+// `rate(client.request.seconds)` reads directly as average concurrency without
+// any per-client state. Dividing it by the matching request rate from
+// `http.server.request.count` gives mean duration.
+//
+// `peak` covers what an average cannot — a client that saturates its
+// connection budget in bursts. Note it is per michael replica: a client whose
+// connections spread across replicas makes a summed peak an upper bound,
+// whereas the Little's Law average sums exactly.
+type clientMetrics struct {
+	seconds     otelmetric.Float64Counter
+	ttfbSeconds otelmetric.Float64Counter
+	tracker     *clientTracker
+}
+
+func newClientMetrics(meter otelmetric.Meter) (*clientMetrics, error) {
+	seconds, err := meter.Float64Counter("client.request.seconds",
+		otelmetric.WithDescription("Accumulated request-seconds per client; its rate is average parallelism"),
+		otelmetric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("creating client.request.seconds counter: %w", err)
+	}
+
+	// Duration runs until the client has drained the body, so on large blobs it
+	// measures the client's link; TTFB isolates michael+RGW. Split per client so
+	// a slow customer is distinguishable from a slow backend.
+	ttfbSeconds, err := meter.Float64Counter("client.request.ttfb_seconds",
+		otelmetric.WithDescription("Accumulated time-to-first-byte seconds per client"),
+		otelmetric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("creating client.request.ttfb_seconds counter: %w", err)
+	}
+
+	peak, err := meter.Int64ObservableGauge("client.requests.peak",
+		otelmetric.WithDescription("Highest number of concurrent requests per client since the last collection"))
+	if err != nil {
+		return nil, fmt.Errorf("creating client.requests.peak gauge: %w", err)
+	}
+
+	c := &clientMetrics{seconds: seconds, ttfbSeconds: ttfbSeconds, tracker: &clientTracker{}}
+
+	if _, err := meter.RegisterCallback(
+		func(_ context.Context, o otelmetric.Observer) error {
+			c.tracker.observe(o, peak, time.Now())
+			return nil
+		},
+		peak,
+	); err != nil {
+		return nil, fmt.Errorf("registering client concurrency callback: %w", err)
+	}
+
+	return c, nil
+}

--- a/packages/michael/internal/metrics/client_test.go
+++ b/packages/michael/internal/metrics/client_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -192,6 +193,124 @@ func TestClientTrackerEvictsIdleClients(t *testing.T) {
 	tr.states.Range(func(any, any) bool { count++; return true })
 	if count != 0 {
 		t.Fatalf("expected the tracker map to be empty, got %d entries", count)
+	}
+}
+
+// TestClientTrackerEvictionDoesNotSplitClient drives the eviction race by hand:
+// a request arrives after a collection has decided an entry is idle. The client
+// must end up on ONE entry — an orphan kept alive by the in-flight request while
+// later requests build a replacement would under-report its concurrency.
+func TestClientTrackerEvictionDoesNotSplitClient(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "restic"}
+
+	tr.enter(key).exit(time.Now())
+	v, _ := tr.states.Load(key)
+	idle := v.(*clientConcurrency)
+
+	// The collection retires the entry, then the request lands before the map
+	// delete would have run.
+	if !idle.retire() {
+		t.Fatal("expected an idle entry to retire")
+	}
+	racing := tr.enter(key)
+	if racing == idle {
+		t.Fatal("expected the retired entry to be replaced, not reused")
+	}
+
+	// The delete now arrives; it must not take the replacement with it.
+	tr.states.CompareAndDelete(key, idle)
+
+	current, ok := tr.states.Load(key)
+	if !ok {
+		t.Fatal("expected the replacement to survive the delete")
+	}
+	if current.(*clientConcurrency) != racing {
+		t.Fatal("expected the map to hold the entry the request is using")
+	}
+
+	// A later request must join the same entry rather than start a third one.
+	if next := tr.enter(key); next != racing {
+		t.Fatal("expected later requests to share the replacement")
+	}
+	if cur := racing.cur.Load(); cur != 2 {
+		t.Fatalf("expected both requests on one entry, got %d", cur)
+	}
+	if peak := peakFor(t, tr, collect(t, tr, time.Now()), key); peak != 2 {
+		t.Fatalf("expected the peak to see both requests, got %d", peak)
+	}
+}
+
+// TestClientTrackerEvictionKeepsRequestsAttached drives eviction and entry
+// against each other for real, with the clock always past the TTL so every
+// collection tries to evict. The invariant it checks is what the retire
+// handshake buys: an entry is only ever retired while idle, so a request that
+// is outstanding on a state must still find that state in the map. Deleting on
+// the idle read alone breaks this — the request is left updating an orphan
+// while later requests build a successor, splitting the client's concurrency.
+func TestClientTrackerEvictionKeepsRequestsAttached(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "restic"}
+	gauge := testGauge(t)
+
+	var orphaned atomic.Int64
+	done := make(chan struct{})
+	var collectors, requests sync.WaitGroup
+
+	// Collect for as long as requests are arriving, so the two actually overlap.
+	collectors.Add(1)
+	go func() {
+		defer collectors.Done()
+		obs := &recordingObserver{}
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				tr.observe(obs, gauge, time.Now().Add(2*clientIdleTTL))
+				obs.got = obs.got[:0]
+			}
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		requests.Add(1)
+		go func() {
+			defer requests.Done()
+			for n := 0; n < 20000; n++ {
+				state := tr.enter(key)
+				if v, ok := tr.states.Load(key); !ok || v.(*clientConcurrency) != state {
+					orphaned.Add(1)
+				}
+				state.exit(time.Now())
+			}
+		}()
+	}
+
+	requests.Wait()
+	close(done)
+	collectors.Wait()
+
+	if got := orphaned.Load(); got != 0 {
+		t.Fatalf("expected outstanding requests to stay attached to the mapped entry, got %d orphaned", got)
+	}
+}
+
+func TestClientConcurrencyRetireRequiresIdle(t *testing.T) {
+	c := &clientConcurrency{}
+	if !c.enter() {
+		t.Fatal("expected enter to succeed on a fresh entry")
+	}
+	if c.retire() {
+		t.Fatal("expected retire to fail while a request is outstanding")
+	}
+
+	c.exit(time.Now())
+	if !c.retire() {
+		t.Fatal("expected retire to succeed once idle")
+	}
+	if c.enter() {
+		t.Fatal("expected enter to fail on a retired entry")
 	}
 }
 

--- a/packages/michael/internal/metrics/client_test.go
+++ b/packages/michael/internal/metrics/client_test.go
@@ -1,0 +1,340 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"michael/internal/auth"
+
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// observation is one ObserveInt64 call captured from a collection cycle. The
+// option is retained rather than decoded: each client's label set is built once
+// and held on its tracker entry, so it can be compared by identity.
+type observation struct {
+	value int64
+	opt   otelmetric.ObserveOption
+}
+
+type recordingObserver struct {
+	embedded.Observer
+	got []observation
+}
+
+func (r *recordingObserver) ObserveFloat64(otelmetric.Float64Observable, float64, ...otelmetric.ObserveOption) {
+}
+
+func (r *recordingObserver) ObserveInt64(_ otelmetric.Int64Observable, value int64, opts ...otelmetric.ObserveOption) {
+	var opt otelmetric.ObserveOption
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	r.got = append(r.got, observation{value, opt})
+}
+
+// testGauge is the instrument handed to observe(); its identity is all the
+// tracker uses.
+func testGauge(t *testing.T) otelmetric.Int64ObservableGauge {
+	t.Helper()
+	gauge, err := noop.NewMeterProvider().Meter("test").Int64ObservableGauge("test")
+	if err != nil {
+		t.Fatalf("unexpected error creating gauge: %v", err)
+	}
+	return gauge
+}
+
+func collect(t *testing.T, tr *clientTracker, now time.Time) []observation {
+	t.Helper()
+	obs := &recordingObserver{}
+	tr.observe(obs, testGauge(t), now)
+	return obs.got
+}
+
+// peakFor returns the observed high-water mark for one client, matching on the
+// label set held by that client's tracker entry.
+func peakFor(t *testing.T, tr *clientTracker, got []observation, key clientAttrKey) int64 {
+	t.Helper()
+	v, ok := tr.states.Load(key)
+	if !ok {
+		t.Fatalf("no tracker entry for %+v", key)
+	}
+	var want otelmetric.ObserveOption = v.(*clientConcurrency).attrs
+	for _, o := range got {
+		if o.opt == want {
+			return o.value
+		}
+	}
+	t.Fatalf("no observation for %+v", key)
+	return 0
+}
+
+func TestClientAttrsBuiltOncePerClient(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "immich"}
+
+	first := tr.enter(key)
+	if second := tr.enter(key); second.attrs != first.attrs {
+		t.Fatal("expected repeat requests to reuse the client's label set")
+	}
+
+	for _, other := range []clientAttrKey{
+		{"u2", "r1", "immich"},
+		{"u1", "r2", "immich"},
+		{"u1", "r1", "restic"},
+	} {
+		if tr.enter(other).attrs == first.attrs {
+			t.Fatalf("expected %+v to get its own label set", other)
+		}
+	}
+}
+
+// TestClientAttrsReclaimedOnEviction is the memory bound: the label set lives on
+// the tracker entry, so an idle client leaves nothing behind. A cache keyed by
+// identity would instead retain every client-repository pair ever seen.
+func TestClientAttrsReclaimedOnEviction(t *testing.T) {
+	tr := &clientTracker{}
+	now := time.Now()
+
+	for _, key := range []clientAttrKey{{"u1", "r1", "restic"}, {"u2", "r2", "immich"}} {
+		tr.enter(key).exit(now)
+	}
+	collect(t, tr, now)                                // drain each peak to 0
+	collect(t, tr, now.Add(clientIdleTTL+time.Minute)) // evict
+
+	count := 0
+	tr.states.Range(func(any, any) bool { count++; return true })
+	if count != 0 {
+		t.Fatalf("expected every label set to be reclaimed, got %d retained", count)
+	}
+}
+
+func TestClientConcurrencyTracksHighWater(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "restic"}
+
+	first := tr.enter(key)
+	second := tr.enter(key)
+	third := tr.enter(key)
+	third.exit(time.Now())
+	second.exit(time.Now())
+
+	// Re-entering after a partial drain must not pull the high-water mark down
+	// to the new, lower concurrency: the window peaked at 3.
+	fourth := tr.enter(key)
+
+	if peak := peakFor(t, tr, collect(t, tr, time.Now()), key); peak != 3 {
+		t.Fatalf("expected peak 3, got %d", peak)
+	}
+
+	// The window resets to what is still outstanding, not to zero.
+	if peak := peakFor(t, tr, collect(t, tr, time.Now()), key); peak != 2 {
+		t.Fatalf("expected peak to reset to the outstanding count 2, got %d", peak)
+	}
+
+	first.exit(time.Now())
+	fourth.exit(time.Now())
+	if peak := peakFor(t, tr, collect(t, tr, time.Now()), key); peak != 2 {
+		t.Fatalf("expected the window those requests spanned to report 2, got %d", peak)
+	}
+	if peak := peakFor(t, tr, collect(t, tr, time.Now()), key); peak != 0 {
+		t.Fatalf("expected an idle client to report 0, got %d", peak)
+	}
+}
+
+func TestClientTrackerSeparatesClients(t *testing.T) {
+	tr := &clientTracker{}
+	tr.enter(clientAttrKey{"u1", "r1", "restic"})
+	tr.enter(clientAttrKey{"u1", "r2", "restic"})
+	tr.enter(clientAttrKey{"u2", "r3", "immich"})
+
+	got := collect(t, tr, time.Now())
+	if len(got) != 3 {
+		t.Fatalf("expected 3 tracked clients, got %d", len(got))
+	}
+	for _, key := range []clientAttrKey{
+		{"u1", "r1", "restic"},
+		{"u1", "r2", "restic"},
+		{"u2", "r3", "immich"},
+	} {
+		if peak := peakFor(t, tr, got, key); peak != 1 {
+			t.Fatalf("expected %+v at peak 1, got %d", key, peak)
+		}
+	}
+}
+
+func TestClientTrackerEvictsIdleClients(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "restic"}
+
+	state := tr.enter(key)
+	now := time.Now()
+	state.exit(now)
+
+	// Still inside the TTL, and the window's peak is not yet drained.
+	if got := collect(t, tr, now); len(got) != 1 {
+		t.Fatalf("expected the client to survive its first collection, got %d", len(got))
+	}
+	// Peak has drained to 0 but the TTL has not elapsed.
+	if got := collect(t, tr, now); len(got) != 1 {
+		t.Fatalf("expected the client to survive inside the TTL, got %d", len(got))
+	}
+	if got := collect(t, tr, now.Add(clientIdleTTL+time.Minute)); len(got) != 0 {
+		t.Fatalf("expected the idle client to be evicted, got %d", len(got))
+	}
+
+	count := 0
+	tr.states.Range(func(any, any) bool { count++; return true })
+	if count != 0 {
+		t.Fatalf("expected the tracker map to be empty, got %d entries", count)
+	}
+}
+
+func TestClientTrackerKeepsBusyClients(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "restic"}
+	tr.enter(key)
+
+	// lastSeen is only stamped on exit, so a client that has been holding a
+	// request open longer than the TTL must not be evicted underneath it.
+	if got := collect(t, tr, time.Now().Add(24*time.Hour)); len(got) != 1 {
+		t.Fatalf("expected a client with an outstanding request to survive, got %d", len(got))
+	}
+}
+
+func TestClientTrackerConcurrentEnterExit(t *testing.T) {
+	tr := &clientTracker{}
+	key := clientAttrKey{"u1", "r1", "restic"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tr.enter(key).exit(time.Now())
+		}()
+	}
+	wg.Wait()
+
+	v, ok := tr.states.Load(key)
+	if !ok {
+		t.Fatal("expected the client to be tracked")
+	}
+	if cur := v.(*clientConcurrency).cur.Load(); cur != 0 {
+		t.Fatalf("expected every request to be accounted out, got %d outstanding", cur)
+	}
+}
+
+func TestNewClientMetricsWithNoopMeter(t *testing.T) {
+	c, err := newClientMetrics(noop.NewMeterProvider().Meter("test"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.seconds == nil || c.ttfbSeconds == nil || c.tracker == nil {
+		t.Fatal("expected fully populated clientMetrics")
+	}
+}
+
+// TestMiddlewareTracksConcurrency drives the real middleware chain: CaptureAuth
+// must enter the tracker and Middleware must account the request back out.
+func TestMiddlewareTracksConcurrency(t *testing.T) {
+	m, err := NewMetrics(noop.NewMeterProvider().Meter("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := clientAttrKey{"u1", "r1", "restic"}
+	var insidePeak int64
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v, ok := m.client.tracker.states.Load(key); ok {
+			insidePeak = v.(*clientConcurrency).cur.Load()
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Middleware(m)(CaptureAuth(inner))
+
+	req := httptest.NewRequest("GET", "/r1/config", nil)
+	req = req.WithContext(auth.NewContext(req.Context(),
+		auth.Auth{User: "u1", Repository: "r1", Connection: "restic"}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if insidePeak != 1 {
+		t.Fatalf("expected 1 request in flight inside the handler, got %d", insidePeak)
+	}
+
+	v, ok := m.client.tracker.states.Load(key)
+	if !ok {
+		t.Fatal("expected the client to be tracked")
+	}
+	if cur := v.(*clientConcurrency).cur.Load(); cur != 0 {
+		t.Fatalf("expected the request to be accounted out, got %d outstanding", cur)
+	}
+	if peak := v.(*clientConcurrency).peak.Load(); peak != 1 {
+		t.Fatalf("expected peak 1, got %d", peak)
+	}
+}
+
+// TestMiddlewareAccountsOutOnPanic covers the path chi's Recoverer owns: it is
+// mounted outside this middleware, so a handler panic unwinds past us. Without
+// a deferred exit the request stays counted forever, pinning the client's peak
+// above zero and blocking idle eviction for the life of the process.
+func TestMiddlewareAccountsOutOnPanic(t *testing.T) {
+	m, err := NewMetrics(noop.NewMeterProvider().Meter("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+	handler := Middleware(m)(CaptureAuth(inner))
+
+	req := httptest.NewRequest("GET", "/r1/config", nil)
+	req = req.WithContext(auth.NewContext(req.Context(),
+		auth.Auth{User: "u1", Repository: "r1", Connection: "restic"}))
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected the panic to propagate to the outer Recoverer")
+			}
+		}()
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	v, ok := m.client.tracker.states.Load(clientAttrKey{"u1", "r1", "restic"})
+	if !ok {
+		t.Fatal("expected the client to be tracked")
+	}
+	if cur := v.(*clientConcurrency).cur.Load(); cur != 0 {
+		t.Fatalf("expected the panicking request to be accounted out, got %d outstanding", cur)
+	}
+}
+
+// TestMiddlewareSkipsUnauthenticated guards the tracker against unauthenticated
+// traffic, which has no identity to attribute and would otherwise accumulate
+// under an empty key.
+func TestMiddlewareSkipsUnauthenticated(t *testing.T) {
+	m, err := NewMetrics(noop.NewMeterProvider().Meter("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	handler := Middleware(m)(inner)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/r1/config", nil))
+
+	count := 0
+	m.client.tracker.states.Range(func(any, any) bool { count++; return true })
+	if count != 0 {
+		t.Fatalf("expected no tracked clients, got %d", count)
+	}
+}

--- a/packages/michael/internal/metrics/metrics.go
+++ b/packages/michael/internal/metrics/metrics.go
@@ -53,6 +53,7 @@ type Metrics struct {
 	AuthCacheHits   otelmetric.Int64Counter
 	AuthCacheMisses otelmetric.Int64Counter
 	UnknownCluster  otelmetric.Int64Counter
+	client          *clientMetrics
 
 	// Traffic counters, labelled by the SOURCE NETWORK instead of the identity:
 	// the blobs.* family answers "which customer moved this", these answer
@@ -180,6 +181,11 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating traffic_requests counter: %w", err)
 	}
 
+	client, err := newClientMetrics(meter)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Metrics{
 		RequestedBytes:  requestedBytes,
 		DownloadedBytes: downloadedBytes,
@@ -193,6 +199,7 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		AuthCacheHits:   authCacheHits,
 		AuthCacheMisses: authCacheMisses,
 		UnknownCluster:  unknownCluster,
+		client:          client,
 
 		TrafficUploadedBytes:   trafficUploadedBytes,
 		TrafficDownloadedBytes: trafficDownloadedBytes,
@@ -569,6 +576,12 @@ type authCapture struct {
 	user       string
 	repository string
 	connection string
+
+	// Concurrency is tracked from the moment auth resolves rather than from the
+	// start of the request: before that there is no identity to attribute it to,
+	// and the unattributed prefix is a cache lookup.
+	tracker *clientTracker
+	state   *clientConcurrency
 }
 
 type authCaptureKey struct{}
@@ -583,6 +596,9 @@ func CaptureAuth(next http.Handler) http.Handler {
 			h.user = a.User
 			h.repository = a.Repository
 			h.connection = connectionLabel(a)
+			if h.tracker != nil && h.user != "" {
+				h.state = h.tracker.enter(clientAttrKey{h.user, h.repository, h.connection})
+			}
 		}
 		next.ServeHTTP(w, r)
 	})
@@ -594,8 +610,18 @@ func Middleware(m *Metrics) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			ww := &ResponseWriter{ResponseWriter: w}
-			capture := &authCapture{}
+			capture := &authCapture{tracker: m.client.tracker}
 			r = r.WithContext(context.WithValue(r.Context(), authCaptureKey{}, capture))
+
+			// Deferred: a handler panic unwinds straight past this middleware to
+			// chi's Recoverer, and an outstanding request never accounted back out
+			// would pin the client's concurrency above zero for the life of the
+			// process — inflating its reported peak and blocking idle eviction.
+			defer func() {
+				if capture.state != nil {
+					capture.state.exit(time.Now())
+				}
+			}()
 
 			next.ServeHTTP(ww, r)
 
@@ -621,6 +647,13 @@ func Middleware(m *Metrics) func(http.Handler) http.Handler {
 				m.RequestTTFB.Record(r.Context(), ww.FirstByte.Sub(start).Seconds(), attrs)
 			}
 			m.RequestCount.Add(r.Context(), 1, countAttrs)
+
+			if capture.state != nil {
+				m.client.seconds.Add(r.Context(), duration, capture.state.attrs)
+				if !ww.FirstByte.IsZero() {
+					m.client.ttfbSeconds.Add(r.Context(), ww.FirstByte.Sub(start).Seconds(), capture.state.attrs)
+				}
+			}
 
 			if status >= 400 {
 				m.RequestErrors.Add(r.Context(), 1, countAttrs)


### PR DESCRIPTION
Per-client request-seconds, TTFB and peak-concurrency instruments in michael, plus the dashboard panels that read them.

- `main` <!-- branch-stack -->
  - \#427 :point\_left:
