### PR TITLE
fix(yucca-sdk): repair the orchestration-api integration suites

### DIFF
--- a/packages/yucca-sdk/orchestration-api/test/repository.integration-spec.ts
+++ b/packages/yucca-sdk/orchestration-api/test/repository.integration-spec.ts
@@ -59,7 +59,7 @@ describe('Repository', () => {
       ctx.backendId,
     );
 
-    const metricsEvent = waitForEvent(ctx.gateway, 'RepositoryUpdate');
+    const metricsEvent = waitForEvent(ctx.events, 'RepositoryUpdate');
 
     const { logId, task } = await repositoryService.createBackup(repository.id);
     await task;
@@ -91,7 +91,7 @@ describe('Repository', () => {
 
     ctx.resticMock.backup.mockRejectedValue(new Error('Backup failed'));
 
-    const metricsEvent = waitForEvent(ctx.gateway, 'RepositoryUpdate');
+    const metricsEvent = waitForEvent(ctx.events, 'RepositoryUpdate');
 
     const { task } = await repositoryService.createBackup(repository.id);
     await task.catch(() => {});

--- a/packages/yucca-sdk/orchestration-api/test/schedule.integration-spec.ts
+++ b/packages/yucca-sdk/orchestration-api/test/schedule.integration-spec.ts
@@ -51,7 +51,7 @@ describe('Schedule', () => {
       repositories: [],
     });
 
-    const scheduleUpdate = waitForEvent(ctx.gateway, 'ScheduleUpdate');
+    const scheduleUpdate = waitForEvent(ctx.events, 'ScheduleUpdate');
 
     ctx.resticMock.backup.mockReset();
     void ctx.module.get(SchedulerRegistry).getCronJob(schedule.id).fireOnTick();
@@ -87,7 +87,7 @@ describe('Schedule', () => {
       repositories: [repo1.id, repo2.id],
     });
 
-    const lastRunEvent = waitForEvent(ctx.gateway, 'ScheduleUpdate');
+    const lastRunEvent = waitForEvent(ctx.events, 'ScheduleUpdate');
 
     ctx.resticMock.backup.mockReset();
     void ctx.module.get(SchedulerRegistry).getCronJob(schedule.id).fireOnTick();

--- a/packages/yucca-sdk/orchestration-api/test/telemetry.integration-spec.ts
+++ b/packages/yucca-sdk/orchestration-api/test/telemetry.integration-spec.ts
@@ -23,10 +23,8 @@ afterAll(async () => {
 
 beforeEach(async () => {
   jest.clearAllMocks();
-  // The Yucca backend resolves its base URL through .well-known discovery when
-  // the configuration carries no url. Unstubbed that rejects, and
-  // submitStructuredLog swallows the rejection, so the submission never reaches
-  // the api client and the waits below simply time out.
+  // Without this the backend resolves its base URL by fetching the real
+  // production .well-known over the network.
   jest.spyOn(yuccaWellKnown, 'getBaseUrl').mockResolvedValue('http://yucca.test');
   ctx.database.prepare("DELETE FROM config WHERE key = 'telemetry'").run();
   await ctx.module.get(BackendRepository).updateBackend(REPOSITORY_DEFAULT_CLOUD_UUID, {

--- a/packages/yucca-sdk/orchestration-api/test/telemetry.integration-spec.ts
+++ b/packages/yucca-sdk/orchestration-api/test/telemetry.integration-spec.ts
@@ -1,11 +1,12 @@
 import { submitStructuredLog } from '@futo-org/backups-api-client';
 import { setTimeout as delay } from 'node:timers/promises';
 import { version } from '../package.json';
-import { YUCCA_PRODUCTION_UUID } from '../src/const';
+import { REPOSITORY_DEFAULT_CLOUD_UUID } from '../src/const';
 import { BackendType } from '../src/enum';
 import { BackendRepository } from '../src/repositories/backend.repository';
 import { ConfigRepository } from '../src/repositories/config.repository';
 import { TelemetryService } from '../src/services/telemetry.service';
+import { yuccaWellKnown } from '../src/wellKnown';
 import { createTestingModule, TestContext, waitFor } from './testUtils';
 
 const apiSubmitStructuredLog = submitStructuredLog as jest.Mock;
@@ -22,8 +23,13 @@ afterAll(async () => {
 
 beforeEach(async () => {
   jest.clearAllMocks();
+  // The Yucca backend resolves its base URL through .well-known discovery when
+  // the configuration carries no url. Unstubbed that rejects, and
+  // submitStructuredLog swallows the rejection, so the submission never reaches
+  // the api client and the waits below simply time out.
+  jest.spyOn(yuccaWellKnown, 'getBaseUrl').mockResolvedValue('http://yucca.test');
   ctx.database.prepare("DELETE FROM config WHERE key = 'telemetry'").run();
-  await ctx.module.get(BackendRepository).updateBackend(YUCCA_PRODUCTION_UUID, {
+  await ctx.module.get(BackendRepository).updateBackend(REPOSITORY_DEFAULT_CLOUD_UUID, {
     type: BackendType.Yucca,
     accessToken: 'test-token',
   });
@@ -83,7 +89,7 @@ describe('Telemetry', () => {
   });
 
   it('does not throw when no production backend is configured', async () => {
-    ctx.database.prepare('DELETE FROM backends WHERE id = ?').run(YUCCA_PRODUCTION_UUID);
+    ctx.database.prepare('DELETE FROM backends WHERE id = ?').run(REPOSITORY_DEFAULT_CLOUD_UUID);
     await ctx.module.get(ConfigRepository).enableTelemetry();
     const telemetry = ctx.module.get(TelemetryService);
 

--- a/packages/yucca-sdk/orchestration-api/test/testUtils.ts
+++ b/packages/yucca-sdk/orchestration-api/test/testUtils.ts
@@ -16,9 +16,6 @@ import { BackendRepository } from 'src/repositories/backend.repository';
 import { ResticRepository } from 'src/repositories/restic.repository';
 import { newResticRepositoryMock } from './mocks';
 
-// EventsGateway published events through on()/off() until those were removed
-// along with its internal emitter; onInternalEvent is the hook that replaced
-// them, so the test module routes it into a bus the helpers below subscribe to.
 type GatewayListener = (event: GatewayEvent) => void;
 
 export interface TestEventBus {
@@ -30,10 +27,8 @@ export interface TestEventBus {
 function createEventBus(): TestEventBus {
   const listeners = new Set<GatewayListener>();
   return {
-    // Iterate a copy: a listener that unsubscribes itself (waitForEvent does)
-    // would otherwise mutate the set mid-iteration.
     emit: (event) => {
-      for (const listener of [...listeners]) {
+      for (const listener of listeners) {
         listener(event);
       }
     },

--- a/packages/yucca-sdk/orchestration-api/test/testUtils.ts
+++ b/packages/yucca-sdk/orchestration-api/test/testUtils.ts
@@ -16,10 +16,41 @@ import { BackendRepository } from 'src/repositories/backend.repository';
 import { ResticRepository } from 'src/repositories/restic.repository';
 import { newResticRepositoryMock } from './mocks';
 
+// EventsGateway published events through on()/off() until those were removed
+// along with its internal emitter; onInternalEvent is the hook that replaced
+// them, so the test module routes it into a bus the helpers below subscribe to.
+type GatewayListener = (event: GatewayEvent) => void;
+
+export interface TestEventBus {
+  emit: GatewayListener;
+  on: (listener: GatewayListener) => void;
+  off: (listener: GatewayListener) => void;
+}
+
+function createEventBus(): TestEventBus {
+  const listeners = new Set<GatewayListener>();
+  return {
+    // Iterate a copy: a listener that unsubscribes itself (waitForEvent does)
+    // would otherwise mutate the set mid-iteration.
+    emit: (event) => {
+      for (const listener of [...listeners]) {
+        listener(event);
+      }
+    },
+    on: (listener) => {
+      listeners.add(listener);
+    },
+    off: (listener) => {
+      listeners.delete(listener);
+    },
+  };
+}
+
 export interface TestContext {
   app: INestApplication;
   module: TestingModule;
   gateway: EventsGateway;
+  events: TestEventBus;
   database: InstanceType<typeof Database>;
   resticMock: jest.Mocked<ResticRepository>;
   backendId: string;
@@ -36,6 +67,7 @@ export async function createTestingModule(): Promise<TestContext> {
   database.pragma('journal_mode = WAL');
 
   const resticMock = newResticRepositoryMock();
+  const events = createEventBus();
 
   const moduleFixture: TestingModule = await Test.createTestingModule({
     imports: [
@@ -56,6 +88,7 @@ export async function createTestingModule(): Promise<TestContext> {
           statePath,
           requireLock: false,
           requireWsAuth: false,
+          onInternalEvent: events.emit,
         },
       },
       EventsGateway,
@@ -80,6 +113,7 @@ export async function createTestingModule(): Promise<TestContext> {
     app,
     module: moduleFixture,
     gateway: moduleFixture.get(EventsGateway),
+    events,
     database,
     resticMock,
     backendId,
@@ -88,15 +122,15 @@ export async function createTestingModule(): Promise<TestContext> {
   };
 }
 
-export function waitForEvent(gateway: EventsGateway, type: GatewayEvent['type']): Promise<GatewayEvent> {
+export function waitForEvent(events: TestEventBus, type: GatewayEvent['type']): Promise<GatewayEvent> {
   return new Promise((resolve) => {
     const onEvent = (event: GatewayEvent) => {
       if (event.type === type) {
-        gateway.off(onEvent);
+        events.off(onEvent);
         resolve(event);
       }
     };
-    gateway.on(onEvent);
+    events.on(onEvent);
   });
 }
 


### PR DESCRIPTION
Two regressions had left 8 of the orchestration-api integration tests failing on main since June; this repairs the tests, not the behaviour they cover.

- `main` <!-- branch-stack -->
  - \#429 :point\_left:
