### PR TITLE
feat(all): per-repository storage credentials

### DIFF
--- a/.mise/tasks/restic-api/env
+++ b/.mise/tasks/restic-api/env
@@ -14,6 +14,12 @@ GS7NQtJ3AnJkYaigO1MS5J59I4uRXCmpLtcwTocUGHMRVZrGLQMWdZY4DQ==
 -----END PUBLIC KEY-----
 }
 
+# Shared with the APIs (.mise/tasks/yucca-api/env): opens the credentials a
+# restic token carries. michael has no S3 credentials of its own.
+export STORAGE_CREDENTIAL_SEAL_KEY=${STORAGE_CREDENTIAL_SEAL_KEY:-eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=}
+
+# For restic-api, the reference implementation, which still reads its S3
+# credentials from the environment. michael ignores these.
 export S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID:-minio}
 export S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY:-miniominio}
 export S3_REGION=${S3_REGION:-minio}

--- a/.mise/tasks/test/integration/k3d
+++ b/.mise/tasks/test/integration/k3d
@@ -27,6 +27,7 @@ wait_for() {
 echo "==> wait for infra (tilt ci-infra returns before Rook mints the S3 user)"
 wait_for "CNPG cluster Ready"  kubectl -n yucca wait --for=condition=Ready cluster/yucca-db --timeout=5s
 wait_for "Ceph S3 user secret" kubectl -n yucca get secret rook-ceph-object-user-yucca-michael
+wait_for "Ceph provisioner secret" kubectl -n yucca get secret rook-ceph-object-user-yucca-provisioner
 wait_for "mock-oidc Available" kubectl -n yucca wait --for=condition=Available deploy/yucca-mock-oidc --timeout=5s
 
 echo "==> port-forward infra to the localhost ports the tests expect"
@@ -55,13 +56,24 @@ S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 export S3_ENDPOINT S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_REGION S3_FORCE_PATH_STYLE
 
-if kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics >/dev/null 2>&1; then
+# RADOS_* is the RGW admin credential. Prefer the provisioner user (users+buckets
+# caps — what yucca-api creates per-repository S3 users with, and a superset of
+# the read caps the metrics worker's suite needs); fall back to the metrics user.
+RADOS_SECRET_NAME=""
+for candidate in rook-ceph-object-user-yucca-provisioner rook-ceph-object-user-yucca-metrics; do
+  if kubectl -n yucca get secret "$candidate" >/dev/null 2>&1; then
+    RADOS_SECRET_NAME="$candidate"
+    break
+  fi
+done
+if [ -n "$RADOS_SECRET_NAME" ]; then
+  echo "==> RGW admin credential: $RADOS_SECRET_NAME"
   RADOS_ENDPOINT=http://localhost:9000
-  RADOS_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.AccessKey}' | base64 -d)"
-  RADOS_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.SecretKey}' | base64 -d)"
+  RADOS_ACCESS_KEY_ID="$(kubectl -n yucca get secret "$RADOS_SECRET_NAME" -o jsonpath='{.data.AccessKey}' | base64 -d)"
+  RADOS_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret "$RADOS_SECRET_NAME" -o jsonpath='{.data.SecretKey}' | base64 -d)"
   export RADOS_ENDPOINT RADOS_ACCESS_KEY_ID RADOS_SECRET_ACCESS_KEY
 else
-  echo "==> rook-ceph-object-user-yucca-metrics not found; RGW integration tests will skip"
+  echo "==> no RGW admin object-user secret found; RGW integration tests will skip"
 fi
 
 # The deployed mock-oidc advertises its in-cluster name as the issuer; the dns

--- a/.mise/tasks/tilt/ci-infra
+++ b/.mise/tasks/tilt/ci-infra
@@ -2,7 +2,8 @@
 #MISE description="tilt ci for the infra subset only (no app images) — what integration tests need"
 #MISE dir="{{config_root}}"
 # The closure of every non-app resource: chart repos, operators, the Ceph dev
-# cluster + RGW user, CNPG database, mock-oidc and the victoria pair. Skipping
+# cluster + its RGW users (michael's bucket owner and the APIs' provisioner
+# admin), CNPG database, mock-oidc and the victoria pair. Skipping
 # the four heavy app images (yucca-api/admin/web/michael) saves ~10 min in CI;
 # integration tests boot those apps on the host themselves.
 set -euo pipefail
@@ -15,5 +16,5 @@ fi
 exec tilt ci --timeout 1800s \
   rook-release-repo helm-deps \
   cloudnative-pg rook-ceph-operator rook-ceph-cluster \
-  yucca-object-user yucca-database yucca-mock-oidc \
+  yucca-object-user yucca-provisioner-object-user yucca-database yucca-mock-oidc \
   yucca-victoria-metrics yucca-victoria-logs

--- a/.mise/tasks/yucca-admin-api/env
+++ b/.mise/tasks/yucca-admin-api/env
@@ -20,6 +20,13 @@ Ls1C0ncCcmRhqKA7UxLknn0ji5FcKaku1zBOhxQYcxFVmsYtAxZ1ljgN
 # Dev restic minting: the same dev keypair signs repo tokens (michael's dev
 # public key matches), pointed at the local michael.
 export RESTIC_JWT_PRIVATE_KEY=${RESTIC_JWT_PRIVATE_KEY:-$JWT_PRIVATE_KEY}
+# Same well-known local-dev keys as .mise/tasks/yucca-api/env: both APIs mint
+# restic tokens, so both seal credentials into them.
+export STORAGE_CREDENTIAL_KEY=${STORAGE_CREDENTIAL_KEY:-eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=}
+export STORAGE_CREDENTIAL_SEAL_KEY=${STORAGE_CREDENTIAL_SEAL_KEY:-eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=}
+export STORAGE_STATIC_ACCESS_KEY_ID=${STORAGE_STATIC_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-minio}}
+export STORAGE_STATIC_SECRET_ACCESS_KEY=${STORAGE_STATIC_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-miniominio}}
+
 export TOPOLOGY_FILE=${TOPOLOGY_FILE:-./topology.dev.json}
 export LEGACY_SITE_CODE=${LEGACY_SITE_CODE:-local}
 export LEGACY_STORAGE_CLUSTER_CODE=${LEGACY_STORAGE_CLUSTER_CODE:-local-dev}

--- a/.mise/tasks/yucca-api/env
+++ b/.mise/tasks/yucca-api/env
@@ -27,6 +27,16 @@ export OIDC_LOGOUT_REDIRECT_URI=${OIDC_LOGOUT_REDIRECT_URI:-http://localhost:360
 export OIDC_DEVICE_ISSUER=${OIDC_DEVICE_ISSUER:-http://localhost:8092}
 export OIDC_DEVICE_CLIENT_ID=${OIDC_DEVICE_CLIENT_ID:-device client ID}
 
+# Well-known local-dev keys. STORAGE_CREDENTIAL_SEAL_KEY is shared with michael
+# (.mise/tasks/restic-api/env); STORAGE_CREDENTIAL_KEY never leaves the API.
+export STORAGE_CREDENTIAL_KEY=${STORAGE_CREDENTIAL_KEY:-eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=}
+export STORAGE_CREDENTIAL_SEAL_KEY=${STORAGE_CREDENTIAL_SEAL_KEY:-eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=}
+
+# The compose stack stores into MinIO, which has no RGW admin API, so every
+# repository is handed the MinIO root credentials instead of its own user.
+export STORAGE_STATIC_ACCESS_KEY_ID=${STORAGE_STATIC_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-minio}}
+export STORAGE_STATIC_SECRET_ACCESS_KEY=${STORAGE_STATIC_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-miniominio}}
+
 export TOPOLOGY_FILE=${TOPOLOGY_FILE:-./topology.dev.json}
 export API_ROOT=${API_ROOT:-http://localhost:3020/api}
 export LEGACY_SITE_CODE=${LEGACY_SITE_CODE:-local}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Zod-validated `env.ts`, JWT auth guards via `@AuthRoute()`, OTel from `@common/s
 |---|---|---|
 | `yucca-api` | NestJS | User-facing API. Owns auth (OIDC code + device flow, ES256 JWTs), repositories, **DB schema + migrations**. |
 | `yucca-admin-api` | NestJS | Admin API (user/session/repository management). Same DB + JWT validation. |
-| `michael` | Go | **Production** restic REST backend — S3 proxy with JWT verification, WORM enforcement, backend pooling. |
+| `michael` | Go | **Production** restic REST backend — S3 proxy with JWT verification, WORM enforcement, backend pooling. Holds **no S3 credentials**: each token carries its repository's own, sealed. |
 | `restic-api` | NestJS | Earlier TS implementation of the restic backend, kept as **reference**; not deployed. |
 | `yucca-metrics-worker` | NestJS | 5-min cron: RadosGW usage → meter tables → per-connection rollup (`connectionMetrics`, billing floor), OTel gauges. |
 | `redis` (valkey) | | Shared platform cache (ephemeral; keys `yucca:<service>:<purpose>:*`). Primary-region only. |
@@ -136,6 +136,28 @@ Full detail: `docs/connections.md`. The essentials:
   introspection (`GET /internal/restic-tokens/:jti`). Revoke flips the DB row + best-effort DELs
   the valkey key; introspection outage honors the grace window then **fails closed**. Long-lived
   tokens are revocable-only. yuctl: `tokens list/revoke`, `repos url --ttl`.
+
+### Per-repository storage credentials
+
+Full detail: `docs/storage-credentials.md`. The essentials:
+
+- Every repository owns an RGW user (`yucca-repo-<id>`, `max-buckets=1`), created by the APIs
+  through the RadosGW admin API with the ansible-provisioned `yucca-provisioner` credential
+  (`users=*`, Secret `yucca-provisioner-rgw`, chart `radosSecretName`). Bucket ops belong to a
+  separate `yucca-migrator` (`buckets=*`) that only the yuctl migration uses, read from 1Password
+  and never mounted into the cluster.
+- Its keys ride in the token as the `storageCredentials` claim: AES-256-GCM,
+  `base64url(version||nonce||ct||tag)`, **repository id as AAD**. Sealed by `@common/server`
+  `sealStorageCredentials`, opened by michael's `internal/credentials`; a cross-language fixture
+  test pins the format.
+- Two keys, both comma-separated lists (first seals, all open, so rotation is a two-step deploy):
+  `STORAGE_CREDENTIAL_KEY` (APIs only, at-rest column `repositories.storageSecretAccessKey`) and
+  `STORAGE_CREDENTIAL_SEAL_KEY` (APIs **+ michael**).
+- michael caches one S3 client per credential per backend and probes backends **unsigned**. A
+  token without credentials is a 401 — there is no fallback. Clusters without an
+  `rgw_admin_endpoint` (compose/MinIO) fall back to `STORAGE_STATIC_*`.
+- Pre-existing buckets: `yuctl repos migrate-storage-credentials` (BucketOwnerEnforced as the old
+  owner, admin-API link, then verify).
 
 ## Infrastructure architecture
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -272,14 +272,16 @@ APP_WIRING = {
     # dev_env: receives the .env override Secret (see load_dev_env above).
     # dev_keypair: render the well-known dev JWT fixture into the chart Secret
     # (the chart default is useDevKeypair=false so real overlays fail loudly).
-    'yucca-api':              {'build': 'yucca-api',          'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-michael', 'yucca-topology'], 'dev_env': True, 'dev_keypair': True},
-    'yucca-admin-api':        {'build': 'yucca-admin-api',    'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-topology'], 'dev_keypair': True},
+    'yucca-api':              {'build': 'yucca-api',          'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-michael', 'yucca-topology', 'yucca-provisioner-object-user'], 'dev_env': True, 'dev_keypair': True},
+    'yucca-admin-api':        {'build': 'yucca-admin-api',    'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-topology', 'yucca-provisioner-object-user'], 'dev_keypair': True},
     'yucca-metrics-worker':   {'build': 'yucca-metrics-worker', 'deps': ['yucca-database', 'yucca-metrics-object-user', 'yucca-topology'], 'dev_env': True},
     'yucca-web':              {'build': 'web',                'deps': ['yucca-api']},
     # Stock upstream nginx serving the .well-known pointer — nothing to build,
     # nothing to wait for (it's a static file, deliberately independent of the
     # API whose URL it advertises).
     'yucca-meta':             {'build': None,                 'deps': []},
+    # yucca-object-user is no longer michael's credential — it owns the buckets
+    # created before per-repository users, and the e2e harness signs with it.
     'yucca-michael':          {'build': 'michael',            'deps': ['yucca-object-user'], 'dev_keypair': True},
     'yucca-mock-oidc':        {'build': 'mock-oidc-provider', 'deps': []},
     'yucca-database':         {'build': None,                 'deps': ['cloudnative-pg']},
@@ -291,6 +293,9 @@ APP_WIRING = {
     # come from the HelmRelease values, so dev must apply them (dev_values) or
     # both releases would default to userName=michael and collide.
     'yucca-metrics-object-user': {'build': None,              'deps': ['rook-ceph-cluster'], 'pod_readiness': 'ignore', 'dev_values': True},
+    # The RGW admin the APIs create per-repository S3 users with. Same chart,
+    # so its userName/caps also have to come from the HelmRelease values.
+    'yucca-provisioner-object-user': {'build': None,          'deps': ['rook-ceph-cluster'], 'pod_readiness': 'ignore', 'dev_values': True},
     # Rook spins up transient mon/osd "canary" pods and deletes them; Tilt's
     # pod tracking misreads those deletions as failures. Ignore pod readiness
     # here — real convergence is still gated downstream (object-user -> michael

--- a/charts/apps/michael/templates/secret.yaml
+++ b/charts/apps/michael/templates/secret.yaml
@@ -1,6 +1,8 @@
-{{- /* The dev JWT public-key fixture only enters the Secret when explicitly
-opted in (useDevKeypair — dev/local overlay only); see values.yaml. */}}
+{{- /* The dev JWT public key and storage seal key only enter the Secret when
+explicitly opted in (useDevKeypair — dev/local overlay only); see values.yaml. */}}
 {{- if .Values.useDevKeypair }}
-{{- $_ := set .Values "secretData" (merge (dict "JWT_PUBLIC_KEY" .Values.devJwtPublicKey) (.Values.secretData | default dict)) }}
+{{- $_ := set .Values "secretData" (merge (dict
+  "JWT_PUBLIC_KEY" .Values.devJwtPublicKey
+  "STORAGE_CREDENTIAL_SEAL_KEY" .Values.devStorageSealKey) (.Values.secretData | default dict)) }}
 {{- end }}
 {{- include "yucca-common.secret" . }}

--- a/charts/apps/michael/values.yaml
+++ b/charts/apps/michael/values.yaml
@@ -41,6 +41,11 @@ volumeMounts:
 # fails loudly, instead of silently trusting tokens anyone can mint with the
 # committed private half. Prod provides the real key via ExternalSecret.
 useDevKeypair: false
+# The dev half of STORAGE_CREDENTIAL_SEAL_KEY, shared with the APIs
+# (charts/apps/yucca-api/values.yaml, .mise/tasks/*/env). Rendered under the
+# same opt-in as the verification key: without it michael cannot open the
+# credentials any token carries, and every request 401s.
+devStorageSealKey: eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=
 devJwtPublicKey: |
   -----BEGIN PUBLIC KEY-----
   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpLmwUSBO0p7P1UvGReVxFTvAsCfg
@@ -52,10 +57,9 @@ env:
     value: "3010"
   - name: LOG_LEVEL
     value: debug
-  # S3 object store = Rook-Ceph RGW. michael creates one bucket per restic
-  # repository, so it needs a full RGW user (CephObjectStoreUser via
-  # charts/ceph-objectuser), NOT a bucket-scoped ObjectBucketClaim. Rook writes
-  # the user's keys into this namespace as rook-ceph-object-user-<store>-<user>.
+  # S3 object store = Rook-Ceph RGW. michael configures NO credentials: each
+  # restic token carries its repository's own RGW keys, sealed with
+  # STORAGE_CREDENTIAL_SEAL_KEY, and michael can reach no bucket without one.
   # Must match the dev topology's cluster code (ConfigMap yucca-topology /
   # topology.dev.json): yucca-api mints restic tokens with
   # storageCluster=local-dev,
@@ -68,16 +72,6 @@ env:
     value: /etc/yucca/topology.json
   - name: S3_ENDPOINT
     value: http://rook-ceph-rgw-yucca.rook-ceph.svc:80
-  - name: S3_ACCESS_KEY_ID
-    valueFrom:
-      secretKeyRef:
-        name: rook-ceph-object-user-yucca-michael
-        key: AccessKey
-  - name: S3_SECRET_ACCESS_KEY
-    valueFrom:
-      secretKeyRef:
-        name: rook-ceph-object-user-yucca-michael
-        key: SecretKey
   - name: S3_REGION
     value: us-east-1
   - name: S3_FORCE_PATH_STYLE

--- a/charts/apps/yucca-admin-api/templates/deployment.yaml
+++ b/charts/apps/yucca-admin-api/templates/deployment.yaml
@@ -2,13 +2,17 @@
   (dict "name" "OIDC_ADMIN_ISSUER" "value" .Values.oidcIssuer)
   (dict "name" "OIDC_ADMIN_REDIRECT_URI" "value" .Values.oidcRedirectUri)
   (dict "name" "OIDC_ADMIN_LOGOUT_REDIRECT_URI" "value" .Values.oidcLogoutRedirectUri)
+  (dict "name" "RADOS_ACCESS_KEY_ID" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "AccessKey")))
+  (dict "name" "RADOS_SECRET_ACCESS_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "SecretKey")))
   (dict "name" "POSTGRES_HOST" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "host")))
   (dict "name" "POSTGRES_PORT" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "port")))
   (dict "name" "POSTGRES_DATABASE" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "dbname")))
   (dict "name" "POSTGRES_USERNAME" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "username")))
   (dict "name" "POSTGRES_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "password")))
 )) }}
-{{- $_ := set .Values "envFrom" (list (dict "secretRef" (dict "name" (include "yucca-common.fullname" .)))) }}
+{{- $_ := set .Values "envFrom" (list
+  (dict "secretRef" (dict "name" (include "yucca-common.fullname" .)))
+  (dict "secretRef" (dict "name" .Values.radosSecretName))) }}
 {{- $topology := (lookup "v1" "ConfigMap" .Release.Namespace "yucca-topology") | default dict }}
 {{- $topologyData := (get $topology "data") | default dict }}
 {{- $_ := set .Values "podAnnotations" (merge

--- a/charts/apps/yucca-admin-api/templates/secret.yaml
+++ b/charts/apps/yucca-admin-api/templates/secret.yaml
@@ -3,6 +3,10 @@
 {{- if .Values.useDevKeypair }}
 {{- /* The dev keypair doubles as the restic signing key: michael's dev public
 key is its counterpart, so admin-minted repo URLs work against dev michael. */}}
-{{- $_ := set .Values "secretData" (merge (dict "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey "RESTIC_JWT_PRIVATE_KEY" .Values.devJwtPrivateKey) (.Values.secretData | default dict)) }}
+{{- $_ := set .Values "secretData" (merge (dict
+  "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey
+  "RESTIC_JWT_PRIVATE_KEY" .Values.devJwtPrivateKey
+  "STORAGE_CREDENTIAL_KEY" .Values.devStorageCredentialKey
+  "STORAGE_CREDENTIAL_SEAL_KEY" .Values.devStorageSealKey) (.Values.secretData | default dict)) }}
 {{- end }}
 {{- include "yucca-common.secret" . }}

--- a/charts/apps/yucca-admin-api/values.yaml
+++ b/charts/apps/yucca-admin-api/values.yaml
@@ -31,6 +31,13 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
+# RGW user with users+buckets admin caps: the API creates one S3 user per
+# repository with it, so michael never needs a cluster-wide credential. In dev
+# Rook writes the keys here as rook-ceph-object-user-<store>-<user>; prod points
+# this at the TF-provisioned yucca-provisioner-rgw Secret. Per-cluster overrides
+# ride in the same Secret as RADOS_ACCESS_KEY_ID_<CODE>/RADOS_SECRET_ACCESS_KEY_<CODE>.
+radosSecretName: rook-ceph-object-user-yucca-provisioner
+
 # CNPG-managed postgres Cluster name (shares yucca-api's database)
 postgresClusterName: yucca-db
 
@@ -51,6 +58,11 @@ secretData:
 # provide a real key gets a loud missing-JWT_PRIVATE_KEY crash instead of
 # silently signing admin tokens with a public fixture.
 useDevKeypair: false
+# The dev storage-credential keys, under the same opt-in. The seal half is
+# shared with michael (charts/apps/michael/values.yaml); the at-rest half never
+# leaves the APIs.
+devStorageCredentialKey: eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=
+devStorageSealKey: eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=
 devJwtPrivateKey: |
   -----BEGIN PRIVATE KEY-----
   MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgCla79+Sip4o2hZ1K

--- a/charts/apps/yucca-api/templates/deployment.yaml
+++ b/charts/apps/yucca-api/templates/deployment.yaml
@@ -2,6 +2,8 @@
   (dict "name" "OIDC_ISSUER" "value" .Values.oidcIssuer)
   (dict "name" "OIDC_REDIRECT_URI" "value" .Values.oidcRedirectUri)
   (dict "name" "OIDC_LOGOUT_REDIRECT_URI" "value" .Values.oidcLogoutRedirectUri)
+  (dict "name" "RADOS_ACCESS_KEY_ID" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "AccessKey")))
+  (dict "name" "RADOS_SECRET_ACCESS_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "SecretKey")))
   (dict "name" "POSTGRES_HOST" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "host")))
   (dict "name" "POSTGRES_PORT" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "port")))
   (dict "name" "POSTGRES_DATABASE" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "dbname")))
@@ -11,7 +13,9 @@
 {{- /* extraEnvFrom comes after the chart secret: for duplicate keys Kubernetes
 takes the LAST envFrom source, so these act as overrides. */}}
 {{- $_ := set .Values "envFrom" (concat
-  (list (dict "secretRef" (dict "name" (include "yucca-common.fullname" .))))
+  (list
+    (dict "secretRef" (dict "name" (include "yucca-common.fullname" .)))
+    (dict "secretRef" (dict "name" .Values.radosSecretName)))
   (.Values.extraEnvFrom | default (list))) }}
 {{- $topology := (lookup "v1" "ConfigMap" .Release.Namespace "yucca-topology") | default dict }}
 {{- $topologyData := (get $topology "data") | default dict }}

--- a/charts/apps/yucca-api/templates/secret.yaml
+++ b/charts/apps/yucca-api/templates/secret.yaml
@@ -1,6 +1,9 @@
 {{- /* The dev JWT fixture only enters the Secret when explicitly opted in
 (useDevKeypair — dev/local overlay only); see values.yaml. */}}
 {{- if .Values.useDevKeypair }}
-{{- $_ := set .Values "secretData" (merge (dict "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey) (.Values.secretData | default dict)) }}
+{{- $_ := set .Values "secretData" (merge (dict
+  "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey
+  "STORAGE_CREDENTIAL_KEY" .Values.devStorageCredentialKey
+  "STORAGE_CREDENTIAL_SEAL_KEY" .Values.devStorageSealKey) (.Values.secretData | default dict)) }}
 {{- end }}
 {{- include "yucca-common.secret" . }}

--- a/charts/apps/yucca-api/values.yaml
+++ b/charts/apps/yucca-api/values.yaml
@@ -39,6 +39,13 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
+# RGW user with users+buckets admin caps: the API creates one S3 user per
+# repository with it, so michael never needs a cluster-wide credential. In dev
+# Rook writes the keys here as rook-ceph-object-user-<store>-<user>; prod points
+# this at the TF-provisioned yucca-provisioner-rgw Secret. Per-cluster overrides
+# ride in the same Secret as RADOS_ACCESS_KEY_ID_<CODE>/RADOS_SECRET_ACCESS_KEY_<CODE>.
+radosSecretName: rook-ceph-object-user-yucca-provisioner
+
 # CNPG-managed postgres Cluster name (see umbrella chart)
 postgresClusterName: yucca-db
 
@@ -60,6 +67,11 @@ secretData:
 # to provide a real key gets a loud missing-JWT_PRIVATE_KEY crash instead of
 # silently signing production tokens with a public fixture.
 useDevKeypair: false
+# The dev storage-credential keys, under the same opt-in. The seal half is
+# shared with michael (charts/apps/michael/values.yaml); the at-rest half never
+# leaves the APIs.
+devStorageCredentialKey: eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=
+devStorageSealKey: eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=
 devJwtPrivateKey: |
   -----BEGIN PRIVATE KEY-----
   MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgCla79+Sip4o2hZ1K

--- a/docs/storage-credentials.md
+++ b/docs/storage-credentials.md
@@ -1,0 +1,126 @@
+# Per-repository storage credentials
+
+michael used to hold one RGW user per storage cluster — a credential that could
+read and write **every** repository's bucket, sitting in the one service exposed
+to the internet, whether or not anyone was backing up. It no longer holds any.
+
+Each repository has its **own** S3 user. Its keys are sealed into the restic
+token, so michael learns them only from a request that already proves the caller
+owns that repository, and only for as long as that token is in play.
+
+```
+yucca-api ──creates──> RGW user yucca-repo-<repository id>   (users+buckets admin)
+          ──seals────> storageCredentials claim in the restic token
+                            │
+restic ─────────────────────┴──> michael ──opens──> per-request S3 client
+                                              (L1 cache, keyed by credential)
+```
+
+## The seal
+
+The `storageCredentials` claim is written by `@common/server`
+`sealStorageCredentials` and read by michael's `internal/credentials`:
+
+```
+base64url(version[1] || nonce[12] || ciphertext || tag[16])
+```
+
+AES-256-GCM over `{"accessKeyId","secretAccessKey"}`, with the **repository id
+as additional authenticated data** — a blob lifted out of one repository's token
+does not open against another's, even though both were sealed with the same key.
+The format is pinned from both sides: `TestOpenTypeScriptFixture` opens a blob
+the TypeScript implementation actually emitted.
+
+Two keys, deliberately distinct:
+
+| Key | Held by | Seals |
+|---|---|---|
+| `STORAGE_CREDENTIAL_KEY` | yucca-api, yucca-admin-api | the RGW secret key at rest in `repositories.storageSecretAccessKey` |
+| `STORAGE_CREDENTIAL_SEAL_KEY` | the APIs **and michael** | the credentials inside a restic token |
+
+michael can therefore open a token but not a database row. Both accept a
+comma-separated list: the first key seals, every key opens, so a rotation is
+`add new key everywhere` → `move it to the front on the APIs` → `drop the old
+one`, with no flag day.
+
+## Provisioning
+
+`RepositoryService.create` provisions eagerly, so a storage cluster that cannot
+issue a user fails the create rather than the first backup. `createUrl`
+provisions lazily too, which is what heals a repository that predates this.
+
+The RGW user is `yucca-repo-<repository id>`, created through the RadosGW admin
+API with `max-buckets=1` — it owns exactly the one bucket backing its
+repository, so a leaked key cannot stand up storage of its own. Deleting a
+repository revokes its keys and leaves the bucket alone, matching the existing
+behaviour that deleting a repository never deletes data.
+
+A storage cluster with no `rgw_admin_endpoint` (the compose stack, which runs
+against MinIO) falls back to `STORAGE_STATIC_ACCESS_KEY_ID` /
+`STORAGE_STATIC_SECRET_ACCESS_KEY` for every repository. That exercises the
+whole sealing path in dev without isolating anything — it is a development
+fallback, not a deployment mode.
+
+## michael
+
+- The token's claim is required. There is no fallback credential, so a token
+  without one is a 401 rather than a request served with someone else's keys.
+- Credentials are opened once per token: the existing verified-token cache
+  already keys on the `Authorization` header, so a restic session decrypts once.
+- Each S3 **client** is cached per credential fingerprint per backend
+  (`storage.clientCache`, 1024 entries). Every client shares its backend's
+  `*http.Client`, so a new credential costs an options struct, never a
+  connection pool. `storage.credentials.cache.{hits,misses}` tracks it.
+- Backend health probes are **unsigned**. Any HTTP response — including the 403
+  an anonymous `HeadBucket` earns — proves the gateway is serving, and only
+  transport failures and 5xx mark a backend unhealthy, so probing needs no
+  credential at all.
+
+## Migrating existing repositories
+
+Buckets created before this change belong to the old cluster-wide user, and
+their objects carry that user's ACLs. `yuctl repos migrate-storage-credentials`
+does, per repository:
+
+1. `POST /repository/:id/storage-credentials` on the admin API — creates the
+   repository's RGW user and keys (idempotent).
+2. `PutBucketOwnershipControls` = `BucketOwnerEnforced`, signed as the **current**
+   owner. RGW then ignores per-object ACLs, so the objects the old owner wrote
+   follow the bucket instead of staying readable only by it.
+3. Admin-API `link` of the bucket to the new user.
+4. Re-read the bucket and fail loudly unless the owner actually changed.
+
+Ordering matters: enforce ownership *before* the link, or the new owner inherits
+a bucket full of objects it cannot read. `--dry-run` reports what would move;
+`--repository <id>` does one; a repository already on its own user is skipped.
+
+If an RGW rejects bucket ownership controls, the command says so and names the
+fallback (`radosgw-admin bucket chown` on a ceph host) rather than half-migrating.
+
+## Cutover
+
+This is a hard cutover — michael has no path back to a cluster-wide credential.
+Deploy the APIs and michael together, then run the migration. Tokens minted
+before it carry no credentials and are rejected; on the current 1-day token
+lifetime, clients re-mint within a day.
+
+## The admin identities
+
+Two, deliberately split, both ansible-provisioned with TF-minted keys:
+
+| User | Caps | Held by |
+|---|---|---|
+| `yucca-provisioner` | `users=*` | the APIs, online, in `yucca-provisioner-rgw` |
+| `yucca-migrator` | `buckets=*` | operators only, read from 1Password by yuctl |
+
+The APIs only ever call `/admin/user`, so the credential that is online
+permanently has no bucket admin at all — it cannot list, stat, relink or delete
+a bucket. The one that can is used by a human running a one-shot migration and
+is never mounted into the cluster.
+
+**This is a reduction, not a wall.** `users=*` can mint a key for any RGW user,
+including a repository's own, and then read that bucket over the S3 data path.
+RGW admin caps have no finer grain than read/write/`*` per category, so no cap
+set both provisions users and forecloses that escalation. Removing it entirely
+would mean no online component may create storage identities — i.e. provisioning
+moves offline, or moves to short-lived STS credentials once RGW STS is enabled.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -149,10 +149,11 @@ persistence, secrets) are where a future prod cluster overlay diverges. Notably:
   in [`ansible/ceph`](../ansible/ceph) / [`tf/`](../tf)) — not this Rook cluster.
 - The Rook-Ceph dev cluster is single-node/single-replica and synthesizes a
   loopback block device (k3d has no spare disk). See
-  [`charts/platform/rook-ceph-cluster`](../charts/platform/rook-ceph-cluster). `michael`'s S3
-  credentials come from a full RGW user
-  ([`charts/platform/ceph-objectuser`](../charts/platform/ceph-objectuser)) whose Secret Rook
-  writes into the `yucca` namespace.
+  [`charts/platform/rook-ceph-cluster`](../charts/platform/rook-ceph-cluster). `michael` has
+  **no** S3 credentials: the APIs create one RGW user per repository (with the
+  `provisioner` object-user's admin caps,
+  [`charts/platform/ceph-objectuser`](../charts/platform/ceph-objectuser)) and seal its keys
+  into each restic token. See [`docs/storage-credentials.md`](../docs/storage-credentials.md).
 - The dev keypair/secrets committed in chart `secretData` are **well-known
   fixtures** (the same keypair lives in `.mise/tasks/*/env`); they must become
   `ExternalSecret`s backed by the org's 1Password (External Secrets Operator)

--- a/kubernetes/apps/base/michael/helmrelease.yaml
+++ b/kubernetes/apps/base/michael/helmrelease.yaml
@@ -33,9 +33,11 @@ spec:
       # release-please-stamped in git. If unset, the empty default lets the
       # chart fall back to v<appVersion> — the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
-    # secretData nulled: the chart's dev JWT_PUBLIC_KEY fixture is replaced by
-    # the TF-provisioned `yucca-michael` Secret (JWT_PUBLIC_KEY + S3 creds),
-    # which the chart's `envFrom: secretRef: yucca-michael` picks up unchanged.
+    # secretData nulled: the chart's dev fixtures are replaced by the
+    # TF-provisioned `yucca-michael` Secret (JWT_PUBLIC_KEY +
+    # STORAGE_CREDENTIAL_SEAL_KEY), which the chart's
+    # `envFrom: secretRef: yucca-michael` picks up unchanged. No S3 credentials
+    # live here any more: each restic token carries its repository's own.
     secretData: null
     env:
       - name: RESTIC_API_PORT

--- a/kubernetes/apps/base/topology/configmap.yaml
+++ b/kubernetes/apps/base/topology/configmap.yaml
@@ -38,8 +38,6 @@ data:
                 "endpoint": "${S3_ENDPOINT}",
                 "region": "us-east-1",
                 "force_path_style": true,
-                "access_key_env": "S3_ACCESS_KEY_ID",
-                "secret_key_env": "S3_SECRET_ACCESS_KEY",
                 "backend_source": "dns",
                 "backend_dns_host": "${S3_HOST}",
                 "pin_host": true,

--- a/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
@@ -33,6 +33,10 @@ spec:
       tag: ${YUCCA_IMAGE_TAG:=}
     # secretData nulled: replaced by the TF-provisioned `yucca-admin-api` Secret
     # (OIDC_ADMIN_CLIENT_ID/SECRET) via the chart's envFrom: secretRef.
+    # RGW admin keys for per-repository S3 users: TF-provisioned into the
+    # yucca-provisioner-rgw Secret (tf .../talos/secrets.tf), like
+    # yucca-metrics-rgw. Additional clusters get RADOS_*_<CODE> pairs in it.
+    radosSecretName: yucca-provisioner-rgw
     secretData: null
     # Not publicly routed — reached over the NetBird overlay at
     # ${YUCCA_ADMIN_HOST} (per-cluster, from cluster-settings). Admin auth uses

--- a/kubernetes/apps/base/yucca-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-api/helmrelease.yaml
@@ -40,6 +40,10 @@ spec:
     # secretData nulled: the chart's dev fixture (JWT + OIDC placeholders) is
     # replaced by the TF-provisioned `yucca-api` Secret (JWT_PRIVATE_KEY +
     # OIDC_CLIENT_ID/SECRET), picked up via the chart's envFrom: secretRef.
+    # RGW admin keys for per-repository S3 users: TF-provisioned into the
+    # yucca-provisioner-rgw Secret (tf .../talos/secrets.tf), like
+    # yucca-metrics-rgw. Additional clusters get RADOS_*_<CODE> pairs in it.
+    radosSecretName: yucca-provisioner-rgw
     secretData: null
     # Real IdP (no mock-oidc). Chart maps these onto explicit env (which beats
     # envFrom). Redirects target the staging ingress domain.

--- a/kubernetes/apps/dev/local/yucca/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./database/ks.yaml
   - ./object-user/ks.yaml
   - ./metrics-object-user/ks.yaml
+  - ./provisioner-object-user/ks.yaml
   - ./mock-oidc/ks.yaml
   - ./victoria-metrics/ks.yaml
   - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: yucca-provisioner-object-user
+  namespace: yucca
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: charts/platform/ceph-objectuser
+      sourceRef:
+        kind: GitRepository
+        name: yucca
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # RGW admin the APIs use to create one S3 user per repository, so michael can
+    # hold no storage credentials at all. Rook writes its keys to
+    # rook-ceph-object-user-yucca-provisioner. In prod this user is `users=*`
+    # only and bucket ops belong to a separate operator-held `yucca-migrator`;
+    # the dev lab collapses both into one so the integration suites have a single
+    # credential to reach for.
+    userName: provisioner
+    capabilities:
+      user: '*'
+      bucket: '*'

--- a/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/dev/local/yucca/provisioner-object-user/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/provisioner-object-user/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: yucca-provisioner-object-user
+  namespace: flux-system
+spec:
+  targetNamespace: yucca
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: yucca-provisioner-object-user
+  path: ./kubernetes/apps/dev/local/yucca/provisioner-object-user/app
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: yucca
+  dependsOn:
+    - name: rook-ceph-cluster

--- a/kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml
+++ b/kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml
@@ -38,8 +38,6 @@ data:
                 "endpoint": "http://rook-ceph-rgw-yucca.rook-ceph.svc:80",
                 "region": "us-east-1",
                 "force_path_style": true,
-                "access_key_env": "S3_ACCESS_KEY_ID",
-                "secret_key_env": "S3_SECRET_ACCESS_KEY",
                 "backend_source": "dns",
                 "backend_dns_host": "rook-ceph-rgw-yucca.rook-ceph.svc",
                 "probe_bucket": "michael-rgw-healthcheck"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,2 +1,3 @@
 export * from './connections';
 export * from './features';
+export * from './storageCredentials';

--- a/packages/common/src/storageCredentials.ts
+++ b/packages/common/src/storageCredentials.ts
@@ -1,0 +1,88 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+export interface StorageCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+// Wire format of the `storageCredentials` claim, mirrored byte for byte by
+// michael (packages/michael/internal/credentials). Changing it breaks every
+// token in flight:
+//
+//   base64url(version[1] || nonce[12] || ciphertext || tag[16])
+//
+// The repository id is the additional authenticated data, so a blob lifted into
+// another repository's token fails to open rather than granting its bucket.
+const VERSION = 1;
+const NONCE_BYTES = 12;
+const KEY_BYTES = 32;
+const TAG_BYTES = 16;
+
+export const sealStorageCredentials = (key: Buffer, repositoryId: string, credentials: StorageCredentials): string => {
+  if (key.length !== KEY_BYTES) {
+    throw new Error(`Storage credential key must be ${KEY_BYTES} bytes, got ${key.length}`);
+  }
+
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  cipher.setAAD(Buffer.from(repositoryId, 'utf8'));
+
+  const plaintext = Buffer.from(JSON.stringify(credentials), 'utf8');
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+
+  return Buffer.concat([Buffer.from([VERSION]), nonce, ciphertext, cipher.getAuthTag()]).toString('base64url');
+};
+
+// Tries every configured key, so a rotation can run with the new key primary
+// and the old one still accepted.
+export const openStorageCredentials = (
+  keys: readonly Buffer[],
+  repositoryId: string,
+  sealed: string,
+): StorageCredentials => {
+  const blob = Buffer.from(sealed, 'base64url');
+  if (blob.length < 1 + NONCE_BYTES + TAG_BYTES) {
+    throw new Error('Sealed storage credentials are truncated');
+  }
+  if (blob[0] !== VERSION) {
+    throw new Error(`Unsupported sealed storage credential version ${blob[0]}`);
+  }
+
+  const nonce = blob.subarray(1, 1 + NONCE_BYTES);
+  const ciphertext = blob.subarray(1 + NONCE_BYTES, blob.length - TAG_BYTES);
+  const tag = blob.subarray(blob.length - TAG_BYTES);
+
+  for (const key of keys) {
+    try {
+      const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+      decipher.setAAD(Buffer.from(repositoryId, 'utf8'));
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+      return JSON.parse(plaintext.toString('utf8')) as StorageCredentials;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error('Sealed storage credentials could not be opened with any configured key');
+};
+
+// The first key seals; the rest are decrypt-only, which is what makes a
+// rotation a two-step deploy instead of a flag day.
+export const parseStorageCredentialKeys = (value: string): Buffer[] => {
+  const keys = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => Buffer.from(entry, 'base64'));
+
+  if (keys.length === 0) {
+    throw new Error('At least one storage credential key is required');
+  }
+  for (const key of keys) {
+    if (key.length !== KEY_BYTES) {
+      throw new Error(`Storage credential keys must be base64-encoded ${KEY_BYTES}-byte values`);
+    }
+  }
+  return keys;
+};

--- a/packages/e2e/k3d/run.sh
+++ b/packages/e2e/k3d/run.sh
@@ -80,6 +80,12 @@ done
 
 echo "==> jest e2e (it-works, restic-api, yucca-api, orchestration-api)"
 # shellcheck disable=SC1091
+# michael takes its S3 credentials from the token, so the suites that mint their
+# own have to seal the REAL RGW user's keys — the cluster's, not the compose
+# MinIO defaults the env files fall back to.
+S3_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.AccessKey}' | base64 -d)"
+S3_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.SecretKey}' | base64 -d)"
+export S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY
 source .mise/tasks/restic-api/env
 # shellcheck disable=SC1091
 source .mise/tasks/yucca-api/env

--- a/packages/e2e/src/env.ts
+++ b/packages/e2e/src/env.ts
@@ -5,6 +5,11 @@ const schema = z.object({
   YUCCA_API_PORT: z.coerce.number().min(1000),
 
   JWT_PRIVATE_KEY: z.string(),
+
+  // A restic token has to carry its repository's own S3 credentials, sealed.
+  STORAGE_CREDENTIAL_SEAL_KEY: z.string(),
+  S3_ACCESS_KEY_ID: z.string(),
+  S3_SECRET_ACCESS_KEY: z.string(),
 });
 
 export const env = schema.parse(process.env);

--- a/packages/e2e/test/restic-api.spec.ts
+++ b/packages/e2e/test/restic-api.spec.ts
@@ -1,3 +1,4 @@
+import { parseStorageCredentialKeys, sealStorageCredentials } from '@common/server';
 import {
   backup,
   cache,
@@ -34,12 +35,20 @@ import { env } from 'src/env';
 
 const password = 'password';
 
+const sealKey = parseStorageCredentialKeys(env.STORAGE_CREDENTIAL_SEAL_KEY)[0];
+
+// These suites drive michael's protocol directly rather than going through
+// yucca-api (yucca-api.spec covers that path), so they seal their own.
 function generateRepoUrl(repository: string, writeOnce: boolean) {
   const token = jwt.sign(
     {
       user: randomUUID(),
       repository,
       writeOnce,
+      storageCredentials: sealStorageCredentials(sealKey, repository, {
+        accessKeyId: env.S3_ACCESS_KEY_ID,
+        secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+      }),
     },
     env.JWT_PRIVATE_KEY,
     { algorithm: 'ES256' },

--- a/packages/michael/e2e_test.go
+++ b/packages/michael/e2e_test.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"michael/internal/config"
+	michaelcreds "michael/internal/credentials"
 	"michael/internal/handlers"
 	"michael/internal/storage"
 
@@ -71,14 +72,25 @@ func e2eEnv(t *testing.T, key string) string {
 	return v
 }
 
+// The harness's object-user keys reach michael the way real ones do: sealed
+// into the token.
+var e2eSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+func e2eCredentials(t *testing.T) michaelcreds.Credentials {
+	t.Helper()
+	return michaelcreds.Credentials{
+		AccessKeyID:     e2eEnv(t, "S3_ACCESS_KEY_ID"),
+		SecretAccessKey: e2eEnv(t, "S3_SECRET_ACCESS_KEY"),
+	}
+}
+
 func e2eConfig(t *testing.T) config.Config {
 	return config.Config{
-		JWTPublicKey:      e2ePublicKey,
-		S3AccessKeyID:     e2eEnv(t, "S3_ACCESS_KEY_ID"),
-		S3SecretAccessKey: e2eEnv(t, "S3_SECRET_ACCESS_KEY"),
-		S3Region:          envOrE2E("S3_REGION", "us-east-1"),
-		S3Endpoint:        e2eEnv(t, "S3_ENDPOINT"),
-		S3ForcePathStyle:  true,
+		JWTPublicKey:     e2ePublicKey,
+		StorageSealKeys:  e2eSealKeys,
+		S3Region:         envOrE2E("S3_REGION", "us-east-1"),
+		S3Endpoint:       e2eEnv(t, "S3_ENDPOINT"),
+		S3ForcePathStyle: true,
 	}
 }
 
@@ -99,11 +111,16 @@ func e2eJWT(t *testing.T, repo string, writeOnce bool) string {
 // minted before multi-cluster routing existed.
 func e2eJWTForCluster(t *testing.T, repo string, writeOnce bool, storageCluster string) string {
 	t.Helper()
+	sealed, err := michaelcreds.Seal(e2eSealKeys[0], repo, e2eCredentials(t))
+	if err != nil {
+		t.Fatalf("seal storage credentials: %v", err)
+	}
 	claims := jwt.MapClaims{
-		"user":       e2eUser,
-		"repository": repo,
-		"writeOnce":  writeOnce,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               e2eUser,
+		"repository":         repo,
+		"writeOnce":          writeOnce,
+		"storageCredentials": sealed,
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	}
 	if storageCluster != "" {
 		claims["storageCluster"] = storageCluster
@@ -281,10 +298,10 @@ func mustStatus(t *testing.T, resp *http.Response, want int, what string) {
 
 // rawClient builds an S3 client straight to the real RGW (not via the proxies),
 // used only for test bucket cleanup.
-func rawClient(cfg config.Config) *s3.Client {
+func rawClient(cfg config.Config, creds michaelcreds.Credentials) *s3.Client {
 	return s3.New(s3.Options{
 		Region:       cfg.S3Region,
-		Credentials:  credentials.NewStaticCredentialsProvider(cfg.S3AccessKeyID, cfg.S3SecretAccessKey, ""),
+		Credentials:  credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, ""),
 		BaseEndpoint: aws.String(cfg.S3Endpoint),
 		UsePathStyle: true,
 	})
@@ -292,7 +309,7 @@ func rawClient(cfg config.Config) *s3.Client {
 
 func cleanupBucket(t *testing.T, cfg config.Config, bucket string) {
 	t.Helper()
-	c := rawClient(cfg)
+	c := rawClient(cfg, e2eCredentials(t))
 	ctx := context.Background()
 	out, err := c.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
 	if err == nil {
@@ -347,7 +364,7 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	}
 	t.Logf("pool up: 2 backends healthy against real RGW (%s)", cfg.S3Endpoint)
 
-	srv := httptest.NewServer(handlers.NewServer(pool, cfg.JWTPublicKey, nil).Handler())
+	srv := httptest.NewServer(handlers.NewServer(pool, cfg.JWTPublicKey, cfg.StorageSealKeys, nil).Handler())
 	defer srv.Close()
 	client := srv.Client()
 	auth := e2eJWT(t, repo, false)
@@ -524,7 +541,7 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	srv := httptest.NewServer(handlers.NewClusterServer(map[string]storage.Storage{
 		"default": defaultPool,
 		"spice":   spicePool,
-	}, "default", cfg.JWTPublicKey, nil).Handler())
+	}, "default", cfg.JWTPublicKey, cfg.StorageSealKeys, nil).Handler())
 	defer srv.Close()
 	client := srv.Client()
 

--- a/packages/michael/integration_test.go
+++ b/packages/michael/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"michael/internal/config"
+	"michael/internal/credentials"
 	"michael/internal/handlers"
 	"michael/internal/storage"
 
@@ -34,12 +35,22 @@ const (
 	testRepository = "00000000-0000-0000-0000-000000000002"
 )
 
+// Against the compose MinIO these are the root credentials the static dev
+// provider hands out.
+var testSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+func testStorageCredentials() credentials.Credentials {
+	return credentials.Credentials{
+		AccessKeyID:     envOrDefault("S3_ACCESS_KEY_ID", "minio"),
+		SecretAccessKey: envOrDefault("S3_SECRET_ACCESS_KEY", "miniominio"),
+	}
+}
+
 func integrationConfig() config.Config {
 	return config.Config{
 		Port:             3010,
 		JWTPublicKey:     testPublicKey,
-		S3AccessKeyID:    envOrDefault("S3_ACCESS_KEY_ID", "minio"),
-		S3SecretAccessKey: envOrDefault("S3_SECRET_ACCESS_KEY", "miniominio"),
+		StorageSealKeys:  testSealKeys,
 		S3Region:         envOrDefault("S3_REGION", "minio"),
 		S3Endpoint:       envOrDefault("S3_ENDPOINT", "http://localhost:9000"),
 		S3ForcePathStyle: true,
@@ -55,11 +66,16 @@ func envOrDefault(key, fallback string) string {
 
 func integrationJWT(t *testing.T, _ config.Config, repo string, writeOnce bool) string {
 	t.Helper()
+	sealed, err := credentials.Seal(testSealKeys[0], repo, testStorageCredentials())
+	if err != nil {
+		t.Fatalf("seal storage credentials: %v", err)
+	}
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"user":       testUser,
-		"repository": repo,
-		"writeOnce":  writeOnce,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         repo,
+		"writeOnce":          writeOnce,
+		"storageCredentials": sealed,
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	})
 	signed, err := token.SignedString(testPrivateKey)
 	if err != nil {
@@ -75,7 +91,7 @@ func integrationAuth(token string) string {
 func TestIntegration_FullWorkflow(t *testing.T) {
 	cfg := integrationConfig()
 	store := storage.NewS3Storage(cfg)
-	srv := handlers.NewServer(store, cfg.JWTPublicKey, nil)
+	srv := handlers.NewServer(store, cfg.JWTPublicKey, cfg.StorageSealKeys, nil)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -246,7 +262,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 func TestIntegration_WORM(t *testing.T) {
 	cfg := integrationConfig()
 	store := storage.NewS3Storage(cfg)
-	srv := handlers.NewServer(store, cfg.JWTPublicKey, nil)
+	srv := handlers.NewServer(store, cfg.JWTPublicKey, cfg.StorageSealKeys, nil)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 

--- a/packages/michael/internal/auth/auth.go
+++ b/packages/michael/internal/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"michael/internal/cluster"
+	"michael/internal/credentials"
 	"michael/internal/httputil"
 
 	"github.com/go-chi/chi/v5"
@@ -27,6 +28,9 @@ type Auth struct {
 	StorageCluster string `json:"storageCluster"`
 	Jti            string `json:"jti"`
 	Connection     string `json:"connection"`
+	// michael has no credentials of its own, so a token without these reaches no
+	// storage at all.
+	Credentials credentials.Credentials `json:"-"`
 }
 
 type contextKey string
@@ -59,15 +63,18 @@ const (
 // entries expire with the token's exp claim.
 type Verifier struct {
 	publicKey *ecdsa.PublicKey
+	sealKeys  [][]byte
 	cache     *tokenCache
 	onLookup  func(hit bool)
 }
 
 // NewVerifier builds a Verifier. onLookup, if non-nil, is called with the
-// cache outcome of every authenticated request.
-func NewVerifier(publicKey *ecdsa.PublicKey, onLookup func(hit bool)) *Verifier {
+// cache outcome of every authenticated request; a hit reuses the credentials
+// opened for the session's first request, so a restic run decrypts them once.
+func NewVerifier(publicKey *ecdsa.PublicKey, sealKeys [][]byte, onLookup func(hit bool)) *Verifier {
 	return &Verifier{
 		publicKey: publicKey,
+		sealKeys:  sealKeys,
 		cache:     newTokenCache(cacheSize),
 		onLookup:  onLookup,
 	}
@@ -86,7 +93,7 @@ func (v *Verifier) authenticate(r *http.Request) (Auth, *authError) {
 	}
 	v.lookup(false)
 
-	a, exp, err := extractAuth(r, v.publicKey)
+	a, exp, err := extractAuth(r, v.publicKey, v.sealKeys)
 	if err != nil {
 		return Auth{}, err
 	}
@@ -120,13 +127,14 @@ func (v *Verifier) Middleware() func(http.Handler) http.Handler {
 			}
 
 			ctx := context.WithValue(r.Context(), authContextKey, auth)
+			ctx = credentials.NewContext(ctx, auth.Credentials)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
-func Middleware(publicKey *ecdsa.PublicKey) func(http.Handler) http.Handler {
-	return NewVerifier(publicKey, nil).Middleware()
+func Middleware(publicKey *ecdsa.PublicKey, sealKeys [][]byte) func(http.Handler) http.Handler {
+	return NewVerifier(publicKey, sealKeys, nil).Middleware()
 }
 
 type authError struct {
@@ -140,7 +148,7 @@ func (e *authError) Error() string {
 
 // extractAuth verifies the request's token and returns the Auth plus the
 // token's exp claim (zero if absent).
-func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, *authError) {
+func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey, sealKeys [][]byte) (Auth, time.Time, *authError) {
 	header := r.Header.Get("Authorization")
 	if header == "" {
 		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Missing Authorization header"}
@@ -213,6 +221,16 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, 
 		}
 		auth.StorageCluster = storageCluster
 	}
+	sealed, ok := claims["storageCredentials"].(string)
+	if !ok || sealed == "" {
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Token carries no storage credentials"}
+	}
+	creds, err := credentials.Open(sealKeys, auth.Repository, sealed)
+	if err != nil {
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid storage credentials"}
+	}
+	auth.Credentials = creds
+
 	if jti, ok := claims["jti"].(string); ok {
 		auth.Jti = jti
 	}

--- a/packages/michael/internal/auth/auth_test.go
+++ b/packages/michael/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -10,6 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"michael/internal/credentials"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
@@ -37,18 +40,31 @@ func makeBasicAuth(token string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte("restic:"+token))
 }
 
+var testSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+var testCredentials = credentials.Credentials{AccessKeyID: "AKIAREPO", SecretAccessKey: "s3cret"}
+
+func sealedFor(repository string) string {
+	sealed, err := credentials.Seal(testSealKeys[0], repository, testCredentials)
+	if err != nil {
+		panic(err)
+	}
+	return sealed
+}
+
 func validClaims() jwt.MapClaims {
 	return jwt.MapClaims{
-		"user":       testUser,
-		"repository": testRepository,
-		"writeOnce":  false,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         testRepository,
+		"writeOnce":          false,
+		"storageCredentials": sealedFor(testRepository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	}
 }
 
 func TestAuthMissingHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for missing auth header")
 	}
@@ -60,7 +76,7 @@ func TestAuthMissingHeader(t *testing.T) {
 func TestAuthInvalidAuthType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", "Bearer some-token")
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for non-Basic auth")
 	}
@@ -73,7 +89,7 @@ func TestAuthMissingToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	// Basic auth with no password (just username, no colon)
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("restic")))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for missing token")
 	}
@@ -85,7 +101,7 @@ func TestAuthMissingToken(t *testing.T) {
 func TestAuthInvalidJWT(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth("not-a-valid-jwt"))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for invalid JWT")
 	}
@@ -103,7 +119,7 @@ func TestAuthInvalidPayloadNonUUID(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for non-UUID user")
 	}
@@ -120,7 +136,7 @@ func TestAuthInvalidPayloadMissingWriteOnce(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for missing writeOnce")
 	}
@@ -134,7 +150,7 @@ func TestAuthSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
 
-	a, _, err := extractAuth(req, testPublicKey)
+	a, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -175,7 +191,7 @@ func TestAuthOptionalClaims(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 			req.Header.Set("Authorization", makeBasicAuth(token))
 
-			a, _, err := extractAuth(req, testPublicKey)
+			a, _, err := extractAuth(req, testPublicKey, testSealKeys)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -195,7 +211,7 @@ func TestAuthMiddlewareRepoMismatch(t *testing.T) {
 	// Create a chi router to test the middleware with path params
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(Middleware(testPublicKey))
+		r.Use(Middleware(testPublicKey, testSealKeys))
 		r.Get("/config", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -218,7 +234,7 @@ func TestAuthMiddlewareSuccess(t *testing.T) {
 	var gotAuth Auth
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(Middleware(testPublicKey))
+		r.Use(Middleware(testPublicKey, testSealKeys))
 		r.Get("/config", func(w http.ResponseWriter, r *http.Request) {
 			gotAuth = FromContext(r.Context())
 			w.WriteHeader(http.StatusOK)
@@ -242,7 +258,7 @@ func TestVerifierCachesVerifiedTokens(t *testing.T) {
 	token := makeJWT(t, validClaims())
 
 	var lookups []bool
-	v := NewVerifier(testPublicKey, func(hit bool) { lookups = append(lookups, hit) })
+	v := NewVerifier(testPublicKey, testSealKeys, func(hit bool) { lookups = append(lookups, hit) })
 
 	for range 3 {
 		req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
@@ -269,7 +285,7 @@ func TestVerifierCachesVerifiedTokens(t *testing.T) {
 
 func TestVerifierCacheHonorsExpiry(t *testing.T) {
 	token := makeJWT(t, validClaims())
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
@@ -299,7 +315,7 @@ func TestVerifierDoesNotCacheInvalidTokens(t *testing.T) {
 		return signed
 	}()
 
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(badToken))
 	if _, err := v.authenticate(req); err == nil {
@@ -308,5 +324,48 @@ func TestVerifierDoesNotCacheInvalidTokens(t *testing.T) {
 	key := sha256.Sum256([]byte(makeBasicAuth(badToken)))
 	if _, ok := v.cache.get(key, time.Now()); ok {
 		t.Fatal("invalid token must not be cached")
+	}
+}
+
+func TestAuthRejectsTokenWithoutStorageCredentials(t *testing.T) {
+	claims := validClaims()
+	delete(claims, "storageCredentials")
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, claims)))
+
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
+	if err == nil {
+		t.Fatal("expected a token without storage credentials to be rejected")
+	}
+	if err.code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", err.code)
+	}
+}
+
+func TestAuthRejectsStorageCredentialsSealedForAnotherRepository(t *testing.T) {
+	claims := validClaims()
+	claims["storageCredentials"] = sealedFor("00000000-0000-0000-0000-0000000000ff")
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, claims)))
+
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
+	if err == nil {
+		t.Fatal("expected credentials sealed for another repository to be rejected")
+	}
+	if err.code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", err.code)
+	}
+}
+
+func TestAuthCarriesStorageCredentials(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, validClaims())))
+
+	a, _, err := extractAuth(req, testPublicKey, testSealKeys)
+	if err != nil {
+		t.Fatalf("extractAuth: %v", err)
+	}
+	if a.Credentials != testCredentials {
+		t.Errorf("expected the sealed credentials on the auth, got %+v", a.Credentials)
 	}
 }

--- a/packages/michael/internal/auth/cluster_test.go
+++ b/packages/michael/internal/auth/cluster_test.go
@@ -18,7 +18,7 @@ func authRequest(t *testing.T, claims jwt.MapClaims) *http.Request {
 }
 
 func TestAuthStorageClusterAbsent(t *testing.T) {
-	a, _, err := extractAuth(authRequest(t, validClaims()), testPublicKey)
+	a, _, err := extractAuth(authRequest(t, validClaims()), testPublicKey, testSealKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestAuthStorageClusterValid(t *testing.T) {
 	for _, code := range []string{"spice", "sietch-2", "a", strings.Repeat("x", 64)} {
 		claims := validClaims()
 		claims["storageCluster"] = code
-		a, _, err := extractAuth(authRequest(t, claims), testPublicKey)
+		a, _, err := extractAuth(authRequest(t, claims), testPublicKey, testSealKeys)
 		if err != nil {
 			t.Fatalf("code %q: unexpected error: %v", code, err)
 		}
@@ -56,7 +56,7 @@ func TestAuthStorageClusterInvalid(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			claims := validClaims()
 			claims["storageCluster"] = value
-			_, _, err := extractAuth(authRequest(t, claims), testPublicKey)
+			_, _, err := extractAuth(authRequest(t, claims), testPublicKey, testSealKeys)
 			if err == nil {
 				t.Fatal("expected an error for a malformed storageCluster claim")
 			}
@@ -71,7 +71,7 @@ func TestAuthStorageClusterInvalid(t *testing.T) {
 // only in storageCluster must not share an entry — a collision would serve one
 // user's repository out of another cluster.
 func TestVerifierCacheKeepsClustersDistinct(t *testing.T) {
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 
 	for _, code := range []string{"spice", "sietch", ""} {
 		claims := validClaims()
@@ -99,7 +99,7 @@ func TestVerifierCachesStorageCluster(t *testing.T) {
 	req := authRequest(t, claims)
 
 	var lookups []bool
-	v := NewVerifier(testPublicKey, func(hit bool) { lookups = append(lookups, hit) })
+	v := NewVerifier(testPublicKey, testSealKeys, func(hit bool) { lookups = append(lookups, hit) })
 
 	for range 2 {
 		a, err := v.authenticate(req)
@@ -122,7 +122,7 @@ func TestVerifierDoesNotCacheInvalidCluster(t *testing.T) {
 	claims["storageCluster"] = "NOT VALID"
 	req := authRequest(t, claims)
 
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 	for range 2 {
 		if _, err := v.authenticate(req); err == nil {
 			t.Fatal("expected an error for a malformed storageCluster claim")
@@ -137,7 +137,7 @@ func TestAuthMiddlewarePassesStorageCluster(t *testing.T) {
 	var got Auth
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(Middleware(testPublicKey))
+		r.Use(Middleware(testPublicKey, testSealKeys))
 		r.Get("/config", func(w http.ResponseWriter, r *http.Request) {
 			got = FromContext(r.Context())
 			w.WriteHeader(http.StatusOK)
@@ -158,7 +158,7 @@ func TestAuthMiddlewarePassesStorageCluster(t *testing.T) {
 func TestAuthStorageClusterNullClaim(t *testing.T) {
 	claims := validClaims()
 	claims["storageCluster"] = nil
-	a, _, err := extractAuth(authRequest(t, claims), testPublicKey)
+	a, _, err := extractAuth(authRequest(t, claims), testPublicKey, testSealKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/packages/michael/internal/config/clusters_test.go
+++ b/packages/michael/internal/config/clusters_test.go
@@ -9,8 +9,6 @@ import (
 func testDefaultCluster() ClusterConfig {
 	return ClusterConfig{
 		Code:                "default",
-		S3AccessKeyID:       "default-key",
-		S3SecretAccessKey:   "default-secret",
 		S3Region:            "us-east-1",
 		S3Endpoint:          "https://s3.default.example",
 		S3ForcePathStyle:    true,
@@ -62,8 +60,6 @@ func TestParseClustersFull(t *testing.T) {
 
 	want := ClusterConfig{
 		Code:                "spice",
-		S3AccessKeyID:       "spice-key",
-		S3SecretAccessKey:   "spice-secret",
 		S3Region:            "spice-1",
 		S3Endpoint:          "https://s3.spice.example:8443",
 		S3ForcePathStyle:    false,
@@ -140,21 +136,6 @@ func TestParseClustersErrors(t *testing.T) {
 			wantErr: "endpoint is required",
 		},
 		{
-			name:    "missing credential env names",
-			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a"}]}`,
-			wantErr: "access_key_env and secret_key_env are required",
-		},
-		{
-			name:    "credential env unset",
-			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a","access_key_env":"MISSING","secret_key_env":"S"}]}`,
-			wantErr: "MISSING is unset or empty",
-		},
-		{
-			name:    "credential env empty",
-			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a","access_key_env":"K","secret_key_env":"EMPTY"}]}`,
-			wantErr: "EMPTY is unset or empty",
-		},
-		{
 			name:    "unknown backend source",
 			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a","access_key_env":"K","secret_key_env":"S","backend_source":"consul"}]}`,
 			wantErr: "backend_source must be",
@@ -191,6 +172,20 @@ func TestParseClustersErrors(t *testing.T) {
 				t.Errorf("error %q does not mention %q", err, c.wantErr)
 			}
 		})
+	}
+}
+
+// Credential env names are accepted for compatibility but no longer resolved:
+// michael takes its credentials from the request's token.
+func TestParseClustersWithoutCredentialEnvNames(t *testing.T) {
+	doc := `{"clusters":[{"code":"spice","endpoint":"http://s3.spice.example"}]}`
+
+	got, err := ParseClusters([]byte(doc), testDefaultCluster(), testEnv(nil))
+	if err != nil {
+		t.Fatalf("ParseClusters: %v", err)
+	}
+	if len(got) != 1 || got[0].Code != "spice" {
+		t.Fatalf("unexpected clusters: %+v", got)
 	}
 }
 
@@ -255,7 +250,7 @@ func TestParseTopologyClusters(t *testing.T) {
 	if len(got) != 2 || got[0].Code != "father-spice" || got[1].Code != "father-pepper" {
 		t.Fatalf("unexpected topology clusters: %+v", got)
 	}
-	if got[1].S3AccessKeyID != "pepper-key" || got[1].S3Endpoint != "https://s3.pepper.example" {
+	if got[1].S3Endpoint != "https://s3.pepper.example" {
 		t.Fatalf("additional cluster configuration was not resolved: %+v", got[1])
 	}
 }
@@ -275,8 +270,6 @@ func TestParseTopologyClustersRejectsMismatch(t *testing.T) {
 
 func TestDefaultClusterFromFlatConfig(t *testing.T) {
 	cfg := Config{
-		S3AccessKeyID:       "key",
-		S3SecretAccessKey:   "secret",
 		S3Region:            "us-east-1",
 		S3Endpoint:          "https://s3.example",
 		S3ForcePathStyle:    true,
@@ -296,7 +289,7 @@ func TestDefaultClusterFromFlatConfig(t *testing.T) {
 	if got.Code != "sietch" {
 		t.Errorf("expected code sietch, got %q", got.Code)
 	}
-	if got.S3Endpoint != cfg.S3Endpoint || got.S3AccessKeyID != cfg.S3AccessKeyID || got.S3BackendDNSHost != cfg.S3BackendDNSHost {
+	if got.S3Endpoint != cfg.S3Endpoint || got.S3Region != cfg.S3Region || got.S3BackendDNSHost != cfg.S3BackendDNSHost {
 		t.Errorf("flat S3_* config not carried into the default cluster: %+v", got)
 	}
 }

--- a/packages/michael/internal/config/config.go
+++ b/packages/michael/internal/config/config.go
@@ -15,19 +15,21 @@ import (
 	"time"
 
 	"michael/internal/cluster"
+	"michael/internal/credentials"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 type Config struct {
-	Port              int
-	JWTPublicKey      *ecdsa.PublicKey
-	S3AccessKeyID     string
-	S3SecretAccessKey string
-	S3Region          string
-	S3Endpoint        string
-	S3ForcePathStyle  bool
+	Port         int
+	JWTPublicKey *ecdsa.PublicKey
+	// michael configures no S3 credentials of its own; these open the ones each
+	// token carries.
+	StorageSealKeys  [][]byte
+	S3Region         string
+	S3Endpoint       string
+	S3ForcePathStyle bool
 
 	// S3 load-balancing pool. When S3BackendSource is empty, michael talks to
 	// the single S3Endpoint (legacy behavior). When set to "file" or "dns", it
@@ -75,12 +77,10 @@ type Config struct {
 // flat S3_* environment variables describe the default cluster; S3_CLUSTERS_FILE
 // declares any additional ones.
 type ClusterConfig struct {
-	Code              string
-	S3AccessKeyID     string
-	S3SecretAccessKey string
-	S3Region          string
-	S3Endpoint        string
-	S3ForcePathStyle  bool
+	Code             string
+	S3Region         string
+	S3Endpoint       string
+	S3ForcePathStyle bool
 
 	S3BackendSource     string // "" | "file" | "dns"
 	S3BackendFile       string
@@ -98,8 +98,6 @@ type ClusterConfig struct {
 func (c Config) DefaultCluster() ClusterConfig {
 	return ClusterConfig{
 		Code:                c.S3DefaultCluster,
-		S3AccessKeyID:       c.S3AccessKeyID,
-		S3SecretAccessKey:   c.S3SecretAccessKey,
 		S3Region:            c.S3Region,
 		S3Endpoint:          c.S3Endpoint,
 		S3ForcePathStyle:    c.S3ForcePathStyle,
@@ -128,14 +126,9 @@ func LoadConfig() Config {
 
 	jwtPublicKey := parseES256PublicKey(os.Getenv("JWT_PUBLIC_KEY"))
 
-	s3AccessKeyID := os.Getenv("S3_ACCESS_KEY_ID")
-	if s3AccessKeyID == "" {
-		log.Fatal().Msg("S3_ACCESS_KEY_ID is required")
-	}
-
-	s3SecretAccessKey := os.Getenv("S3_SECRET_ACCESS_KEY")
-	if s3SecretAccessKey == "" {
-		log.Fatal().Msg("S3_SECRET_ACCESS_KEY is required")
+	sealKeys, err := credentials.ParseKeys(os.Getenv("STORAGE_CREDENTIAL_SEAL_KEY"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("STORAGE_CREDENTIAL_SEAL_KEY is required")
 	}
 
 	s3Region := os.Getenv("S3_REGION")
@@ -260,8 +253,7 @@ func LoadConfig() Config {
 	cfg := Config{
 		Port:                port,
 		JWTPublicKey:        jwtPublicKey,
-		S3AccessKeyID:       s3AccessKeyID,
-		S3SecretAccessKey:   s3SecretAccessKey,
+		StorageSealKeys:     sealKeys,
 		S3Region:            s3Region,
 		S3Endpoint:          s3Endpoint,
 		S3ForcePathStyle:    s3ForcePathStyle,
@@ -344,11 +336,10 @@ type topologyCluster struct {
 	S3               *clusterEntry `json:"s3"`
 }
 
-// clusterEntry is one cluster in S3_CLUSTERS_FILE. Credentials are named
-// indirectly — the entry gives the NAMES of the environment variables holding
-// them — so the file can be a plain ConfigMap while the secrets stay in a k8s
-// Secret. Pointer fields distinguish "absent, inherit the default cluster" from
-// an explicit false.
+// clusterEntry is one cluster in S3_CLUSTERS_FILE. Pointer fields distinguish
+// "absent, inherit the default cluster" from an explicit false. access_key_env
+// and secret_key_env are still accepted so existing topology documents parse,
+// but nothing reads them: credentials arrive per request, from the token.
 type clusterEntry struct {
 	Code           string `json:"code"`
 	Endpoint       string `json:"endpoint"`
@@ -486,18 +477,6 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 	if e.Endpoint == "" {
 		return ClusterConfig{}, fmt.Errorf("cluster %q: endpoint is required", e.Code)
 	}
-	if e.AccessKeyEnv == "" || e.SecretKeyEnv == "" {
-		return ClusterConfig{}, fmt.Errorf("cluster %q: access_key_env and secret_key_env are required", e.Code)
-	}
-	accessKey := getenv(e.AccessKeyEnv)
-	if accessKey == "" {
-		return ClusterConfig{}, fmt.Errorf("cluster %q: %s is unset or empty", e.Code, e.AccessKeyEnv)
-	}
-	secretKey := getenv(e.SecretKeyEnv)
-	if secretKey == "" {
-		return ClusterConfig{}, fmt.Errorf("cluster %q: %s is unset or empty", e.Code, e.SecretKeyEnv)
-	}
-
 	switch e.BackendSource {
 	case "":
 		// single-endpoint mode
@@ -523,8 +502,6 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 	scheme, port := schemeAndPort(e.Endpoint)
 	cc := ClusterConfig{
 		Code:                e.Code,
-		S3AccessKeyID:       accessKey,
-		S3SecretAccessKey:   secretKey,
 		S3Region:            firstNonEmpty(e.Region, def.S3Region),
 		S3Endpoint:          e.Endpoint,
 		S3ForcePathStyle:    boolOr(e.ForcePathStyle, def.S3ForcePathStyle),

--- a/packages/michael/internal/credentials/credentials.go
+++ b/packages/michael/internal/credentials/credentials.go
@@ -1,0 +1,158 @@
+// Package credentials opens the per-repository S3 credentials a restic token
+// carries. michael has none of its own, so a request reaches only the bucket
+// the token it presents was sealed for.
+package credentials
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Credentials struct {
+	AccessKeyID     string `json:"accessKeyId"`
+	SecretAccessKey string `json:"secretAccessKey"`
+}
+
+// Fingerprint keys a credential pair without retaining the secret.
+func (c Credentials) Fingerprint() [32]byte {
+	return sha256.Sum256([]byte(c.AccessKeyID + "\x00" + c.SecretAccessKey))
+}
+
+// Wire format, written by @common/server sealStorageCredentials:
+//
+//	base64url(version[1] || nonce[12] || ciphertext || tag[16])
+//
+// AES-256-GCM over the JSON above, with the repository id as additional
+// authenticated data — a blob lifted out of one repository's token does not
+// open against another's.
+const (
+	version    = 1
+	keyBytes   = 32
+	nonceBytes = 12
+	tagBytes   = 16
+)
+
+// Every key is accepted when opening, so the API can start sealing with a new
+// one before the old one is withdrawn.
+func ParseKeys(value string) ([][]byte, error) {
+	var keys [][]byte
+	for _, entry := range strings.Split(value, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		key, err := base64.StdEncoding.DecodeString(entry)
+		if err != nil {
+			return nil, fmt.Errorf("storage credential key is not valid base64: %w", err)
+		}
+		if len(key) != keyBytes {
+			return nil, fmt.Errorf("storage credential key must be %d bytes, got %d", keyBytes, len(key))
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("at least one storage credential key is required")
+	}
+	return keys, nil
+}
+
+// Seal exists only so the format can be round-tripped in tests; in production
+// the TypeScript side is the only writer.
+func Seal(key []byte, repositoryID string, creds Credentials) (string, error) {
+	if len(key) != keyBytes {
+		return "", fmt.Errorf("storage credential key must be %d bytes, got %d", keyBytes, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, nonceBytes)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	plaintext, err := json.Marshal(creds)
+	if err != nil {
+		return "", err
+	}
+
+	blob := append([]byte{version}, nonce...)
+	blob = gcm.Seal(blob, nonce, plaintext, []byte(repositoryID))
+	return base64.RawURLEncoding.EncodeToString(blob), nil
+}
+
+func Open(keys [][]byte, repositoryID, sealed string) (Credentials, error) {
+	blob, err := decode(sealed)
+	if err != nil {
+		return Credentials{}, err
+	}
+	if len(blob) < 1+nonceBytes+tagBytes {
+		return Credentials{}, errors.New("sealed storage credentials are truncated")
+	}
+	if blob[0] != version {
+		return Credentials{}, fmt.Errorf("unsupported sealed storage credential version %d", blob[0])
+	}
+
+	nonce := blob[1 : 1+nonceBytes]
+	ciphertext := blob[1+nonceBytes:]
+
+	for _, key := range keys {
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return Credentials{}, err
+		}
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return Credentials{}, err
+		}
+		plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte(repositoryID))
+		if err != nil {
+			continue
+		}
+
+		var creds Credentials
+		if err := json.Unmarshal(plaintext, &creds); err != nil {
+			return Credentials{}, fmt.Errorf("sealed storage credentials are malformed: %w", err)
+		}
+		if creds.AccessKeyID == "" || creds.SecretAccessKey == "" {
+			return Credentials{}, errors.New("sealed storage credentials are incomplete")
+		}
+		return creds, nil
+	}
+
+	return Credentials{}, errors.New("sealed storage credentials could not be opened with any configured key")
+}
+
+func decode(sealed string) ([]byte, error) {
+	if blob, err := base64.RawURLEncoding.DecodeString(sealed); err == nil {
+		return blob, nil
+	}
+	blob, err := base64.URLEncoding.DecodeString(sealed)
+	if err != nil {
+		return nil, fmt.Errorf("sealed storage credentials are not valid base64url: %w", err)
+	}
+	return blob, nil
+}
+
+type contextKey struct{}
+
+func NewContext(ctx context.Context, c Credentials) context.Context {
+	return context.WithValue(ctx, contextKey{}, c)
+}
+
+func FromContext(ctx context.Context) (Credentials, bool) {
+	c, ok := ctx.Value(contextKey{}).(Credentials)
+	return c, ok
+}

--- a/packages/michael/internal/credentials/credentials_test.go
+++ b/packages/michael/internal/credentials/credentials_test.go
@@ -1,0 +1,143 @@
+package credentials
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+var testKey = bytes.Repeat([]byte{0x2a}, 32)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	want := Credentials{AccessKeyID: "AKIAREPO", SecretAccessKey: "s3cret"}
+
+	sealed, err := Seal(testKey, "repo-1", want)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	got, err := Open([][]byte{testKey}, "repo-1", sealed)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got != want {
+		t.Errorf("round trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestOpenRejectsAnotherRepositorysBlob(t *testing.T) {
+	sealed, err := Seal(testKey, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if _, err := Open([][]byte{testKey}, "repo-2", sealed); err == nil {
+		t.Fatal("expected a blob sealed for repo-1 to fail against repo-2")
+	}
+}
+
+// A rotation runs with both keys configured, so neither side restarts first.
+func TestOpenAcceptsAnyConfiguredKey(t *testing.T) {
+	oldKey := bytes.Repeat([]byte{0x11}, 32)
+	newKey := bytes.Repeat([]byte{0x22}, 32)
+
+	for name, key := range map[string][]byte{"old": oldKey, "new": newKey} {
+		t.Run(name, func(t *testing.T) {
+			sealed, err := Seal(key, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+			if err != nil {
+				t.Fatalf("Seal: %v", err)
+			}
+			if _, err := Open([][]byte{newKey, oldKey}, "repo-1", sealed); err != nil {
+				t.Fatalf("Open with both keys configured: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenRejectsUnknownKey(t *testing.T) {
+	sealed, err := Seal(testKey, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if _, err := Open([][]byte{bytes.Repeat([]byte{0x99}, 32)}, "repo-1", sealed); err == nil {
+		t.Fatal("expected an unknown key to fail")
+	}
+}
+
+// The producer is TypeScript (@common/server sealStorageCredentials) and the
+// consumer is this package, so the format is pinned by a fixture the TS side
+// actually emitted, not by this package's own round trip.
+func TestOpenTypeScriptFixture(t *testing.T) {
+	const sealed = "AU4he_wpRIQ5oOmfSJSMmHrxBGCCHG3VEIK6D_Y7ivi4y_rRLwGNK9Zk--dCK1apZ6d44R8y7CPhF4lVj8gu4LBJo1MSK5_FHGAQQV6-g24I4puAOLxt8uDh0E61"
+
+	got, err := Open([][]byte{testKey}, "repo-1234", sealed)
+	if err != nil {
+		t.Fatalf("Open TypeScript fixture: %v", err)
+	}
+	want := Credentials{AccessKeyID: "AKIAFIXTURE", SecretAccessKey: "fixture-secret"}
+	if got != want {
+		t.Errorf("fixture mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestOpenRejectsMalformedBlobs(t *testing.T) {
+	cases := map[string]string{
+		"not base64": "!!!not-base64!!!",
+		"truncated":  "AQID",
+		"wrong version": func() string {
+			sealed, err := Seal(testKey, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+			if err != nil {
+				t.Fatalf("Seal: %v", err)
+			}
+			return "Ag" + sealed[2:]
+		}(),
+	}
+
+	for name, sealed := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Open([][]byte{testKey}, "repo-1", sealed); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestParseKeys(t *testing.T) {
+	first := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, 32))
+	second := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x22}, 32))
+
+	keys, err := ParseKeys(first + ", " + second)
+	if err != nil {
+		t.Fatalf("ParseKeys: %v", err)
+	}
+	if len(keys) != 2 || !bytes.Equal(keys[0], bytes.Repeat([]byte{0x11}, 32)) {
+		t.Fatalf("expected the first key to stay first, got %d keys", len(keys))
+	}
+
+	for name, value := range map[string]string{
+		"empty":      "",
+		"not base64": "@@@",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseKeys(value); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+
+	t.Run("wrong size", func(t *testing.T) {
+		if _, err := ParseKeys("c2hvcnQ="); err == nil || !strings.Contains(err.Error(), "32 bytes") {
+			t.Fatalf("expected a size error, got %v", err)
+		}
+	})
+}
+
+func TestFingerprintDistinguishesCredentials(t *testing.T) {
+	a := Credentials{AccessKeyID: "one", SecretAccessKey: "two"}
+	b := Credentials{AccessKeyID: "onetwo", SecretAccessKey: ""}
+
+	if a.Fingerprint() == b.Fingerprint() {
+		t.Error("fingerprint must not collide across a shifted field boundary")
+	}
+}

--- a/packages/michael/internal/handlers/cluster_test.go
+++ b/packages/michael/internal/handlers/cluster_test.go
@@ -45,7 +45,7 @@ func twoClusterServer() (*Server, *recordingStorage, *recordingStorage) {
 	srv := NewClusterServer(map[string]storage.Storage{
 		cluster.DefaultCode: def,
 		"spice":             spice,
-	}, cluster.DefaultCode, testPublicKey, nil)
+	}, cluster.DefaultCode, testPublicKey, testSealKeys, nil)
 	return srv, def, spice
 }
 
@@ -87,11 +87,12 @@ func TestClusterRoutingEmptyClaimUsesDefault(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodHead, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, jwt.MapClaims{
-		"user":           testUser,
-		"repository":     testRepository,
-		"writeOnce":      false,
-		"storageCluster": "",
-		"exp":            jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         testRepository,
+		"writeOnce":          false,
+		"storageCluster":     "",
+		"storageCredentials": sealedFor(t, testRepository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	})))
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)
@@ -170,7 +171,7 @@ func TestClusterRoutingUnknownClusterCounted(t *testing.T) {
 		t.Fatalf("NewMetrics: %v", err)
 	}
 	srv := NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: &mockStorage{}},
-		cluster.DefaultCode, testPublicKey, m)
+		cluster.DefaultCode, testPublicKey, testSealKeys, m)
 
 	for range 2 {
 		rec := doRequest(t, srv, http.MethodHead, "/"+testRepository+"/config", nil, clusterAuth("sietch"), nil)
@@ -221,11 +222,12 @@ func TestClusterRoutingNonStringClaimRejected(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodHead, "/"+testRepository+"/config", nil)
 			req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, jwt.MapClaims{
-				"user":           testUser,
-				"repository":     testRepository,
-				"writeOnce":      false,
-				"storageCluster": value,
-				"exp":            jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				"user":               testUser,
+				"repository":         testRepository,
+				"writeOnce":          false,
+				"storageCluster":     value,
+				"storageCredentials": sealedFor(t, testRepository),
+				"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 			})))
 			rec := httptest.NewRecorder()
 			srv.Handler().ServeHTTP(rec, req)

--- a/packages/michael/internal/handlers/server.go
+++ b/packages/michael/internal/handlers/server.go
@@ -26,9 +26,10 @@ type Server struct {
 	Clusters map[string]storage.Storage
 	// DefaultCluster is the code served to tokens carrying no storageCluster
 	// claim — every token minted before multi-cluster routing existed.
-	DefaultCluster string
-	JWTPublicKey   *ecdsa.PublicKey
-	Metrics        *metrics.Metrics
+	DefaultCluster  string
+	JWTPublicKey    *ecdsa.PublicKey
+	StorageSealKeys [][]byte
+	Metrics         *metrics.Metrics
 	// ResolveClient identifies the source network of a request, for the traffic
 	// metrics and the access log. Optional: nil leaves both unattributed, which
 	// is what the tests and any deployment without an ASN database get.
@@ -37,18 +38,25 @@ type Server struct {
 
 // NewServer builds a single-cluster server: everything is served from s under
 // the default cluster code.
-func NewServer(s storage.Storage, jwtPublicKey *ecdsa.PublicKey, m *metrics.Metrics) *Server {
-	return NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: s}, cluster.DefaultCode, jwtPublicKey, m)
+func NewServer(s storage.Storage, jwtPublicKey *ecdsa.PublicKey, sealKeys [][]byte, m *metrics.Metrics) *Server {
+	return NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: s}, cluster.DefaultCode, jwtPublicKey, sealKeys, m)
 }
 
 // NewClusterServer builds a server fronting several storage clusters, routing
 // each request by its token's storageCluster claim.
-func NewClusterServer(clusters map[string]storage.Storage, defaultCluster string, jwtPublicKey *ecdsa.PublicKey, m *metrics.Metrics) *Server {
+func NewClusterServer(
+	clusters map[string]storage.Storage,
+	defaultCluster string,
+	jwtPublicKey *ecdsa.PublicKey,
+	sealKeys [][]byte,
+	m *metrics.Metrics,
+) *Server {
 	return &Server{
-		Clusters:       clusters,
-		DefaultCluster: defaultCluster,
-		JWTPublicKey:   jwtPublicKey,
-		Metrics:        m,
+		Clusters:        clusters,
+		DefaultCluster:  defaultCluster,
+		JWTPublicKey:    jwtPublicKey,
+		StorageSealKeys: sealKeys,
+		Metrics:         m,
 	}
 }
 
@@ -134,7 +142,7 @@ func (s *Server) Handler() http.Handler {
 			}
 		}
 	}
-	verifier := auth.NewVerifier(s.JWTPublicKey, onLookup)
+	verifier := auth.NewVerifier(s.JWTPublicKey, s.StorageSealKeys, onLookup)
 
 	r.Route("/{path}", func(r chi.Router) {
 		r.Use(verifier.Middleware())

--- a/packages/michael/internal/handlers/server_bench_test.go
+++ b/packages/michael/internal/handlers/server_bench_test.go
@@ -52,7 +52,7 @@ func benchServer(b *testing.B, blob []byte, resolve func(*http.Request) geoip.Cl
 		},
 	}
 
-	srv := NewServer(store, testPublicKey, m)
+	srv := NewServer(store, testPublicKey, testSealKeys, m)
 	srv.ResolveClient = resolve
 	return srv
 }
@@ -63,10 +63,11 @@ func benchServer(b *testing.B, blob []byte, resolve func(*http.Request) geoip.Cl
 func benchRequest(b *testing.B) *http.Request {
 	b.Helper()
 	token := makeJWTForBench(b, jwt.MapClaims{
-		"user":       testUser,
-		"repository": testRepository,
-		"writeOnce":  false,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         testRepository,
+		"writeOnce":          false,
+		"storageCredentials": sealedFor(b, testRepository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	})
 	r := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/data/"+testBlobName, nil)
 	r.Header.Set("Authorization", makeBasicAuth(token))

--- a/packages/michael/internal/handlers/server_test.go
+++ b/packages/michael/internal/handlers/server_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"michael/internal/auth"
+	"michael/internal/credentials"
 	"michael/internal/geoip"
 	"michael/internal/metrics"
 	"michael/internal/storage"
@@ -34,6 +35,20 @@ const (
 	testUser       = "00000000-0000-0000-0000-000000000001"
 	testRepository = "00000000-0000-0000-0000-000000000002"
 )
+
+var testSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+func sealedFor(t testing.TB, repository string) string {
+	t.Helper()
+	sealed, err := credentials.Seal(testSealKeys[0], repository, credentials.Credentials{
+		AccessKeyID:     "AKIAREPO",
+		SecretAccessKey: "s3cret",
+	})
+	if err != nil {
+		t.Fatalf("failed to seal storage credentials: %v", err)
+	}
+	return sealed
+}
 
 func makeJWT(t *testing.T, claims jwt.MapClaims) string {
 	t.Helper()
@@ -129,7 +144,7 @@ func (m *mockStorage) DeleteObject(ctx context.Context, bucket, key string) erro
 
 // newTestServer creates a single-cluster Server with mock storage.
 func newTestServer(store *mockStorage) *Server {
-	return NewServer(store, testPublicKey, nil)
+	return NewServer(store, testPublicKey, testSealKeys, nil)
 }
 
 // doRequest creates and executes a request against the test server with a real JWT auth header.
@@ -139,10 +154,11 @@ func doRequest(t *testing.T, srv *Server, method, path string, body io.Reader, a
 
 	// Generate a real JWT for the auth middleware
 	claims := jwt.MapClaims{
-		"user":       a.User,
-		"repository": a.Repository,
-		"writeOnce":  a.WriteOnce,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               a.User,
+		"repository":         a.Repository,
+		"writeOnce":          a.WriteOnce,
+		"storageCredentials": sealedFor(t, a.Repository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	}
 	// Omitted rather than empty when unset, so the default path under test is
 	// the shape of a token minted before multi-cluster routing existed.
@@ -356,7 +372,7 @@ func TestUploadBodySurvivesTrafficAccounting(t *testing.T) {
 		},
 	}
 
-	srv := NewServer(store, testPublicKey, m)
+	srv := NewServer(store, testPublicKey, testSealKeys, m)
 	srv.ResolveClient = func(*http.Request) geoip.Client {
 		return geoip.Client{IP: "203.0.113.7", ASN: "AS64496", Org: "Example Transit"}
 	}

--- a/packages/michael/internal/metrics/metrics.go
+++ b/packages/michael/internal/metrics/metrics.go
@@ -62,6 +62,12 @@ type Metrics struct {
 	TrafficUploadedBytes   otelmetric.Int64Counter
 	TrafficDownloadedBytes otelmetric.Int64Counter
 	TrafficRequests        otelmetric.Int64Counter
+
+	// Per-credential S3 client cache. A collapsing hit rate means clients are
+	// being rebuilt per request, which costs the SDK's per-client state (never
+	// the connection pool, which every client shares).
+	CredentialCacheHits   otelmetric.Int64Counter
+	CredentialCacheMisses otelmetric.Int64Counter
 }
 
 // durationBuckets replaces the SDK default histogram boundaries, which are
@@ -181,6 +187,18 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating traffic_requests counter: %w", err)
 	}
 
+	credentialCacheHits, err := meter.Int64Counter("storage.credentials.cache.hits",
+		otelmetric.WithDescription("Storage requests served by an already-built per-credential S3 client"))
+	if err != nil {
+		return nil, fmt.Errorf("creating credential_cache_hits counter: %w", err)
+	}
+
+	credentialCacheMisses, err := meter.Int64Counter("storage.credentials.cache.misses",
+		otelmetric.WithDescription("Storage requests that had to build an S3 client for their credentials"))
+	if err != nil {
+		return nil, fmt.Errorf("creating credential_cache_misses counter: %w", err)
+	}
+
 	client, err := newClientMetrics(meter)
 	if err != nil {
 		return nil, err
@@ -204,6 +222,9 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		TrafficUploadedBytes:   trafficUploadedBytes,
 		TrafficDownloadedBytes: trafficDownloadedBytes,
 		TrafficRequests:        trafficRequests,
+
+		CredentialCacheHits:   credentialCacheHits,
+		CredentialCacheMisses: credentialCacheMisses,
 	}, nil
 }
 

--- a/packages/michael/internal/storage/clientcache.go
+++ b/packages/michael/internal/storage/clientcache.go
@@ -1,0 +1,64 @@
+package storage
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// Sized to span the repositories backing up concurrently: restic holds one
+// credential for a whole session, and an entry is only an options struct.
+const clientCacheSize = 1024
+
+// clientCache is a bounded LRU of S3 clients keyed by credential fingerprint.
+// Every client wraps the same *http.Client, so the connection pool is shared
+// and an eviction costs nothing but the SDK's per-client state.
+type clientCache struct {
+	mu      sync.Mutex
+	max     int
+	order   *list.List
+	entries map[[32]byte]*list.Element
+}
+
+type clientEntry struct {
+	key    [32]byte
+	client *s3.Client
+}
+
+func newClientCache(max int) *clientCache {
+	return &clientCache{
+		max:     max,
+		order:   list.New(),
+		entries: make(map[[32]byte]*list.Element, max),
+	}
+}
+
+func (c *clientCache) get(key [32]byte) (*s3.Client, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	el, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	c.order.MoveToFront(el)
+	return el.Value.(*clientEntry).client, true
+}
+
+func (c *clientCache) put(key [32]byte, client *s3.Client) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if el, ok := c.entries[key]; ok {
+		el.Value.(*clientEntry).client = client
+		c.order.MoveToFront(el)
+		return
+	}
+	c.entries[key] = c.order.PushFront(&clientEntry{key: key, client: client})
+	if c.order.Len() > c.max {
+		el := c.order.Back()
+		c.order.Remove(el)
+		delete(c.entries, el.Value.(*clientEntry).key)
+	}
+}

--- a/packages/michael/internal/storage/s3.go
+++ b/packages/michael/internal/storage/s3.go
@@ -15,10 +15,11 @@ import (
 	"github.com/rs/zerolog"
 
 	"michael/internal/config"
+	"michael/internal/credentials"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/aws/aws-sdk-go-v2/credentials"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
@@ -51,8 +52,17 @@ type Storage interface {
 	DeleteObject(ctx context.Context, bucket, key string) error
 }
 
+// ErrNoCredentials is fatal to the request by design: there is no fallback
+// credential to serve it with.
+var ErrNoCredentials = errors.New("no storage credentials on request")
+
+// S3Storage owns one endpoint's HTTP transport, and caches an SDK client per
+// credential pair on top of it.
 type S3Storage struct {
-	client *s3.Client
+	base        s3.Options
+	clients     *clientCache
+	probeClient *s3.Client
+	onLookup    func(hit bool)
 }
 
 func NewS3Storage(cfg config.Config) *S3Storage {
@@ -75,12 +85,13 @@ type S3Options struct {
 	TLSSkipVerify bool
 	// Wrap, when set, wraps the backend's transport (e.g. with per-backend
 	// client metrics).
-	Wrap func(http.RoundTripper) http.RoundTripper
+	Wrap               func(http.RoundTripper) http.RoundTripper
+	OnCredentialLookup func(hit bool)
 }
 
 // NewS3StorageForEndpoint builds an S3Storage bound to a specific endpoint,
-// reusing the credentials/region/path-style from cfg. The load-balancing pool
-// uses this to stamp out one client per backend gateway.
+// reusing the region/path-style from cfg. The load-balancing pool uses this to
+// stamp out one backend per gateway.
 func NewS3StorageForEndpoint(cfg config.Config, endpoint string) *S3Storage {
 	return NewS3StorageWithOptions(cfg, S3Options{
 		Endpoint:      endpoint,
@@ -90,27 +101,59 @@ func NewS3StorageForEndpoint(cfg config.Config, endpoint string) *S3Storage {
 
 // NewS3StorageWithOptions builds an S3Storage for the default storage cluster
 // with explicit per-backend options (host-pinned dialing and/or TLS
-// skip-verify) layered on the cfg credentials.
+// skip-verify).
 func NewS3StorageWithOptions(cfg config.Config, opts S3Options) *S3Storage {
 	return NewS3StorageForCluster(cfg.DefaultCluster(), opts)
 }
 
 // NewS3StorageForCluster builds an S3Storage against one storage cluster's
-// credentials, region, and path-style. Each cluster michael fronts has its own
-// object-user, so credentials cannot be shared across clusters.
+// region and path-style. Credentials are not part of it: they come from the
+// token on each request.
 func NewS3StorageForCluster(cc config.ClusterConfig, opts S3Options) *S3Storage {
-	s3opts := s3.Options{
-		Region: cc.S3Region,
-		Credentials: credentials.NewStaticCredentialsProvider(
-			cc.S3AccessKeyID,
-			cc.S3SecretAccessKey,
-			"",
-		),
+	base := s3.Options{
+		Region:       cc.S3Region,
 		BaseEndpoint: aws.String(opts.Endpoint),
 		UsePathStyle: cc.S3ForcePathStyle,
+		HTTPClient:   buildHTTPClient(opts),
 	}
-	s3opts.HTTPClient = buildHTTPClient(opts)
-	return &S3Storage{client: s3.New(s3opts)}
+
+	probeOptions := base
+	probeOptions.Credentials = aws.AnonymousCredentials{}
+
+	return &S3Storage{
+		base:        base,
+		clients:     newClientCache(clientCacheSize),
+		probeClient: s3.New(probeOptions),
+		onLookup:    opts.OnCredentialLookup,
+	}
+}
+
+// All clients share the backend's transport, so a new credential costs an
+// options struct, not a connection pool.
+func (s *S3Storage) client(ctx context.Context) (*s3.Client, error) {
+	creds, ok := credentials.FromContext(ctx)
+	if !ok {
+		return nil, ErrNoCredentials
+	}
+
+	key := creds.Fingerprint()
+	if client, ok := s.clients.get(key); ok {
+		s.lookup(true)
+		return client, nil
+	}
+	s.lookup(false)
+
+	options := s.base
+	options.Credentials = awscreds.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, "")
+	client := s3.New(options)
+	s.clients.put(key, client)
+	return client, nil
+}
+
+func (s *S3Storage) lookup(hit bool) {
+	if s.onLookup != nil {
+		s.onLookup(hit)
+	}
 }
 
 // buildHTTPClient builds the HTTP client for one backend. Always custom (never
@@ -163,7 +206,7 @@ func buildHTTPClient(opts S3Options) *http.Client {
 func (s *S3Storage) Probe(ctx context.Context, bucket string) error {
 	// Single-shot: a probe must not be silently retried by the SDK, or a dead
 	// gateway would look slow-but-alive and add latency to every reconcile.
-	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+	_, err := s.probeClient.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}, func(o *s3.Options) {
 		o.RetryMaxAttempts = 1
@@ -175,7 +218,11 @@ func (s *S3Storage) Probe(ctx context.Context, bucket string) error {
 }
 
 func (s *S3Storage) CheckBucket(ctx context.Context, bucket string) (bool, error) {
-	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return false, err
+	}
+	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	})
 	if err != nil {
@@ -194,7 +241,11 @@ func (s *S3Storage) CheckBucket(ctx context.Context, bucket string) (bool, error
 }
 
 func (s *S3Storage) CreateBucket(ctx context.Context, bucket string) error {
-	_, err := s.client.CreateBucket(ctx, &s3.CreateBucketInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
 	if err != nil {
@@ -204,7 +255,11 @@ func (s *S3Storage) CreateBucket(ctx context.Context, bucket string) error {
 }
 
 func (s *S3Storage) HeadObject(ctx context.Context, bucket, key string) (int64, error) {
-	out, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return 0, err
+	}
+	out, err := client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
@@ -218,6 +273,11 @@ func (s *S3Storage) HeadObject(ctx context.Context, bucket, key string) (int64, 
 }
 
 func (s *S3Storage) GetObject(ctx context.Context, bucket, key, rangeHeader string) (*S3Object, error) {
+	client, err := s.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -226,7 +286,7 @@ func (s *S3Storage) GetObject(ctx context.Context, bucket, key, rangeHeader stri
 		input.Range = aws.String(rangeHeader)
 	}
 
-	out, err := s.client.GetObject(ctx, input)
+	out, err := client.GetObject(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +310,11 @@ func (s *S3Storage) GetObject(ctx context.Context, bucket, key, rangeHeader stri
 }
 
 func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.Reader, contentLength int64, writeOnce bool, sha256Hex string) error {
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+
 	var uploadBody io.Reader = body
 	var hasher *sha256Writer
 
@@ -277,7 +342,7 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 	// large fraction of PUTs. With retries off, a transient gateway error
 	// surfaces cleanly and restic retries the pack itself (its body IS
 	// seekable). See TestPutObject_NonSeekableBodyOn503_NoRewindRetry.
-	_, err := s.client.PutObject(ctx, input, s3.WithAPIOptions(
+	_, err = client.PutObject(ctx, input, s3.WithAPIOptions(
 		v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
 	), func(o *s3.Options) {
 		o.RetryMaxAttempts = 1
@@ -319,7 +384,12 @@ func (w *sha256Writer) Write(p []byte) (n int, err error) {
 // page (1000 keys each). Names are full object keys; callers strip what they
 // need. An fn error aborts the walk.
 func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error {
-	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+
+	paginator := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
 		Prefix: aws.String(prefix),
 	})
@@ -341,7 +411,11 @@ func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string, fn f
 }
 
 func (s *S3Storage) DeleteObject(ctx context.Context, bucket, key string) error {
-	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})

--- a/packages/michael/internal/storage/s3_test.go
+++ b/packages/michael/internal/storage/s3_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"michael/internal/config"
+	"michael/internal/credentials"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
@@ -128,7 +129,7 @@ func TestListObjects_PaginatesAllPages(t *testing.T) {
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
 	var blobs []BlobInfo
-	err := s.ListObjects(context.Background(), "bucket", "data/", func(b BlobInfo) error {
+	err := s.ListObjects(testCtx(), "bucket", "data/", func(b BlobInfo) error {
 		blobs = append(blobs, b)
 		return nil
 	})
@@ -165,7 +166,7 @@ func TestListObjects_EmptyListing(t *testing.T) {
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
 	calls := 0
-	err := s.ListObjects(context.Background(), "bucket", "data/", func(BlobInfo) error {
+	err := s.ListObjects(testCtx(), "bucket", "data/", func(BlobInfo) error {
 		calls++
 		return nil
 	})
@@ -204,7 +205,7 @@ func TestPutObject_NonSeekableBodyOn503_NoRewindRetry(t *testing.T) {
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
 	body := readOnly{strings.NewReader("restic-pack-bytes")}
-	err := s.PutObject(context.Background(), "bucket", "data/deadbeef", body, int64(len("restic-pack-bytes")), true, "")
+	err := s.PutObject(testCtx(), "bucket", "data/deadbeef", body, int64(len("restic-pack-bytes")), true, "")
 
 	if err == nil {
 		t.Fatal("expected an error from the 503 gateway, got nil")
@@ -220,12 +221,18 @@ func TestPutObject_NonSeekableBodyOn503_NoRewindRetry(t *testing.T) {
 	}
 }
 
+// Only Probe works without credentials.
+func testCtx() context.Context {
+	return credentials.NewContext(context.Background(), credentials.Credentials{
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+	})
+}
+
 func probeConfig() config.Config {
 	return config.Config{
-		S3AccessKeyID:     "test",
-		S3SecretAccessKey: "test",
-		S3Region:          "us-east-1",
-		S3ForcePathStyle:  true,
+		S3Region:         "us-east-1",
+		S3ForcePathStyle: true,
 	}
 }
 
@@ -237,7 +244,7 @@ func TestProbe_HealthyOn404(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Errorf("Probe against 404 gateway: expected healthy, got %v", err)
 	}
 }
@@ -249,7 +256,7 @@ func TestProbe_HealthyOn200(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Errorf("Probe against 200 gateway: expected healthy, got %v", err)
 	}
 }
@@ -261,7 +268,7 @@ func TestProbe_UnhealthyOn503(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	if err := s.Probe(context.Background(), "probe-bucket"); err == nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err == nil {
 		t.Error("Probe against 503 gateway: expected unhealthy, got nil")
 	}
 }
@@ -273,7 +280,7 @@ func TestProbe_UnhealthyOnConnRefused(t *testing.T) {
 	srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), url)
-	if err := s.Probe(context.Background(), "probe-bucket"); err == nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err == nil {
 		t.Error("Probe against down gateway: expected unhealthy, got nil")
 	}
 }
@@ -297,7 +304,7 @@ func TestNewS3StorageWithOptions_PinsDialAndPreservesHost(t *testing.T) {
 		Endpoint: "http://s3.signing-host.invalid",
 		DialAddr: dialAddr,
 	})
-	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Fatalf("Probe through pinned dial: %v", err)
 	}
 	if !hit {
@@ -321,7 +328,7 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 		Endpoint: "https://s3.signing-host.invalid",
 		DialAddr: dialAddr,
 	})
-	if err := noSkip.Probe(context.Background(), "probe-bucket"); err == nil {
+	if err := noSkip.Probe(testCtx(), "probe-bucket"); err == nil {
 		t.Error("expected TLS verification failure without skip-verify")
 	}
 
@@ -331,7 +338,7 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 		DialAddr:      dialAddr,
 		TLSSkipVerify: true,
 	})
-	if err := skip.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := skip.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Errorf("Probe with skip-verify against self-signed gateway: %v", err)
 	}
 }
@@ -350,3 +357,71 @@ type httpError struct {
 
 func (e *httpError) Error() string       { return "http error" }
 func (e *httpError) HTTPStatusCode() int { return e.statusCode }
+
+// The connection pool belongs to the transport, so it is shared regardless.
+func TestClientCachedPerCredential(t *testing.T) {
+	var hits, misses int
+	s := NewS3StorageForCluster(config.ClusterConfig{S3Region: "us-east-1", S3Endpoint: "http://s3.invalid"}, S3Options{
+		Endpoint: "http://s3.invalid",
+		OnCredentialLookup: func(hit bool) {
+			if hit {
+				hits++
+				return
+			}
+			misses++
+		},
+	})
+
+	repoA := credentials.NewContext(context.Background(), credentials.Credentials{AccessKeyID: "a", SecretAccessKey: "a"})
+	repoB := credentials.NewContext(context.Background(), credentials.Credentials{AccessKeyID: "b", SecretAccessKey: "b"})
+
+	first, err := s.client(repoA)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	again, err := s.client(repoA)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	other, err := s.client(repoB)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	if first != again {
+		t.Error("expected the same client for the same credentials")
+	}
+	if first == other {
+		t.Error("expected a distinct client for different credentials")
+	}
+	if misses != 2 || hits != 1 {
+		t.Errorf("expected 2 misses and 1 hit, got %d/%d", misses, hits)
+	}
+}
+
+func TestStorageRejectsRequestWithoutCredentials(t *testing.T) {
+	s := NewS3StorageForEndpoint(probeConfig(), "http://s3.invalid")
+
+	if _, err := s.CheckBucket(context.Background(), "bucket"); !errors.Is(err, ErrNoCredentials) {
+		t.Fatalf("expected ErrNoCredentials, got %v", err)
+	}
+}
+
+// Any HTTP response at all proves the gateway is serving, so an unsigned probe
+// is enough.
+func TestProbeSendsNoAuthorizationHeader(t *testing.T) {
+	var authorization string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
+	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+		t.Errorf("Probe against a 403 gateway: expected healthy, got %v", err)
+	}
+	if authorization != "" {
+		t.Errorf("expected an unsigned probe, got Authorization %q", authorization)
+	}
+}

--- a/packages/michael/main.go
+++ b/packages/michael/main.go
@@ -86,7 +86,7 @@ func main() {
 		log.Info().Str("endpoint", cfg.OTLPMetricsEndpoint).Msg("OpenTelemetry metrics enabled")
 	}
 
-	stores, pools := buildClusters(cfg, tm)
+	stores, pools := buildClusters(cfg, tm, credentialLookup(m))
 
 	if len(pools) > 0 && meterProvider != nil {
 		providers := make(map[string]metrics.BackendStatsProvider, len(pools))
@@ -109,7 +109,7 @@ func main() {
 		log.Info().Str("path", cfg.ASNDatabasePath).Msg("ASN database loaded")
 	}
 
-	srv := handlers.NewClusterServer(stores, cfg.S3DefaultCluster, cfg.JWTPublicKey, m)
+	srv := handlers.NewClusterServer(stores, cfg.S3DefaultCluster, cfg.JWTPublicKey, cfg.StorageSealKeys, m)
 	srv.ResolveClient = func(r *http.Request) geoip.Client {
 		return asnDB.Resolve(r, cfg.ClientIPHeader)
 	}
@@ -169,11 +169,15 @@ func main() {
 // concretely so the caller can register their metrics and run their reconcile
 // loops). A single-cluster deployment yields exactly one entry, under
 // cfg.S3DefaultCluster.
-func buildClusters(cfg config.Config, tm *metrics.TransportMetrics) (map[string]storage.Storage, map[string]*storage.Pool) {
+func buildClusters(
+	cfg config.Config,
+	tm *metrics.TransportMetrics,
+	onCredentialLookup func(hit bool),
+) (map[string]storage.Storage, map[string]*storage.Pool) {
 	stores := make(map[string]storage.Storage, len(cfg.Clusters))
 	pools := make(map[string]*storage.Pool)
 	for _, cc := range cfg.Clusters {
-		store, pool := buildStorage(cc, tm)
+		store, pool := buildStorage(cc, tm, onCredentialLookup)
 		stores[cc.Code] = store
 		if pool != nil {
 			pools[cc.Code] = pool
@@ -187,17 +191,22 @@ func buildClusters(cfg config.Config, tm *metrics.TransportMetrics) (map[string]
 // configured it is a single S3 client (legacy behavior) and pool is nil. With
 // source=file or source=dns it is a load-balancing Pool, also returned
 // concretely so the caller can register its metrics and run its reconcile loop.
-func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storage.Storage, *storage.Pool) {
+func buildStorage(
+	cc config.ClusterConfig,
+	tm *metrics.TransportMetrics,
+	onCredentialLookup func(hit bool),
+) (storage.Storage, *storage.Pool) {
 	if cc.S3BackendSource == "" {
 		return storage.NewS3StorageForCluster(cc, storage.S3Options{
-			Endpoint:      cc.S3Endpoint,
-			TLSSkipVerify: cc.S3TLSSkipVerify,
-			Wrap:          transportWrap(tm, cc.Code, cc.S3Endpoint),
+			Endpoint:           cc.S3Endpoint,
+			TLSSkipVerify:      cc.S3TLSSkipVerify,
+			Wrap:               transportWrap(tm, cc.Code, cc.S3Endpoint),
+			OnCredentialLookup: onCredentialLookup,
 		}), nil
 	}
 
 	resolver := buildResolver(cc)
-	factory := backendFactory(cc, tm)
+	factory := backendFactory(cc, tm, onCredentialLookup)
 	pool, err := storage.NewPool(storage.PoolConfig{
 		EjectThreshold:    cc.S3EjectThreshold,
 		ProbeBucket:       cc.S3ProbeBucket,
@@ -215,13 +224,18 @@ func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storag
 // directly while still signing/Host-ing with the cluster endpoint (replacing the
 // HAProxy hop); otherwise the resolved endpoint is used as the S3 endpoint
 // as-is.
-func backendFactory(cc config.ClusterConfig, tm *metrics.TransportMetrics) storage.BackendFactory {
+func backendFactory(
+	cc config.ClusterConfig,
+	tm *metrics.TransportMetrics,
+	onCredentialLookup func(hit bool),
+) storage.BackendFactory {
 	if !cc.S3BackendPinHost {
 		return func(endpoint string) (storage.Storage, error) {
 			return storage.NewS3StorageForCluster(cc, storage.S3Options{
-				Endpoint:      endpoint,
-				TLSSkipVerify: cc.S3TLSSkipVerify,
-				Wrap:          transportWrap(tm, cc.Code, endpoint),
+				Endpoint:           endpoint,
+				TLSSkipVerify:      cc.S3TLSSkipVerify,
+				Wrap:               transportWrap(tm, cc.Code, endpoint),
+				OnCredentialLookup: onCredentialLookup,
 			}), nil
 		}
 	}
@@ -239,11 +253,27 @@ func backendFactory(cc config.ClusterConfig, tm *metrics.TransportMetrics) stora
 			dial = net.JoinHostPort(u.Hostname(), port)
 		}
 		return storage.NewS3StorageForCluster(cc, storage.S3Options{
-			Endpoint:      cc.S3Endpoint,
-			DialAddr:      dial,
-			TLSSkipVerify: cc.S3TLSSkipVerify,
-			Wrap:          transportWrap(tm, cc.Code, dial),
+			Endpoint:           cc.S3Endpoint,
+			DialAddr:           dial,
+			TLSSkipVerify:      cc.S3TLSSkipVerify,
+			Wrap:               transportWrap(tm, cc.Code, dial),
+			OnCredentialLookup: onCredentialLookup,
 		}), nil
+	}
+}
+
+// credentialLookup returns the per-credential client cache hook, or nil when
+// metrics are disabled.
+func credentialLookup(m *metrics.Metrics) func(hit bool) {
+	if m == nil {
+		return nil
+	}
+	return func(hit bool) {
+		if hit {
+			m.CredentialCacheHits.Add(context.Background(), 1)
+			return
+		}
+		m.CredentialCacheMisses.Add(context.Background(), 1)
 	}
 }
 

--- a/packages/yucca-admin-api/openapi-specs.json
+++ b/packages/yucca-admin-api/openapi-specs.json
@@ -685,6 +685,46 @@
         ]
       }
     },
+    "/api/repository/{id}/storage-credentials": {
+      "post": {
+        "operationId": "repositoryStorageCredentials",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepositoryStorageCredentialsRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryStorageCredentialsResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Repository"
+        ]
+      }
+    },
     "/api/allowlist": {
       "get": {
         "operationId": "listAllowlist",
@@ -835,6 +875,88 @@
         },
         "tags": [
           "Allowlist"
+        ]
+      }
+    },
+    "/api/settings": {
+      "get": {
+        "operationId": "listSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SettingsListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Settings"
+        ]
+      }
+    },
+    "/api/settings/{scope}": {
+      "put": {
+        "operationId": "setSettings",
+        "parameters": [
+          {
+            "name": "scope",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SettingsValueDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SettingsEntryResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Settings"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteSettings",
+        "parameters": [
+          {
+            "name": "scope",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -1268,6 +1390,14 @@
           "worm": {
             "type": "boolean"
           },
+          "siteCode": {
+            "type": "string",
+            "description": "Stable internal site code"
+          },
+          "storageClusterCode": {
+            "type": "string",
+            "description": "Stable, globally unique internal storage cluster code"
+          },
           "connectionId": {
             "type": "string"
           },
@@ -1285,6 +1415,8 @@
           "id",
           "name",
           "worm",
+          "siteCode",
+          "storageClusterCode",
           "connectionId",
           "connectionType",
           "user",
@@ -1321,6 +1453,10 @@
           },
           "worm": {
             "type": "boolean"
+          },
+          "site": {
+            "type": "string",
+            "description": "Internal site code to place the repository in; defaults to the topology default site"
           },
           "connectionType": {
             "type": "string",
@@ -1366,6 +1502,35 @@
         },
         "required": [
           "url"
+        ]
+      },
+      "RepositoryStorageCredentialsRequestDto": {
+        "type": "object",
+        "properties": {
+          "rotate": {
+            "type": "boolean",
+            "description": "Issue a fresh key pair, invalidating the credentials already minted"
+          }
+        }
+      },
+      "RepositoryStorageCredentialsResponseDto": {
+        "type": "object",
+        "properties": {
+          "storageUserId": {
+            "type": "string",
+            "description": "RGW user that owns the repository bucket"
+          },
+          "storageClusterCode": {
+            "type": "string"
+          },
+          "accessKeyId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "storageUserId",
+          "storageClusterCode",
+          "accessKeyId"
         ]
       },
       "RepositoryUpdateRequestDto": {
@@ -1506,6 +1671,63 @@
         },
         "required": [
           "count"
+        ]
+      },
+      "SettingsValueDto": {
+        "type": "object",
+        "properties": {
+          "restic_pack_size_mib": {
+            "type": "number"
+          },
+          "connections_math": {
+            "type": "string",
+            "description": "Client-evaluated expression: integers, cores, min, max, + - * /"
+          }
+        }
+      },
+      "SettingsEntryDto": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string",
+            "description": "'global', 'site:<code>' or 'cluster:<code>'"
+          },
+          "value": {
+            "$ref": "#/components/schemas/SettingsValueDto"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope",
+          "value",
+          "updatedAt"
+        ]
+      },
+      "SettingsListResponseDto": {
+        "type": "object",
+        "properties": {
+          "settings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SettingsEntryDto"
+            }
+          }
+        },
+        "required": [
+          "settings"
+        ]
+      },
+      "SettingsEntryResponseDto": {
+        "type": "object",
+        "properties": {
+          "entry": {
+            "$ref": "#/components/schemas/SettingsEntryDto"
+          }
+        },
+        "required": [
+          "entry"
         ]
       },
       "FeatureFlagDefDto": {

--- a/packages/yucca-admin-api/package.json
+++ b/packages/yucca-admin-api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "catalog:",
     "@nestjs/swagger": "catalog:",
     "@opentelemetry/api": "catalog:",
+    "aws4fetch": "catalog:",
     "class-validator": "catalog:",
     "cookie": "catalog:",
     "event-iterator": "catalog:",

--- a/packages/yucca-admin-api/src/app.module.ts
+++ b/packages/yucca-admin-api/src/app.module.ts
@@ -18,6 +18,7 @@ import { DatabaseRepository } from './repositories/database.repository';
 import { FeatureFlagRepository } from './repositories/featureFlag.repository';
 import { OidcRepository } from './repositories/oidc.repository';
 import { RepositoryRepository } from './repositories/repository.repository';
+import { RgwAdminRepository } from './repositories/rgwAdmin.repository';
 import { SessionRepository } from './repositories/session.repository';
 import { SettingsRepository } from './repositories/settings.repository';
 import { StorageRepository } from './repositories/storage.repository';
@@ -31,6 +32,7 @@ import { FeaturesService } from './services/features.service';
 import { RepositoryService } from './services/repository.service';
 import { SessionService } from './services/session.service';
 import { SettingsService } from './services/settings.service';
+import { StorageCredentialService } from './services/storageCredential.service';
 import { TopologyService } from './services/topology.service';
 import { UserService } from './services/user.service';
 import { getKyselyConfig } from './utils/database';
@@ -68,6 +70,7 @@ export const providers = [
   UserAllowlistRepository,
   SessionRepository,
   RepositoryRepository,
+  RgwAdminRepository,
   SettingsRepository,
   StorageRepository,
   TopologyRepository,
@@ -80,6 +83,7 @@ export const providers = [
   SettingsService,
   TopologyService,
   RepositoryService,
+  StorageCredentialService,
   FeaturesService,
   { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },
   { provide: APP_GUARD, useClass: AuthGuard },

--- a/packages/yucca-admin-api/src/controllers/repository.controller.ts
+++ b/packages/yucca-admin-api/src/controllers/repository.controller.ts
@@ -6,6 +6,8 @@ import {
   RepositoryGetResponseDto,
   RepositoryListQueryDto,
   RepositoryListResponseDto,
+  RepositoryStorageCredentialsRequestDto,
+  RepositoryStorageCredentialsResponseDto,
   RepositoryUpdateRequestDto,
   RepositoryUpdateResponseDto,
   RepositoryUrlResponseDto,
@@ -43,6 +45,16 @@ export class RepositoryController {
   @ApiOkResponse({ type: RepositoryUrlResponseDto })
   repositoryUrl(@Param('id') id: string): Promise<RepositoryUrlResponseDto> {
     return this.repository.url(id);
+  }
+
+  @Post('/:id/storage-credentials')
+  @AuthRoute()
+  @ApiOkResponse({ type: RepositoryStorageCredentialsResponseDto })
+  repositoryStorageCredentials(
+    @Param('id') id: string,
+    @Body() dto: RepositoryStorageCredentialsRequestDto,
+  ): Promise<RepositoryStorageCredentialsResponseDto> {
+    return this.repository.provisionStorageCredentials(id, dto);
   }
 
   @Patch('/:id')

--- a/packages/yucca-admin-api/src/dto/repository.dto.ts
+++ b/packages/yucca-admin-api/src/dto/repository.dto.ts
@@ -142,3 +142,21 @@ export class RepositoryUpdateResponseDto {
   @ApiProperty()
   repository!: RepositoryAdminDto;
 }
+
+export class RepositoryStorageCredentialsRequestDto {
+  @ApiProperty({ required: false, description: 'Issue a fresh key pair, invalidating the credentials already minted' })
+  @IsOptional()
+  @IsBoolean()
+  rotate?: boolean;
+}
+
+export class RepositoryStorageCredentialsResponseDto {
+  @ApiProperty({ description: 'RGW user that owns the repository bucket' })
+  storageUserId!: string;
+
+  @ApiProperty()
+  storageClusterCode!: string;
+
+  @ApiProperty()
+  accessKeyId!: string;
+}

--- a/packages/yucca-admin-api/src/env.ts
+++ b/packages/yucca-admin-api/src/env.ts
@@ -1,3 +1,4 @@
+import { parseStorageCredentialKeys } from '@common/server';
 import type { StringValue } from 'ms';
 import { z } from 'zod';
 
@@ -29,6 +30,17 @@ const schema = z.object({
     .regex(/^\d+\s*(ms|s|m|h|d|w|y)$/i, 'Expected a duration like "1d", "30m", "3600s"')
     .default('1d')
     .transform((value): StringValue => value as StringValue),
+
+  // First key seals, the rest stay accepted so a rotation is a two-step deploy.
+  // Only the SEAL key is shared with michael.
+  STORAGE_CREDENTIAL_KEY: z.string().transform(parseStorageCredentialKeys),
+  STORAGE_CREDENTIAL_SEAL_KEY: z.string().transform(parseStorageCredentialKeys),
+
+  RADOS_ACCESS_KEY_ID: z.string().optional(),
+  RADOS_SECRET_ACCESS_KEY: z.string().optional(),
+
+  STORAGE_STATIC_ACCESS_KEY_ID: z.string().optional(),
+  STORAGE_STATIC_SECRET_ACCESS_KEY: z.string().optional(),
 
   TOPOLOGY_FILE: z.string().default('./topology.dev.json'),
   LEGACY_SITE_CODE: z.string(),

--- a/packages/yucca-admin-api/src/repositories/repository.repository.ts
+++ b/packages/yucca-admin-api/src/repositories/repository.repository.ts
@@ -84,6 +84,21 @@ export class RepositoryRepository {
     return this.get(id);
   }
 
+  getStorageOwner(id: string) {
+    return this.db
+      .selectFrom('repositories')
+      .select(['id', 'storageClusterCode', 'storageAccessKeyId', 'storageSecretAccessKey'])
+      .where('id', '=', id)
+      .executeTakeFirstOrThrow();
+  }
+
+  async setStorageCredentials(
+    id: string,
+    credentials: Pick<RepositoryTable, 'storageAccessKeyId' | 'storageSecretAccessKey'>,
+  ) {
+    await this.db.updateTable('repositories').where('id', '=', id).set(credentials).execute();
+  }
+
   async delete(id: string) {
     await this.db.deleteFrom('repositories').where('id', '=', id).execute();
   }

--- a/packages/yucca-admin-api/src/repositories/rgwAdmin.repository.ts
+++ b/packages/yucca-admin-api/src/repositories/rgwAdmin.repository.ts
@@ -1,0 +1,1 @@
+../../../yucca-api/src/repositories/rgwAdmin.repository.ts

--- a/packages/yucca-admin-api/src/services/repository.service.spec.ts
+++ b/packages/yucca-admin-api/src/services/repository.service.spec.ts
@@ -35,11 +35,25 @@ describe(RepositoryService.name, () => {
   let users: { [k: string]: jest.Mock };
   let topology: { [k: string]: jest.Mock };
   let connections: { [k: string]: jest.Mock };
+  let storageCredentials: { [k: string]: jest.Mock };
   let jwt: JwtService;
   let sut: RepositoryService;
 
   beforeEach(() => {
-    repositories = { list: jest.fn(), get: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+    repositories = {
+      list: jest.fn(),
+      get: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      getStorageOwner: jest.fn().mockResolvedValue({
+        id: repositoryRow.id,
+        storageClusterCode: repositoryRow.storageClusterCode,
+        storageAccessKeyId: 'access',
+        storageSecretAccessKey: 'sealed-at-rest',
+      }),
+      setStorageCredentials: jest.fn(),
+    };
     users = { getBySub: jest.fn(), create: jest.fn() };
     topology = {
       getSite: jest.fn().mockReturnValue(site),
@@ -48,8 +62,21 @@ describe(RepositoryService.name, () => {
       hasCluster: jest.fn(),
     };
     connections = { getByUser: jest.fn(), getOrCreateByType: jest.fn().mockResolvedValue({ id: 'connection-id' }) };
+    storageCredentials = {
+      ensure: jest.fn().mockResolvedValue({ accessKeyId: 'access', secretAccessKey: 'secret' }),
+      rotate: jest.fn(),
+      revoke: jest.fn(),
+      seal: jest.fn().mockReturnValue('sealed'),
+    };
     jwt = newJwtService();
-    sut = new RepositoryService(repositories as never, users as never, connections as never, jwt, topology as never);
+    sut = new RepositoryService(
+      repositories as never,
+      users as never,
+      connections as never,
+      jwt,
+      topology as never,
+      storageCredentials as never,
+    );
   });
 
   describe('create', () => {

--- a/packages/yucca-admin-api/src/services/repository.service.ts
+++ b/packages/yucca-admin-api/src/services/repository.service.ts
@@ -6,6 +6,8 @@ import {
   RepositoryGetResponseDto,
   RepositoryListQueryDto,
   RepositoryListResponseDto,
+  RepositoryStorageCredentialsRequestDto,
+  RepositoryStorageCredentialsResponseDto,
   RepositoryUpdateRequestDto,
   RepositoryUpdateResponseDto,
   RepositoryUrlResponseDto,
@@ -15,6 +17,7 @@ import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { TopologyRepository } from 'src/repositories/topology.repository';
 import { UserRepository } from 'src/repositories/user.repository';
+import { StorageCredentialService, storageUserId } from 'src/services/storageCredential.service';
 import { resolveLimit } from 'src/utils/pagination';
 
 const serviceUser = {
@@ -31,6 +34,7 @@ export class RepositoryService {
     private readonly connections: ConnectionRepository,
     private readonly jwt: JwtService,
     private readonly topology: TopologyRepository,
+    private readonly storageCredentials: StorageCredentialService,
   ) {}
 
   list(query: RepositoryListQueryDto): Promise<RepositoryListResponseDto> {
@@ -69,6 +73,12 @@ export class RepositoryService {
       siteCode: site.code,
       storageClusterCode: cluster.code,
     });
+    await this.storageCredentials.ensure({
+      id: repository.id,
+      storageClusterCode: repository.storageClusterCode,
+      storageAccessKeyId: null,
+      storageSecretAccessKey: null,
+    });
     return { repository };
   }
 
@@ -78,6 +88,7 @@ export class RepositoryService {
     }
     const repository = await this.repositories.get(id);
     const site = this.topology.getSite(repository.siteCode);
+    const credentials = await this.storageCredentials.ensure(await this.repositories.getStorageOwner(id));
     const token = await this.jwt.signAsync(
       {
         user: repository.user.id,
@@ -85,6 +96,7 @@ export class RepositoryService {
         writeOnce: repository.worm,
         storageCluster: repository.storageClusterCode,
         connection: repository.connectionType,
+        storageCredentials: this.storageCredentials.seal(repository.id, credentials),
       },
       { privateKey: env.RESTIC_JWT_PRIVATE_KEY, algorithm: 'ES256', expiresIn: env.RESTIC_JWT_EXPIRES_IN },
     );
@@ -95,6 +107,22 @@ export class RepositoryService {
     url.pathname = repository.id;
 
     return { url: `rest:${url.href}` };
+  }
+
+  // Drives `yuctl repos migrate-storage-credentials`.
+  async provisionStorageCredentials(
+    id: string,
+    dto: RepositoryStorageCredentialsRequestDto,
+  ): Promise<RepositoryStorageCredentialsResponseDto> {
+    const owner = await this.repositories.getStorageOwner(id);
+    const credentials = dto.rotate
+      ? await this.storageCredentials.rotate(owner)
+      : await this.storageCredentials.ensure(owner);
+    return {
+      storageUserId: storageUserId(id),
+      storageClusterCode: owner.storageClusterCode,
+      accessKeyId: credentials.accessKeyId,
+    };
   }
 
   async update(id: string, dto: RepositoryUpdateRequestDto): Promise<RepositoryUpdateResponseDto> {

--- a/packages/yucca-admin-api/src/services/storageCredential.service.ts
+++ b/packages/yucca-admin-api/src/services/storageCredential.service.ts
@@ -1,0 +1,1 @@
+../../../yucca-api/src/services/storageCredential.service.ts

--- a/packages/yucca-api/package.json
+++ b/packages/yucca-api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "catalog:",
     "@nestjs/swagger": "catalog:",
     "@opentelemetry/api": "catalog:",
+    "aws4fetch": "catalog:",
     "class-validator": "catalog:",
     "cookie": "catalog:",
     "event-iterator": "catalog:",

--- a/packages/yucca-api/src/app.module.ts
+++ b/packages/yucca-api/src/app.module.ts
@@ -17,6 +17,7 @@ import { OidcRepository } from './repositories/oidc.repository';
 import { RepositoryRepository } from './repositories/repository.repository';
 import { RepositoryMetricsRepository } from './repositories/repositoryMetrics.repository';
 import { RepositoryMetricsHistoryRepository } from './repositories/repositoryMetricsHistory.repository';
+import { RgwAdminRepository } from './repositories/rgwAdmin.repository';
 import { SessionRepository } from './repositories/session.repository';
 import { SettingsRepository } from './repositories/settings.repository';
 import { StorageRepository } from './repositories/storage.repository';
@@ -29,6 +30,7 @@ import { DatabaseService } from './services/database.service';
 import { MetaService } from './services/meta.service';
 import { MetricsService } from './services/metrics.service';
 import { RepositoryService } from './services/repository.service';
+import { StorageCredentialService } from './services/storageCredential.service';
 import { TopologyService } from './services/topology.service';
 import { getKyselyConfig } from './utils/database';
 
@@ -62,6 +64,7 @@ export const providers = [
   UserRepository,
   UserAllowlistRepository,
   RepositoryRepository,
+  RgwAdminRepository,
   RepositoryMetricsRepository,
   RepositoryMetricsHistoryRepository,
   SessionRepository,
@@ -70,6 +73,7 @@ export const providers = [
   TopologyService,
   MetricsService,
   RepositoryService,
+  StorageCredentialService,
   AuthService,
   ConnectionService,
   { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },

--- a/packages/yucca-api/src/env.ts
+++ b/packages/yucca-api/src/env.ts
@@ -1,3 +1,4 @@
+import { parseStorageCredentialKeys } from '@common/server';
 import type { StringValue } from 'ms';
 import { z } from 'zod';
 
@@ -43,6 +44,22 @@ const schema = z.object({
   OIDC_DEVICE_CLIENT_ID: z.string(),
   OIDC_DEVICE_ALLOW_INSECURE: z.coerce.boolean().default(false),
   OIDC_DEVICE_SCOPE: z.string().default('openid profile email'),
+
+  // At rest only. First key seals, the rest stay accepted so a rotation is a
+  // two-step deploy.
+  STORAGE_CREDENTIAL_KEY: z.string().transform(parseStorageCredentialKeys),
+  // Shared with michael: seals the credentials carried by a restic token.
+  STORAGE_CREDENTIAL_SEAL_KEY: z.string().transform(parseStorageCredentialKeys),
+
+  // Per-cluster overrides are read straight from the environment as
+  // RADOS_ACCESS_KEY_ID_<CLUSTER_CODE>, as in yucca-metrics-worker.
+  RADOS_ACCESS_KEY_ID: z.string().optional(),
+  RADOS_SECRET_ACCESS_KEY: z.string().optional(),
+
+  // Fallback for clusters with no rgw_admin_endpoint (MinIO has no admin API):
+  // every repository is handed these keys instead of its own.
+  STORAGE_STATIC_ACCESS_KEY_ID: z.string().optional(),
+  STORAGE_STATIC_SECRET_ACCESS_KEY: z.string().optional(),
 
   TOPOLOGY_FILE: z.string().default('./topology.dev.json'),
   API_ROOT: z.string().default('http://localhost:3020/api'),

--- a/packages/yucca-api/src/repositories/repository.repository.ts
+++ b/packages/yucca-api/src/repositories/repository.repository.ts
@@ -13,6 +13,18 @@ const metricsJson = (eb: ExpressionBuilder<DB, 'repositories' | 'repositoryMetri
     lastBackupDuration: eb.ref('repositoryMetrics.lastBackupDuration'),
   }).as('metrics');
 
+// Every read outside StorageCredentialService goes through this list: a
+// selectAll() would put the sealed secret straight into a JSON response.
+const columns = [
+  'repositories.id',
+  'repositories.userId',
+  'repositories.worm',
+  'repositories.name',
+  'repositories.siteCode',
+  'repositories.storageClusterCode',
+  'repositories.connectionId',
+] as const;
+
 const meterJson = (eb: ExpressionBuilder<DB, 'repositories' | 'repositoryMeter'>) =>
   jsonBuildObject({
     sizeBytes: eb.fn.coalesce('repositoryMeter.sizeBytes', eb.val(0)),
@@ -36,7 +48,7 @@ export class RepositoryRepository {
       .leftJoin('repositoryMetrics', 'repositoryMetrics.id', 'repositories.id')
       .leftJoin('repositoryMeter', 'repositoryMeter.repositoryId', 'repositories.id')
       .where('repositories.id', '=', id)
-      .selectAll('repositories')
+      .select(columns)
       .select('connections.type as connectionType')
       .select(metricsJson)
       .select(meterJson)
@@ -50,7 +62,7 @@ export class RepositoryRepository {
       .leftJoin('repositoryMetrics', 'repositoryMetrics.id', 'repositories.id')
       .leftJoin('repositoryMeter', 'repositoryMeter.repositoryId', 'repositories.id')
       .where('repositories.userId', '=', userId)
-      .selectAll('repositories')
+      .select(columns)
       .select('connections.type as connectionType')
       .select(metricsJson)
       .select(meterJson)
@@ -67,7 +79,22 @@ export class RepositoryRepository {
   }
 
   getByIds(ids: string[]) {
-    return this.db.selectFrom('repositories').selectAll().where('id', 'in', ids).execute();
+    return this.db.selectFrom('repositories').select(columns).where('repositories.id', 'in', ids).execute();
+  }
+
+  getStorageOwner(id: string) {
+    return this.db
+      .selectFrom('repositories')
+      .select(['id', 'storageClusterCode', 'storageAccessKeyId', 'storageSecretAccessKey'])
+      .where('id', '=', id)
+      .executeTakeFirstOrThrow();
+  }
+
+  async setStorageCredentials(
+    id: string,
+    credentials: Pick<RepositoryTable, 'storageAccessKeyId' | 'storageSecretAccessKey'>,
+  ) {
+    await this.db.updateTable('repositories').where('id', '=', id).set(credentials).execute();
   }
 
   async reparent(ids: string[], connectionId: string) {

--- a/packages/yucca-api/src/repositories/rgwAdmin.repository.ts
+++ b/packages/yucca-api/src/repositories/rgwAdmin.repository.ts
@@ -1,0 +1,163 @@
+import { Injectable } from '@nestjs/common';
+import { AwsClient } from 'aws4fetch';
+import { env } from 'src/env';
+import { TopologyStorageCluster } from 'src/repositories/topology.repository';
+
+export type StorageUserKeys = { accessKeyId: string; secretAccessKey: string };
+
+type RgwKey = { user: string; access_key: string; secret_key: string };
+type RgwUser = { user_id: string; keys?: RgwKey[] };
+type RgwResponse = { status: number; ok: boolean; body: any };
+
+// The admin credential lives here, in the control plane; michael only ever sees
+// the keys of the one repository a request is for.
+@Injectable()
+export class RgwAdminRepository {
+  private clients = new Map<string, AwsClient>();
+
+  supports(cluster: TopologyStorageCluster): boolean {
+    return Boolean(cluster.rgw_admin_endpoint);
+  }
+
+  async ensureUser(cluster: TopologyStorageCluster, uid: string, displayName: string): Promise<StorageUserKeys> {
+    // max-buckets=1: the user owns exactly the one bucket backing its
+    // repository, so a leaked key cannot stand up storage of its own.
+    const created = await this.request(cluster, 'PUT', '/admin/user', {
+      uid,
+      'display-name': displayName,
+      'max-buckets': '1',
+    });
+    if (created.ok) {
+      return this.firstKey(cluster, uid, created.body as RgwUser);
+    }
+    if (errorCode(created) !== 'UserAlreadyExists') {
+      throw rgwError('create user', uid, created);
+    }
+
+    const existing = await this.request(cluster, 'GET', '/admin/user', { uid });
+    if (!existing.ok) {
+      throw rgwError('read user', uid, existing);
+    }
+    return this.firstKey(cluster, uid, existing.body as RgwUser);
+  }
+
+  // Drops every other key, so the credentials an already-minted token carries
+  // stop working.
+  async rotateKeys(cluster: TopologyStorageCluster, uid: string): Promise<StorageUserKeys> {
+    const before = await this.request(cluster, 'GET', '/admin/user', { uid });
+    if (!before.ok) {
+      throw rgwError('read user', uid, before);
+    }
+    const stale = new Set(((before.body as RgwUser).keys ?? []).map((key) => key.access_key));
+
+    const generated = await this.request(cluster, 'PUT', '/admin/user', { key: '', uid, 'generate-key': 'True' });
+    if (!generated.ok) {
+      throw rgwError('generate key', uid, generated);
+    }
+
+    const fresh = (generated.body as RgwKey[]).find((key) => !stale.has(key.access_key));
+    if (!fresh) {
+      throw new Error(`RGW generated no new key for user '${uid}' on cluster '${cluster.code}'`);
+    }
+
+    for (const accessKey of stale) {
+      await this.removeKey(cluster, uid, accessKey);
+    }
+    return { accessKeyId: fresh.access_key, secretAccessKey: fresh.secret_key };
+  }
+
+  // The bucket is left alone: deleting a repository has never deleted its data,
+  // and it must not start here.
+  async revokeKeys(cluster: TopologyStorageCluster, uid: string): Promise<void> {
+    const user = await this.request(cluster, 'GET', '/admin/user', { uid });
+    if (!user.ok) {
+      if (errorCode(user) === 'NoSuchUser') {
+        return;
+      }
+      throw rgwError('read user', uid, user);
+    }
+
+    for (const key of (user.body as RgwUser).keys ?? []) {
+      await this.removeKey(cluster, uid, key.access_key);
+    }
+  }
+
+  private async removeKey(cluster: TopologyStorageCluster, uid: string, accessKey: string): Promise<void> {
+    const removed = await this.request(cluster, 'DELETE', '/admin/user', {
+      key: '',
+      uid,
+      'access-key': accessKey,
+    });
+    if (!removed.ok && errorCode(removed) !== 'InvalidAccessKeyId') {
+      throw rgwError('remove key', uid, removed);
+    }
+  }
+
+  private async firstKey(cluster: TopologyStorageCluster, uid: string, user: RgwUser): Promise<StorageUserKeys> {
+    const key = user.keys?.find((key) => key.user === uid) ?? user.keys?.[0];
+    if (key) {
+      return { accessKeyId: key.access_key, secretAccessKey: key.secret_key };
+    }
+    return this.rotateKeys(cluster, uid);
+  }
+
+  private async request(
+    cluster: TopologyStorageCluster,
+    method: string,
+    path: string,
+    query: Record<string, string>,
+  ): Promise<RgwResponse> {
+    const url = new URL(cluster.rgw_admin_endpoint!);
+    url.pathname = path;
+    url.search = new URLSearchParams(query).toString();
+
+    const response = await this.client(cluster).fetch(url.toString(), { method });
+    const text = await response.text();
+    let body: any = undefined;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    return { status: response.status, ok: response.ok, body };
+  }
+
+  private client(cluster: TopologyStorageCluster): AwsClient {
+    const endpoint = cluster.rgw_admin_endpoint;
+    if (!endpoint) {
+      throw new Error(`Storage cluster '${cluster.code}' has no rgw_admin_endpoint`);
+    }
+
+    const cacheKey = `${cluster.code}:${endpoint}`;
+    const cached = this.clients.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Same per-cluster override convention as yucca-metrics-worker, so one
+    // object-user Secret can be mounted with envFrom under these exact names.
+    const suffix = cluster.code.toUpperCase().replaceAll('-', '_');
+    const accessKeyId = process.env[`RADOS_ACCESS_KEY_ID_${suffix}`] ?? env.RADOS_ACCESS_KEY_ID;
+    const secretAccessKey = process.env[`RADOS_SECRET_ACCESS_KEY_${suffix}`] ?? env.RADOS_SECRET_ACCESS_KEY;
+    if (!accessKeyId || !secretAccessKey) {
+      throw new Error(
+        `No RGW admin credentials for cluster '${cluster.code}' ` +
+          `(set RADOS_ACCESS_KEY_ID_${suffix}/RADOS_SECRET_ACCESS_KEY_${suffix} or the RADOS_* fallback)`,
+      );
+    }
+
+    const client = new AwsClient({ accessKeyId, secretAccessKey, service: 's3', region: 'rgw' });
+    this.clients.set(cacheKey, client);
+    return client;
+  }
+}
+
+const errorCode = (response: RgwResponse): string | undefined =>
+  typeof response.body === 'object' && response.body !== null ? (response.body.Code as string) : undefined;
+
+const rgwError = (action: string, uid: string, response: RgwResponse): Error =>
+  new Error(
+    `RGW admin failed to ${action} '${uid}': ${response.status} ${errorCode(response) ?? JSON.stringify(response.body)}`,
+  );

--- a/packages/yucca-api/src/repositories/topology.repository.ts
+++ b/packages/yucca-api/src/repositories/topology.repository.ts
@@ -15,8 +15,10 @@ const storageClusterSchema = z
         endpoint: z.url(),
         region: z.string().min(1).default('us-east-1'),
         force_path_style: z.boolean().default(true),
-        access_key_env: envNameSchema,
-        secret_key_env: envNameSchema,
+        // Accepted but unread: michael takes its credentials from the token
+        // now, so nothing resolves these environment variable names.
+        access_key_env: envNameSchema.optional(),
+        secret_key_env: envNameSchema.optional(),
         backend_source: z.enum(['file', 'dns']).optional(),
         backend_file: z.string().min(1).optional(),
         backend_dns_host: z.string().min(1).optional(),
@@ -150,6 +152,17 @@ export class TopologyRepository {
 
   hasCluster(code: string): boolean {
     return this.get().sites.some((site) => site.clusters.some((cluster) => cluster.code === code));
+  }
+
+  getCluster(code: string): TopologyStorageCluster {
+    for (const site of this.get().sites) {
+      const cluster = site.clusters.find((cluster) => cluster.code === code);
+      if (cluster) {
+        return cluster;
+      }
+    }
+
+    throw new BadRequestException(`Unknown storage cluster '${code}'`);
   }
 
   getActiveCluster(site: TopologySite): TopologyStorageCluster {

--- a/packages/yucca-api/src/schema/migrations/20260804120000-AddRepositoryStorageCredentials.ts
+++ b/packages/yucca-api/src/schema/migrations/20260804120000-AddRepositoryStorageCredentials.ts
@@ -1,0 +1,11 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "repositories" ADD "storageAccessKeyId" text;`.execute(db);
+  await sql`ALTER TABLE "repositories" ADD "storageSecretAccessKey" text;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "repositories" DROP COLUMN "storageSecretAccessKey";`.execute(db);
+  await sql`ALTER TABLE "repositories" DROP COLUMN "storageAccessKeyId";`.execute(db);
+}

--- a/packages/yucca-api/src/schema/tables/repository.table.ts
+++ b/packages/yucca-api/src/schema/tables/repository.table.ts
@@ -24,4 +24,12 @@ export class RepositoryTable {
 
   @ForeignKeyColumn(() => ConnectionTable, { onUpdate: 'CASCADE', onDelete: 'RESTRICT', index: true })
   connectionId!: string;
+
+  @Column({ type: 'text', nullable: true })
+  storageAccessKeyId!: string | null;
+
+  // Sealed with STORAGE_CREDENTIAL_KEY, never the key michael holds: a database
+  // dump is not enough to reach the bucket.
+  @Column({ type: 'text', nullable: true })
+  storageSecretAccessKey!: string | null;
 }

--- a/packages/yucca-api/src/services/repository.service.spec.ts
+++ b/packages/yucca-api/src/services/repository.service.spec.ts
@@ -28,6 +28,7 @@ describe(RepositoryService.name, () => {
       mocks.wideContext as never,
       mocks.connection as never,
       mocks.topology as never,
+      mocks.storageCredential as never,
     );
   });
 
@@ -36,7 +37,7 @@ describe(RepositoryService.name, () => {
       mocks.topology.getSite.mockReturnValue(site);
       mocks.topology.getActiveCluster.mockReturnValue(site.clusters[0]);
       mocks.connection.getOrCreateDefault.mockResolvedValue({ id: 'conn', type: 'immich' } as never);
-      mocks.repository.create.mockResolvedValue({ id: 'repo' } as never);
+      mocks.repository.create.mockResolvedValue({ id: 'repo', storageClusterCode: 'father-spice' } as never);
 
       await sut.create(auth, { name: 'backup', worm: false, site: 'father' });
 
@@ -48,6 +49,12 @@ describe(RepositoryService.name, () => {
         worm: false,
         siteCode: 'father',
         storageClusterCode: 'father-spice',
+      });
+      expect(mocks.storageCredential.ensure).toHaveBeenCalledWith({
+        id: 'repo',
+        storageClusterCode: 'father-spice',
+        storageAccessKeyId: null,
+        storageSecretAccessKey: null,
       });
     });
 
@@ -75,6 +82,12 @@ describe(RepositoryService.name, () => {
         connectionType: 'immich',
       } as never);
       mocks.topology.getSite.mockReturnValue(site);
+      mocks.repository.getStorageOwner.mockResolvedValue({
+        id: repoId,
+        storageClusterCode: 'father-spice',
+        storageAccessKeyId: 'access',
+        storageSecretAccessKey: 'sealed-at-rest',
+      } as never);
       mocks.jwt.signAsync.mockResolvedValue('signed-token');
 
       const { url } = await sut.createUrl(auth, repoId);
@@ -86,6 +99,7 @@ describe(RepositoryService.name, () => {
         writeOnce: true,
         storageCluster: 'father-spice',
         connection: 'immich',
+        storageCredentials: 'sealed',
       });
       expect(url).toBe(`rest:https://restic:signed-token@rest.htz-fsn1.backups.futo.cloud/${repoId}`);
     });

--- a/packages/yucca-api/src/services/repository.service.ts
+++ b/packages/yucca-api/src/services/repository.service.ts
@@ -6,6 +6,7 @@ import { RepositoryCreateRequestDto, RepositoryUpdateRequestDto } from 'src/dto/
 import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { TopologyRepository } from 'src/repositories/topology.repository';
+import { StorageCredentialService } from 'src/services/storageCredential.service';
 
 @Injectable({ scope: Scope.REQUEST })
 export class RepositoryService {
@@ -15,6 +16,7 @@ export class RepositoryService {
     private readonly wideContext: WideContextRepository,
     private readonly connection: ConnectionRepository,
     private readonly topology: TopologyRepository,
+    private readonly storageCredentials: StorageCredentialService,
   ) {}
 
   async create(auth: AuthDto, { site: siteCode, ...dto }: RepositoryCreateRequestDto) {
@@ -27,13 +29,24 @@ export class RepositoryService {
       connectionId = connection.id;
     }
 
-    return this.repositoryRepository.create({
+    const repository = await this.repositoryRepository.create({
       userId: auth.id,
       connectionId,
       ...dto,
       siteCode: site.code,
       storageClusterCode: cluster.code,
     });
+
+    // Eager, so a storage cluster that cannot issue an identity fails the
+    // create rather than the first backup.
+    await this.storageCredentials.ensure({
+      id: repository.id,
+      storageClusterCode: repository.storageClusterCode,
+      storageAccessKeyId: null,
+      storageSecretAccessKey: null,
+    });
+
+    return repository;
   }
 
   async get(auth: AuthDto, id: string) {
@@ -64,12 +77,16 @@ export class RepositoryService {
 
     const site = this.topology.getSite(repository.siteCode);
 
+    const owner = await this.repositoryRepository.getStorageOwner(repository.id);
+    const credentials = await this.storageCredentials.ensure(owner);
+
     const token = await this.jwt.signAsync({
       user: auth.id,
       repository: repository.id,
       writeOnce: repository.worm,
       storageCluster: repository.storageClusterCode,
       connection: repository.connectionType,
+      storageCredentials: this.storageCredentials.seal(repository.id, credentials),
     });
 
     this.wideContext.addContext('repositoryId', repository.id);
@@ -88,6 +105,7 @@ export class RepositoryService {
       throw new BadRequestException('Refusing to delete write-only repository');
     }
 
+    await this.storageCredentials.revoke(await this.repositoryRepository.getStorageOwner(id));
     await this.repositoryRepository.delete(id);
   }
 }

--- a/packages/yucca-api/src/services/storageCredential.service.spec.ts
+++ b/packages/yucca-api/src/services/storageCredential.service.spec.ts
@@ -1,0 +1,105 @@
+import { openStorageCredentials } from '@common/server';
+import { env } from 'src/env';
+import { StorageCredentialService, storageUserId } from 'src/services/storageCredential.service';
+import { Mocks, newMocks } from '../../test/mocks';
+
+const repoId = 'e2b47875-91a9-4c67-a3cd-fd6c0a5b6d11';
+
+const cluster = { code: 'father-spice', display_name: 'Spice', active: true, rgw_admin_endpoint: 'https://rgw.test' };
+
+const unprovisioned = {
+  id: repoId,
+  storageClusterCode: 'father-spice',
+  storageAccessKeyId: null,
+  storageSecretAccessKey: null,
+};
+
+const credentials = { accessKeyId: 'AKIAREPO', secretAccessKey: 's3cret' };
+
+describe(StorageCredentialService.name, () => {
+  let sut: StorageCredentialService;
+  let mocks: Mocks;
+
+  beforeEach(() => {
+    mocks = newMocks();
+    mocks.topology.getCluster.mockReturnValue(cluster);
+    sut = new StorageCredentialService(mocks.rgwAdmin as never, mocks.repository as never, mocks.topology as never);
+  });
+
+  describe('ensure', () => {
+    it('creates the repository RGW user and stores the keys sealed', async () => {
+      mocks.rgwAdmin.ensureUser.mockResolvedValue(credentials);
+
+      await expect(sut.ensure(unprovisioned)).resolves.toEqual(credentials);
+
+      expect(mocks.rgwAdmin.ensureUser).toHaveBeenCalledWith(cluster, storageUserId(repoId), expect.any(String));
+
+      const [, stored] = mocks.repository.setStorageCredentials.mock.calls[0];
+      expect(stored.storageAccessKeyId).toBe('AKIAREPO');
+      expect(stored.storageSecretAccessKey).not.toContain('s3cret');
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repoId, stored.storageSecretAccessKey!)).toEqual(
+        credentials,
+      );
+    });
+
+    it('reuses the stored credentials without touching RGW', async () => {
+      mocks.rgwAdmin.ensureUser.mockResolvedValue(credentials);
+      await sut.ensure(unprovisioned);
+      const [, stored] = mocks.repository.setStorageCredentials.mock.calls[0];
+      mocks.rgwAdmin.ensureUser.mockClear();
+
+      await expect(
+        sut.ensure({ ...unprovisioned, storageSecretAccessKey: stored.storageSecretAccessKey }),
+      ).resolves.toEqual(credentials);
+
+      expect(mocks.rgwAdmin.ensureUser).not.toHaveBeenCalled();
+    });
+
+    // The compose stack runs against MinIO, which has no RGW admin API.
+    it('falls back to the static keys on a cluster without an admin endpoint', async () => {
+      mocks.rgwAdmin.supports.mockReturnValue(false);
+
+      await expect(sut.ensure(unprovisioned)).resolves.toEqual({
+        accessKeyId: env.STORAGE_STATIC_ACCESS_KEY_ID,
+        secretAccessKey: env.STORAGE_STATIC_SECRET_ACCESS_KEY,
+      });
+      expect(mocks.rgwAdmin.ensureUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rotate', () => {
+    it('issues a fresh key pair and re-seals it', async () => {
+      const rotated = { accessKeyId: 'AKIANEW', secretAccessKey: 'newsecret' };
+      mocks.rgwAdmin.rotateKeys.mockResolvedValue(rotated);
+
+      await expect(sut.rotate(unprovisioned)).resolves.toEqual(rotated);
+
+      const [, stored] = mocks.repository.setStorageCredentials.mock.calls[0];
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repoId, stored.storageSecretAccessKey!)).toEqual(
+        rotated,
+      );
+    });
+  });
+
+  describe('revoke', () => {
+    it('drops the RGW keys and clears the stored ones', async () => {
+      await sut.revoke({ ...unprovisioned, storageAccessKeyId: 'AKIAREPO', storageSecretAccessKey: 'sealed' });
+
+      expect(mocks.rgwAdmin.revokeKeys).toHaveBeenCalledWith(cluster, storageUserId(repoId));
+      expect(mocks.repository.setStorageCredentials).toHaveBeenCalledWith(repoId, {
+        storageAccessKeyId: null,
+        storageSecretAccessKey: null,
+      });
+    });
+  });
+
+  describe('seal', () => {
+    it('seals against the repository it was minted for', () => {
+      const sealed = sut.seal(repoId, credentials);
+
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, repoId, sealed)).toEqual(credentials);
+      expect(() => openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, 'another-repository', sealed)).toThrow();
+      expect(() => openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repoId, sealed)).toThrow();
+    });
+  });
+});

--- a/packages/yucca-api/src/services/storageCredential.service.ts
+++ b/packages/yucca-api/src/services/storageCredential.service.ts
@@ -1,0 +1,78 @@
+import { openStorageCredentials, sealStorageCredentials, StorageCredentials } from '@common/server';
+import { Injectable } from '@nestjs/common';
+import { env } from 'src/env';
+import { RepositoryRepository } from 'src/repositories/repository.repository';
+import { RgwAdminRepository } from 'src/repositories/rgwAdmin.repository';
+import { TopologyRepository, TopologyStorageCluster } from 'src/repositories/topology.repository';
+
+export type StorageCredentialOwner = {
+  id: string;
+  storageClusterCode: string;
+  storageAccessKeyId: string | null;
+  storageSecretAccessKey: string | null;
+};
+
+export const storageUserId = (repositoryId: string) => `yucca-repo-${repositoryId}`;
+
+@Injectable()
+export class StorageCredentialService {
+  constructor(
+    private readonly rgw: RgwAdminRepository,
+    private readonly repositoryRepository: RepositoryRepository,
+    private readonly topology: TopologyRepository,
+  ) {}
+
+  async ensure(repository: StorageCredentialOwner): Promise<StorageCredentials> {
+    if (repository.storageSecretAccessKey) {
+      return openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repository.id, repository.storageSecretAccessKey);
+    }
+    return this.provision(repository, (cluster) =>
+      this.rgw.ensureUser(cluster, storageUserId(repository.id), `yucca repository ${repository.id}`),
+    );
+  }
+
+  async rotate(repository: StorageCredentialOwner): Promise<StorageCredentials> {
+    return this.provision(repository, (cluster) => this.rgw.rotateKeys(cluster, storageUserId(repository.id)));
+  }
+
+  async revoke(repository: StorageCredentialOwner): Promise<void> {
+    const cluster = this.topology.getCluster(repository.storageClusterCode);
+    if (this.rgw.supports(cluster)) {
+      await this.rgw.revokeKeys(cluster, storageUserId(repository.id));
+    }
+    await this.repositoryRepository.setStorageCredentials(repository.id, {
+      storageAccessKeyId: null,
+      storageSecretAccessKey: null,
+    });
+  }
+
+  seal(repositoryId: string, credentials: StorageCredentials): string {
+    return sealStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY[0], repositoryId, credentials);
+  }
+
+  private async provision(
+    repository: StorageCredentialOwner,
+    issue: (cluster: TopologyStorageCluster) => Promise<StorageCredentials>,
+  ): Promise<StorageCredentials> {
+    const cluster = this.topology.getCluster(repository.storageClusterCode);
+    const credentials = this.rgw.supports(cluster) ? await issue(cluster) : staticCredentials(cluster);
+
+    await this.repositoryRepository.setStorageCredentials(repository.id, {
+      storageAccessKeyId: credentials.accessKeyId,
+      storageSecretAccessKey: sealStorageCredentials(env.STORAGE_CREDENTIAL_KEY[0], repository.id, credentials),
+    });
+    return credentials;
+  }
+}
+
+const staticCredentials = (cluster: TopologyStorageCluster): StorageCredentials => {
+  const accessKeyId = env.STORAGE_STATIC_ACCESS_KEY_ID;
+  const secretAccessKey = env.STORAGE_STATIC_SECRET_ACCESS_KEY;
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error(
+      `Storage cluster '${cluster.code}' has no rgw_admin_endpoint and no ` +
+        `STORAGE_STATIC_ACCESS_KEY_ID/STORAGE_STATIC_SECRET_ACCESS_KEY to fall back to`,
+    );
+  }
+  return { accessKeyId, secretAccessKey };
+};

--- a/packages/yucca-api/test/mocks.ts
+++ b/packages/yucca-api/test/mocks.ts
@@ -4,11 +4,13 @@ import type { CryptoRepository } from 'src/repositories/crypto.repository';
 import type { DatabaseRepository } from 'src/repositories/database.repository';
 import type { OidcRepository } from 'src/repositories/oidc.repository';
 import type { RepositoryRepository } from 'src/repositories/repository.repository';
+import type { RgwAdminRepository } from 'src/repositories/rgwAdmin.repository';
 import type { SessionRepository } from 'src/repositories/session.repository';
 import type { SettingsRepository } from 'src/repositories/settings.repository';
 import type { TopologyRepository } from 'src/repositories/topology.repository';
 import type { UserRepository } from 'src/repositories/user.repository';
 import type { UserAllowlistRepository } from 'src/repositories/userAllowlist.repository';
+import type { StorageCredentialService } from 'src/services/storageCredential.service';
 
 export type RepositoryInterface<T extends object> = Pick<T, keyof T>;
 
@@ -65,8 +67,30 @@ export const newRepositoryRepositoryMock = (): jest.Mocked<RepositoryInterface<R
     create: jest.fn(),
     get: jest.fn(),
     getByUser: jest.fn(),
+    getByIds: jest.fn(),
+    getStorageOwner: jest.fn(),
+    setStorageCredentials: jest.fn(),
+    reparent: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+  };
+};
+
+export const newRgwAdminRepositoryMock = (): jest.Mocked<RepositoryInterface<RgwAdminRepository>> => {
+  return {
+    supports: jest.fn().mockReturnValue(true),
+    ensureUser: jest.fn(),
+    rotateKeys: jest.fn(),
+    revokeKeys: jest.fn(),
+  };
+};
+
+export const newStorageCredentialServiceMock = (): jest.Mocked<RepositoryInterface<StorageCredentialService>> => {
+  return {
+    ensure: jest.fn().mockResolvedValue({ accessKeyId: 'access', secretAccessKey: 'secret' }),
+    rotate: jest.fn(),
+    revoke: jest.fn(),
+    seal: jest.fn().mockReturnValue('sealed'),
   };
 };
 
@@ -97,6 +121,7 @@ export const newTopologyRepositoryMock = (): jest.Mocked<RepositoryInterface<Top
     load: jest.fn(),
     get: jest.fn(),
     getSite: jest.fn(),
+    getCluster: jest.fn(),
     hasSite: jest.fn(),
     hasCluster: jest.fn(),
     getActiveCluster: jest.fn(),
@@ -140,6 +165,8 @@ export const newMocks = () => {
     user: newUserRepositoryMock(),
     userAllowlist: newUserAllowlistRepositoryMock(),
     repository: newRepositoryRepositoryMock(),
+    rgwAdmin: newRgwAdminRepositoryMock(),
+    storageCredential: newStorageCredentialServiceMock(),
     settings: newSettingsRepositoryMock(),
     topology: newTopologyRepositoryMock(),
     logger: newLoggerRepositoryMock(),

--- a/packages/yucca-api/test/repository.integration-spec.ts
+++ b/packages/yucca-api/test/repository.integration-spec.ts
@@ -1,9 +1,11 @@
+import { openStorageCredentials } from '@common/server';
 import { MetricService } from '@common/server/otel';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { controllers, imports, providers } from '../src/app.module';
+import { env } from '../src/env';
 import { newMetricServiceMock } from './mocks';
 import { testUtils } from './testUtils';
 
@@ -156,6 +158,27 @@ describe('RepositoryController (e2e)', () => {
         writeOnce: false,
         connection: 'immich',
       });
+    });
+
+    // Without this claim michael 401s every request for the repository.
+    it('carries the repository storage credentials, sealed', async () => {
+      const { body } = await request(app.getHttpServer())
+        .post(`/api/repository/${repository.id}/restic`)
+        .set('Cookie', `yucca-access-token=${session.accessToken}`)
+        .expect(201);
+
+      const token = new URL((body.url as string).slice('rest:'.length)).password;
+      const claims = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as Record<string, unknown>;
+
+      const sealed = claims.storageCredentials as string;
+      expect(sealed).toEqual(expect.any(String));
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, repository.id, sealed)).toEqual({
+        accessKeyId: expect.any(String),
+        secretAccessKey: expect.any(String),
+      });
+      expect(() =>
+        openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, '00000000-0000-0000-0000-000000000000', sealed),
+      ).toThrow();
     });
   });
 

--- a/packages/yucca-api/test/rgwAdmin.integration-spec.ts
+++ b/packages/yucca-api/test/rgwAdmin.integration-spec.ts
@@ -1,0 +1,82 @@
+import { AwsClient } from 'aws4fetch';
+import { RgwAdminRepository } from 'src/repositories/rgwAdmin.repository';
+import { TopologyStorageCluster } from 'src/repositories/topology.repository';
+
+// Needs a real RadosGW: `mise k3d:up && mise tilt:ci-infra`, then
+// `mise test:integration:k3d` (which exports RADOS_*). Skipped otherwise —
+// MinIO has no admin API to run this against.
+const endpoint = process.env.RADOS_ENDPOINT;
+const configured = Boolean(endpoint && process.env.RADOS_ACCESS_KEY_ID && process.env.RADOS_SECRET_ACCESS_KEY);
+const describeRgw = configured ? describe : describe.skip;
+
+const cluster = {
+  code: 'local-dev',
+  display_name: 'Local development storage',
+  active: true,
+  rgw_admin_endpoint: endpoint,
+} as TopologyStorageCluster;
+
+describeRgw('RgwAdminRepository (integration)', () => {
+  const repository = new RgwAdminRepository();
+  const uid = `yucca-repo-it-${Date.now()}`;
+  const bucket = `${uid}-bucket`;
+
+  const canWrite = async (keys: { accessKeyId: string; secretAccessKey: string }, method: string) => {
+    const client = new AwsClient({ ...keys, service: 's3', region: 'rgw' });
+    const response = await client.fetch(new URL(`/${bucket}`, endpoint).toString(), { method });
+    return response.status;
+  };
+
+  afterAll(async () => {
+    if (!configured) {
+      return;
+    }
+    await repository.revokeKeys(cluster, uid).catch(() => undefined);
+  });
+
+  it('creates the user and returns keys that can stand up its bucket', async () => {
+    const keys = await repository.ensureUser(cluster, uid, 'integration test repository');
+
+    expect(keys.accessKeyId).toEqual(expect.any(String));
+    expect(keys.secretAccessKey).toEqual(expect.any(String));
+    // 200 proves RGW accepted a request signed with the freshly minted keys.
+    await expect(canWrite(keys, 'PUT')).resolves.toBe(200);
+  });
+
+  it('is idempotent: a second ensure returns the same key', async () => {
+    const first = await repository.ensureUser(cluster, uid, 'integration test repository');
+    const second = await repository.ensureUser(cluster, uid, 'integration test repository');
+
+    expect(second.accessKeyId).toBe(first.accessKeyId);
+  });
+
+  // Rotation answers a leaked credential, so the old key has to stop working,
+  // not merely be superseded.
+  it('rotate issues a new key and invalidates the old one', async () => {
+    const before = await repository.ensureUser(cluster, uid, 'integration test repository');
+    const after = await repository.rotateKeys(cluster, uid);
+
+    expect(after.accessKeyId).not.toBe(before.accessKeyId);
+    await expect(canWrite(after, 'HEAD')).resolves.toBe(200);
+    await expect(canWrite(before, 'HEAD')).resolves.toBe(403);
+  });
+
+  it('revoke leaves the bucket but kills every key', async () => {
+    const keys = await repository.ensureUser(cluster, uid, 'integration test repository');
+    await repository.revokeKeys(cluster, uid);
+
+    await expect(canWrite(keys, 'HEAD')).resolves.toBe(403);
+
+    // The bucket is still there — deleting a repository has never deleted data.
+    const admin = new AwsClient({
+      accessKeyId: process.env.RADOS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.RADOS_SECRET_ACCESS_KEY!,
+      service: 's3',
+      region: 'rgw',
+    });
+    const stats = await admin.fetch(
+      `${endpoint!.replace(/\/$/, '')}/admin/bucket?${new URLSearchParams({ bucket, format: 'json' })}`,
+    );
+    expect(stats.status).toBe(200);
+  });
+});

--- a/packages/yuctl/README.md
+++ b/packages/yuctl/README.md
@@ -41,6 +41,7 @@ packages/yuctl/
     context/                  # ~/.config/yuctl/context.json {partition,region,ceph_cluster}
     k8s/                      # talosctl upgrade wrapper
     ceph/                     # RGW/dashboard health probe
+    rgw/                      # RadosGW admin ops + bucket-ownership calls
     adminapi/                 # CLI loopback login + Bearer admin-api client
 ```
 
@@ -60,6 +61,8 @@ yuctl
 ├── users
 │   ├── list                        list users in the partition's PRIMARY region
 │   └── view-dashboard              open the grafana per-user drill-down (--id or --email)
+├── repos
+│   └── migrate-storage-credentials  give each repository its own RGW user and hand its bucket over
 ├── config                          scoped config overrides (served to clients via /api/meta)
 │   ├── list                        list every settings scope (global / site:* / cluster:*)
 │   ├── get                         print one scope's overrides (--site / --cluster)
@@ -89,6 +92,26 @@ yuctl
 
 Global flags: `--log-level` (trace|debug|info|warn|error), `--log-format`
 (pretty|json).
+
+## Storage-credential migration
+
+`repos migrate-storage-credentials` is the one-time cutover behind
+[`docs/storage-credentials.md`](../../docs/storage-credentials.md): every
+repository gets its own RGW user, and its bucket is handed over to it, so
+michael can stop holding a cluster-wide S3 credential.
+
+```sh
+yuctl ceph select spice
+yuctl repos migrate-storage-credentials --dry-run   # report what would move
+yuctl repos migrate-storage-credentials
+```
+
+It talks to the admin API (provisioning) and to the RGW directly, using the
+selected ceph cluster's `s3_migrator_cred_refs` (bucket admin) and
+`s3_owner_cred_refs` (the current bucket owner, which has to sign the
+ownership-controls call) from discovery. Neither is the credential the APIs
+hold online — that one has no bucket admin at all. Idempotent, and it re-reads each bucket
+afterwards rather than trusting the link.
 
 ## State-reading approach
 

--- a/packages/yuctl/internal/adminapi/repos.go
+++ b/packages/yuctl/internal/adminapi/repos.go
@@ -135,3 +135,20 @@ func (c *Client) ListRepositories(ctx context.Context, userID string, limit int)
 	}
 	return all, nil
 }
+
+// StorageCredentials carries no secret: it never leaves the API.
+type StorageCredentials struct {
+	StorageUserID      string `json:"storageUserId"`
+	StorageClusterCode string `json:"storageClusterCode"`
+	AccessKeyID        string `json:"accessKeyId"`
+}
+
+// rotate issues a fresh key pair, invalidating the credentials any
+// already-minted token carries.
+func (c *Client) ProvisionStorageCredentials(ctx context.Context, id string, rotate bool) (*StorageCredentials, error) {
+	var out StorageCredentials
+	if err := c.postJSON(ctx, "/api/repository/"+id+"/storage-credentials", map[string]any{"rotate": rotate}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/packages/yuctl/internal/cli/repos.go
+++ b/packages/yuctl/internal/cli/repos.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"yuctl/internal/adminapi"
+	"yuctl/internal/op"
+	"yuctl/internal/rgw"
+	"yuctl/internal/state"
+)
+
+func newReposCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repos",
+		Short: "Repository administration via yucca-admin-api",
+	}
+	cmd.AddCommand(newReposMigrateStorageCredentialsCmd())
+	return cmd
+}
+
+func newReposMigrateStorageCredentialsCmd() *cobra.Command {
+	flags := &adminFlags{}
+	var (
+		dryRun      bool
+		rotate      bool
+		repoID      string
+		rgwEndpoint string
+		region      string
+		insecure    bool
+	)
+
+	c := &cobra.Command{
+		Use:   "migrate-storage-credentials",
+		Short: "Give each repository its own RGW user and hand its bucket over",
+		Long: "Provisions every repository's own S3 user through admin-api, marks its bucket\n" +
+			"BucketOwnerEnforced (signed as the current owner, so existing objects follow the\n" +
+			"bucket), then links the bucket to the new user. Idempotent: a repository that is\n" +
+			"already migrated is reported and skipped.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			client, _, err := flags.allowlistClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			cluster, err := selectedCephCluster(ctx)
+			if err != nil {
+				return err
+			}
+			endpoint := rgwEndpoint
+			if endpoint == "" {
+				endpoint = cluster.RGWS3Endpoint
+			}
+			if endpoint == "" {
+				return fmt.Errorf("no rgw_s3_endpoint in discovery for the selected ceph cluster; pass --rgw-endpoint")
+			}
+
+			admin, err := resolveCredentials(ctx, cluster.S3MigratorCredRefs, "s3_migrator_cred_refs")
+			if err != nil {
+				return err
+			}
+			owner, err := resolveCredentials(ctx, cluster.S3OwnerCredRefs, "s3_owner_cred_refs")
+			if err != nil {
+				return err
+			}
+
+			repositories, err := listMigrationTargets(ctx, client, repoID)
+			if err != nil {
+				return err
+			}
+
+			rgwAdmin := rgw.NewAdminClient(endpoint, region, admin, insecure)
+			out := cmd.OutOrStdout()
+			var migrated, skipped, failed int
+
+			for _, repository := range repositories {
+				status, err := migrateOne(ctx, migration{
+					client:   client,
+					rgw:      rgwAdmin,
+					endpoint: endpoint,
+					region:   region,
+					owner:    owner,
+					insecure: insecure,
+					dryRun:   dryRun,
+					rotate:   rotate,
+				}, repository)
+				switch {
+				case err != nil:
+					failed++
+					fmt.Fprintf(out, "%s  FAILED  %s\n", repository.ID, err)
+				case status == statusSkipped:
+					skipped++
+					fmt.Fprintf(out, "%s  ok      already owned by its repository user\n", repository.ID)
+				default:
+					migrated++
+					fmt.Fprintf(out, "%s  %s\n", repository.ID, status)
+				}
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "\n%d migrated, %d already done, %d failed (of %d)\n",
+				migrated, skipped, failed, len(repositories))
+			if failed > 0 {
+				return fmt.Errorf("%d repositories could not be migrated", failed)
+			}
+			return nil
+		},
+	}
+
+	flags.register(c)
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "report what would change without provisioning or linking anything")
+	c.Flags().BoolVar(&rotate, "rotate", false, "issue fresh keys even for repositories that already have some")
+	c.Flags().StringVar(&repoID, "repository", "", "migrate a single repository by id")
+	c.Flags().StringVar(&rgwEndpoint, "rgw-endpoint", "", "RGW S3 endpoint (default: the selected ceph cluster's rgw_s3_endpoint)")
+	c.Flags().StringVar(&region, "region", "us-east-1", "S3 region to sign with")
+	c.Flags().BoolVar(&insecure, "insecure-skip-tls-verify", false, "skip TLS verification (self-signed RGW certs)")
+	return c
+}
+
+type migrationStatus string
+
+const (
+	statusSkipped   migrationStatus = "skipped"
+	statusMigrated  migrationStatus = "migrated"
+	statusWouldMove migrationStatus = "would migrate"
+)
+
+type migration struct {
+	client   *adminapi.Client
+	rgw      *rgw.AdminClient
+	endpoint string
+	region   string
+	owner    rgw.Credentials
+	insecure bool
+	dryRun   bool
+	rotate   bool
+}
+
+// Ownership is enforced before the link, or the new owner inherits a bucket
+// full of objects it cannot read.
+func migrateOne(ctx context.Context, m migration, repository adminapi.Repository) (migrationStatus, error) {
+	bucket, err := m.rgw.GetBucket(ctx, repository.ID)
+	if err != nil {
+		return "", fmt.Errorf("read bucket: %w", err)
+	}
+
+	credentials, err := m.provision(ctx, repository.ID)
+	if err != nil {
+		return "", err
+	}
+
+	if bucket.Owner == credentials.StorageUserID && !m.rotate {
+		return statusSkipped, nil
+	}
+	if m.dryRun {
+		return statusWouldMove, nil
+	}
+
+	if bucket.Owner != credentials.StorageUserID {
+		if err := rgw.EnforceBucketOwner(ctx, m.endpoint, m.region, m.owner, repository.ID, m.insecure); err != nil {
+			return "", err
+		}
+		if err := m.rgw.LinkBucket(ctx, repository.ID, bucket.ID, credentials.StorageUserID); err != nil {
+			return "", fmt.Errorf("link bucket to %s: %w", credentials.StorageUserID, err)
+		}
+
+		// A silently no-op link would leave the repository unreadable with its
+		// new credentials.
+		after, err := m.rgw.GetBucket(ctx, repository.ID)
+		if err != nil {
+			return "", fmt.Errorf("verify bucket owner: %w", err)
+		}
+		if after.Owner != credentials.StorageUserID {
+			return "", fmt.Errorf("bucket owner is still %q after link, expected %q", after.Owner, credentials.StorageUserID)
+		}
+	}
+
+	return statusMigrated, nil
+}
+
+// Mirrors storageUserId() in the APIs: a dry run must not provision anything,
+// so it is the one path that derives the name instead of being told it.
+const storageUserPrefix = "yucca-repo-"
+
+func (m migration) provision(ctx context.Context, id string) (*adminapi.StorageCredentials, error) {
+	if m.dryRun {
+		return &adminapi.StorageCredentials{StorageUserID: storageUserPrefix + id}, nil
+	}
+	credentials, err := m.client.ProvisionStorageCredentials(ctx, id, m.rotate)
+	if err != nil {
+		return nil, fmt.Errorf("provision storage credentials: %w", err)
+	}
+	return credentials, nil
+}
+
+func listMigrationTargets(ctx context.Context, client *adminapi.Client, repoID string) ([]adminapi.Repository, error) {
+	if repoID != "" {
+		return []adminapi.Repository{{ID: repoID}}, nil
+	}
+	return client.ListRepositories(ctx, "", 0)
+}
+
+func selectedCephCluster(ctx context.Context) (state.CephCluster, error) {
+	c, err := requireContext()
+	if err != nil {
+		return state.CephCluster{}, err
+	}
+	if c.CephCluster == "" {
+		return state.CephCluster{}, fmt.Errorf("no ceph cluster selected; run `yuctl ceph select <name>` first")
+	}
+	topo, err := resolveTopology(ctx)
+	if err != nil {
+		return state.CephCluster{}, err
+	}
+	clusters := topo.CephClusters(c.Partition, c.Region)
+	cluster, ok := clusters[c.CephCluster]
+	if !ok {
+		return state.CephCluster{}, fmt.Errorf("ceph cluster %q no longer present in %s@%s", c.CephCluster, c.Partition, c.Region)
+	}
+	return cluster, nil
+}
+
+// resolveCredentials reads an {access_key, secret_key} pair of op:// references
+// out of a discovery payload.
+func resolveCredentials(ctx context.Context, refs map[string]string, field string) (rgw.Credentials, error) {
+	access, secret := refs["access_key"], refs["secret_key"]
+	if access == "" || secret == "" {
+		return rgw.Credentials{}, fmt.Errorf("ceph discovery has no %s.{access_key,secret_key}", field)
+	}
+	accessKey, err := op.Read(ctx, access)
+	if err != nil {
+		return rgw.Credentials{}, fmt.Errorf("resolve %s.access_key: %w", field, err)
+	}
+	secretKey, err := op.Read(ctx, secret)
+	if err != nil {
+		return rgw.Credentials{}, fmt.Errorf("resolve %s.secret_key: %w", field, err)
+	}
+	return rgw.Credentials{
+		AccessKeyID:     strings.TrimSpace(accessKey),
+		SecretAccessKey: strings.TrimSpace(secretKey),
+	}, nil
+}

--- a/packages/yuctl/internal/cli/root.go
+++ b/packages/yuctl/internal/cli/root.go
@@ -49,6 +49,7 @@ func NewRootCmd() *cobra.Command {
 		newCephCmd(),
 		newInfraCmd(),
 		newUsersCmd(),
+		newReposCmd(),
 		newConfigCmd(),
 		newFeaturesCmd(),
 		newToolsCmd(),

--- a/packages/yuctl/internal/rgw/rgw.go
+++ b/packages/yuctl/internal/rgw/rgw.go
@@ -1,0 +1,168 @@
+// Package rgw drives the RadosGW admin ops API and the bucket-ownership S3
+// calls behind `yuctl repos migrate-storage-credentials`.
+package rgw
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// Credentials is one S3 identity.
+type Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+}
+
+// emptyPayloadHash is the SigV4 hash of an empty body; every admin ops call
+// here sends one.
+var emptyPayloadHash = func() string {
+	sum := sha256.Sum256(nil)
+	return hex.EncodeToString(sum[:])
+}()
+
+// AdminClient calls the RadosGW admin ops API with a users+buckets admin
+// credential.
+type AdminClient struct {
+	endpoint string
+	region   string
+	creds    aws.Credentials
+	http     *http.Client
+}
+
+func NewAdminClient(endpoint, region string, creds Credentials, insecureTLS bool) *AdminClient {
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if insecureTLS {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		hc.Transport = tr
+	}
+	return &AdminClient{
+		endpoint: strings.TrimRight(endpoint, "/"),
+		region:   region,
+		creds: aws.Credentials{
+			AccessKeyID:     creds.AccessKeyID,
+			SecretAccessKey: creds.SecretAccessKey,
+		},
+		http: hc,
+	}
+}
+
+// Bucket is the slice of the admin API's bucket stats yuctl acts on.
+type Bucket struct {
+	Bucket string `json:"bucket"`
+	ID     string `json:"id"`
+	Owner  string `json:"owner"`
+}
+
+// GetBucket reads one bucket's stats, which is how the migration learns its
+// current owner and its bucket id.
+func (c *AdminClient) GetBucket(ctx context.Context, bucket string) (*Bucket, error) {
+	var out Bucket
+	if err := c.do(ctx, http.MethodGet, "/admin/bucket", url.Values{
+		"bucket": {bucket},
+		"stats":  {"true"},
+		"format": {"json"},
+	}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// LinkBucket moves a bucket to another owner. The bucket id is passed alongside
+// the name because RGW resolves an unqualified name against the *caller's*
+// tenant, which is not the owner here.
+func (c *AdminClient) LinkBucket(ctx context.Context, bucket, bucketID, uid string) error {
+	return c.do(ctx, http.MethodPut, "/admin/bucket", url.Values{
+		"bucket":    {bucket},
+		"bucket-id": {bucketID},
+		"uid":       {uid},
+		"format":    {"json"},
+	}, nil)
+}
+
+func (c *AdminClient) do(ctx context.Context, method, path string, query url.Values, out any) error {
+	u := c.endpoint + path + "?" + query.Encode()
+	req, err := http.NewRequestWithContext(ctx, method, u, nil)
+	if err != nil {
+		return err
+	}
+	if err := v4.NewSigner().SignHTTP(ctx, c.creds, req, emptyPayloadHash, "s3", c.region, time.Now().UTC()); err != nil {
+		return fmt.Errorf("sign %s %s: %w", method, path, err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out != nil {
+		if err := json.Unmarshal(body, out); err != nil {
+			return fmt.Errorf("parse %s %s response: %w", method, path, err)
+		}
+	}
+	return nil
+}
+
+// EnforceBucketOwner sets ObjectOwnership to BucketOwnerEnforced, which makes
+// RGW ignore per-object ACLs so the bucket's owner controls every object in it.
+// It must be signed by the CURRENT owner, and must run before the bucket is
+// linked to its new one: without it, objects written by the old owner stay
+// readable only by the old owner.
+func EnforceBucketOwner(ctx context.Context, endpoint, region string, creds Credentials, bucket string, insecureTLS bool) error {
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if insecureTLS {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		hc.Transport = tr
+	}
+
+	client := s3.New(s3.Options{
+		Region:       region,
+		BaseEndpoint: aws.String(endpoint),
+		UsePathStyle: true,
+		HTTPClient:   hc,
+		Credentials: awscreds.NewStaticCredentialsProvider(
+			creds.AccessKeyID,
+			creds.SecretAccessKey,
+			"",
+		),
+	})
+
+	_, err := client.PutBucketOwnershipControls(ctx, &s3.PutBucketOwnershipControlsInput{
+		Bucket: aws.String(bucket),
+		OwnershipControls: &types.OwnershipControls{
+			Rules: []types.OwnershipControlsRule{
+				{ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf(
+			"set BucketOwnerEnforced on %s: %w "+
+				"(if this RGW does not support bucket ownership controls, chown the bucket on a ceph host instead: "+
+				"`radosgw-admin bucket chown --bucket=%s --uid=<uid>`)",
+			bucket, err, bucket,
+		)
+	}
+	return nil
+}

--- a/packages/yuctl/internal/state/contract.go
+++ b/packages/yuctl/internal/state/contract.go
@@ -54,13 +54,18 @@ type Kubernetes struct {
 // CephCluster is one entry of the ceph payload's ceph_clusters map. A region may
 // have one-or-more, keyed by friendly name (e.g. "sietch").
 type CephCluster struct {
-	ClusterName      string            `json:"cluster_name"`
-	FQDN             string            `json:"fqdn"`
-	RGWS3Endpoint    string            `json:"rgw_s3_endpoint"`
-	HealthCredRef    string            `json:"health_cred_ref"`    // op:// reference
-	S3AdminCredRefs  map[string]string `json:"s3_admin_cred_refs"` // op:// references
-	SecretItemTitles map[string]string `json:"secret_item_titles"` // purpose → 1P item title
-	BootstrapHost    string            `json:"bootstrap_host"`
+	ClusterName     string            `json:"cluster_name"`
+	FQDN            string            `json:"fqdn"`
+	RGWS3Endpoint   string            `json:"rgw_s3_endpoint"`
+	HealthCredRef   string            `json:"health_cred_ref"`    // op:// reference
+	S3AdminCredRefs map[string]string `json:"s3_admin_cred_refs"` // op:// references
+	// Full users+buckets RGW admin, and the S3 user owning pre-migration
+	// buckets. Both are maps of {access_key, secret_key} to op:// references.
+	S3ProvisionerCredRefs map[string]string `json:"s3_provisioner_cred_refs"`
+	S3MigratorCredRefs    map[string]string `json:"s3_migrator_cred_refs"`
+	S3OwnerCredRefs       map[string]string `json:"s3_owner_cred_refs"`
+	SecretItemTitles      map[string]string `json:"secret_item_titles"` // purpose → 1P item title
+	BootstrapHost         string            `json:"bootstrap_host"`
 }
 
 // DNS is the dns stack payload.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,6 +726,9 @@ importers:
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.0
+      aws4fetch:
+        specifier: 'catalog:'
+        version: 1.0.20
       class-validator:
         specifier: 'catalog:'
         version: 0.14.3
@@ -850,6 +853,9 @@ importers:
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.0
+      aws4fetch:
+        specifier: 'catalog:'
+        version: 1.0.20
       class-validator:
         specifier: 'catalog:'
         version: 0.14.3

--- a/tf/.env
+++ b/tf/.env
@@ -53,6 +53,8 @@ export TF_VAR_yucca_rgw_secret_access_key="op://yucca_tf_staging/SIETCH_CEPH_S3_
 # Secret (secrets.tf). NOT from CI — the cluster pulls nothing from CI.
 export TF_VAR_sietch_metrics_worker_access_key="op://yucca_tf_staging/SIETCH_METRICS_WORKER_ACCESS_KEY/password"
 export TF_VAR_sietch_metrics_worker_secret_key="op://yucca_tf_staging/SIETCH_METRICS_WORKER_SECRET_KEY/password"
+export TF_VAR_sietch_provisioner_access_key="op://yucca_tf_staging/SIETCH_PROVISIONER_ACCESS_KEY/password"
+export TF_VAR_sietch_provisioner_secret_key="op://yucca_tf_staging/SIETCH_PROVISIONER_SECRET_KEY/password"
 
 # vmagent + collector → o11y staging vmauth bearer token.
 export TF_VAR_vmauth_remote_write_password="op://shared_tf_staging/VICTORIAMETRICS_VMAUTH_PASSWORD/password"

--- a/tf/.env.prod
+++ b/tf/.env.prod
@@ -70,6 +70,8 @@ export TF_VAR_yucca_rgw_secret_access_key="op://yucca_tf_prod/SPICE_CEPH_S3_SVC_
 # yucca-metrics-worker → spice RGW admin API.
 export TF_VAR_spice_metrics_worker_access_key="op://yucca_tf_prod/SPICE_METRICS_WORKER_ACCESS_KEY/password"
 export TF_VAR_spice_metrics_worker_secret_key="op://yucca_tf_prod/SPICE_METRICS_WORKER_SECRET_KEY/password"
+export TF_VAR_spice_provisioner_access_key="op://yucca_tf_prod/SPICE_PROVISIONER_ACCESS_KEY/password"
+export TF_VAR_spice_provisioner_secret_key="op://yucca_tf_prod/SPICE_PROVISIONER_SECRET_KEY/password"
 
 # vmagent/logs remote-write bearer for o11y prod vmauth.
 export TF_VAR_vmauth_remote_write_password="op://shared_tf_prod/O11Y_VICTORIAMETRICS_VMAUTH_PASSWORD/password"

--- a/tf/deployment/prod/htz-fsn1/talos/secrets.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/secrets.tf
@@ -128,6 +128,44 @@ resource "kubernetes_namespace_v1" "observability" {
   }
 }
 
+# Per-repository storage credentials. STORAGE_CREDENTIAL_KEY encrypts the RGW
+# secret keys at rest in postgres; STORAGE_CREDENTIAL_SEAL_KEY is shared with
+# michael and seals them into each restic token. Both are 32-byte AES-256 keys.
+# prevent_destroy: losing the at-rest key orphans every repository's stored
+# credential, and losing the seal key invalidates every token in flight.
+resource "random_bytes" "yucca_storage_credential_key" {
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "random_bytes" "yucca_storage_seal_key" {
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "onepassword_item" "yucca_storage_keys" {
+  vault    = data.onepassword_vault.prod.uuid
+  title    = "YUCCA_STORAGE_CREDENTIAL_KEYS"
+  category = "password"
+
+  password = random_bytes.yucca_storage_credential_key.base64
+
+  section {
+    label = "keys"
+    field {
+      label = "seal_key"
+      type  = "STRING"
+      value = random_bytes.yucca_storage_seal_key.base64
+    }
+  }
+}
+
 # yucca-api: signs JWTs with the generated private key + its OIDC client creds
 # (prod Zitadel, CUSTOMER_ZITADEL_OAUTH_*_YUCCA_WEB / _YUCCA_ORCHESTRATOR).
 resource "kubernetes_secret_v1" "yucca_api" {
@@ -140,6 +178,10 @@ resource "kubernetes_secret_v1" "yucca_api" {
     OIDC_CLIENT_ID        = var.yucca_oidc_client_id
     OIDC_CLIENT_SECRET    = var.yucca_oidc_client_secret
     OIDC_DEVICE_CLIENT_ID = var.yucca_oidc_device_client_id
+    # Per-repository storage credentials: sealed at rest with the first key,
+    # sealed into restic tokens with the second (michael holds only the second).
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key.base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key.base64
   }
 
   lifecycle {
@@ -165,6 +207,10 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
     # bench): deliberately the yucca_jwt SIGNING key — michael only accepts
     # tokens from that keypair. Admin session JWTs stay on yucca_admin_jwt.
     RESTIC_JWT_PRIVATE_KEY = tls_private_key.yucca_jwt.private_key_pem_pkcs8
+    # Same storage-credential keys as yucca-api: admin-created repositories and
+    # admin-minted restic URLs go through the identical provisioning path.
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key.base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key.base64
   }
 
   lifecycle {
@@ -175,17 +221,16 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
   }
 }
 
-# michael: verifies yucca-api's JWTs + the spice RGW svc-yucca-restic S3 keys
-# (out-of-band contract items, seeded into the RGW by the ceph ansible).
+# michael: verifies yucca-api's JWTs and opens the per-repository S3 credentials
+# they carry. It holds no S3 keys of its own.
 resource "kubernetes_secret_v1" "yucca_michael" {
   metadata {
     name      = "yucca-michael"
     namespace = kubernetes_namespace_v1.yucca.metadata[0].name
   }
   data = {
-    JWT_PUBLIC_KEY       = tls_private_key.yucca_jwt.public_key_pem
-    S3_ACCESS_KEY_ID     = var.yucca_rgw_access_key_id
-    S3_SECRET_ACCESS_KEY = var.yucca_rgw_secret_access_key
+    JWT_PUBLIC_KEY              = tls_private_key.yucca_jwt.public_key_pem
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key.base64
   }
 
   lifecycle {
@@ -213,6 +258,27 @@ resource "kubernetes_secret_v1" "yucca_metrics_rgw" {
     precondition {
       condition     = length(var.spice_metrics_worker_access_key) > 0 && length(var.spice_metrics_worker_secret_key) > 0
       error_message = "spice metrics-worker RGW keys are empty — run applies through tf/op-run.sh with OP_ENV_FILE=tf/.env.prod."
+    }
+  }
+}
+
+# yucca-api / yucca-admin-api: the RGW user with users+buckets admin caps, used
+# to create one S3 user per repository. Keys are AccessKey/SecretKey to match
+# the charts' radosSecretName lookup, as with yucca-metrics-rgw.
+resource "kubernetes_secret_v1" "yucca_provisioner_rgw" {
+  metadata {
+    name      = "yucca-provisioner-rgw"
+    namespace = kubernetes_namespace_v1.yucca.metadata[0].name
+  }
+  data = {
+    AccessKey = var.spice_provisioner_access_key
+    SecretKey = var.spice_provisioner_secret_key
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.spice_provisioner_access_key) > 0 && length(var.spice_provisioner_secret_key) > 0
+      error_message = "spice provisioner RGW keys are empty — run applies through tf/op-run.sh."
     }
   }
 }

--- a/tf/deployment/prod/htz-fsn1/talos/variables.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/variables.tf
@@ -220,3 +220,16 @@ variable "vmauth_remote_write_password" {
   sensitive   = true
   default     = ""
 }
+
+variable "spice_provisioner_access_key" {
+  description = "Spice RGW admin access key for the yucca APIs (creates one S3 user per repository)."
+  type        = string
+  default     = ""
+}
+
+variable "spice_provisioner_secret_key" {
+  description = "Spice RGW admin secret key for the yucca APIs."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/tf/deployment/prod/htz-fsn1/talos/versions.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/versions.tf
@@ -22,6 +22,11 @@ terraform {
       source  = "1Password/onepassword"
       version = "~> 2.1"
     }
+    # Storage-credential key generation (secrets.tf).
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
     # App JWT keypair generation (secrets.tf).
     tls = {
       source  = "hashicorp/tls"

--- a/tf/deployment/staging/austin/talos/secrets.tf
+++ b/tf/deployment/staging/austin/talos/secrets.tf
@@ -149,6 +149,47 @@ resource "kubernetes_namespace_v1" "netbird" {
 
 # ─── App Secrets (namespace: yucca) ─────────────────────────────────────
 
+# Per-repository storage credentials. STORAGE_CREDENTIAL_KEY encrypts the RGW
+# secret keys at rest in postgres; STORAGE_CREDENTIAL_SEAL_KEY is shared with
+# michael and seals them into each restic token. Both are 32-byte AES-256 keys.
+# prevent_destroy: losing the at-rest key orphans every repository's stored
+# credential, and losing the seal key invalidates every token in flight.
+resource "random_bytes" "yucca_storage_credential_key" {
+  count  = local.provision_secrets ? 1 : 0
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "random_bytes" "yucca_storage_seal_key" {
+  count  = local.provision_secrets ? 1 : 0
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "onepassword_item" "yucca_storage_keys" {
+  count    = local.provision_secrets ? 1 : 0
+  vault    = data.onepassword_vault.staging.uuid
+  title    = "YUCCA_STORAGE_CREDENTIAL_KEYS"
+  category = "password"
+
+  password = random_bytes.yucca_storage_credential_key[0].base64
+
+  section {
+    label = "keys"
+    field {
+      label = "seal_key"
+      type  = "STRING"
+      value = random_bytes.yucca_storage_seal_key[0].base64
+    }
+  }
+}
+
 # yucca-api: signs JWTs with the generated private key + its OIDC client creds.
 resource "kubernetes_secret_v1" "yucca_api" {
   count = local.provision_secrets ? 1 : 0
@@ -161,6 +202,10 @@ resource "kubernetes_secret_v1" "yucca_api" {
     OIDC_CLIENT_ID        = var.yucca_oidc_client_id
     OIDC_CLIENT_SECRET    = var.yucca_oidc_client_secret
     OIDC_DEVICE_CLIENT_ID = var.yucca_oidc_device_client_id
+    # Per-repository storage credentials: sealed at rest with the first key,
+    # sealed into restic tokens with the second (michael holds only the second).
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key[0].base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key[0].base64
   }
 }
 
@@ -179,6 +224,10 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
     # bench): deliberately the yucca_jwt SIGNING key — michael only accepts
     # tokens from that keypair. Admin session JWTs stay on yucca_admin_jwt.
     RESTIC_JWT_PRIVATE_KEY = tls_private_key.yucca_jwt[0].private_key_pem_pkcs8
+    # Same storage-credential keys as yucca-api: admin-created repositories and
+    # admin-minted restic URLs go through the identical provisioning path.
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key[0].base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key[0].base64
   }
 
   lifecycle {
@@ -198,9 +247,8 @@ resource "kubernetes_secret_v1" "yucca_michael" {
     namespace = kubernetes_namespace_v1.yucca[0].metadata[0].name
   }
   data = {
-    JWT_PUBLIC_KEY       = tls_private_key.yucca_jwt[0].public_key_pem
-    S3_ACCESS_KEY_ID     = var.yucca_rgw_access_key_id
-    S3_SECRET_ACCESS_KEY = var.yucca_rgw_secret_access_key
+    JWT_PUBLIC_KEY              = tls_private_key.yucca_jwt[0].public_key_pem
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key[0].base64
   }
 }
 
@@ -217,6 +265,28 @@ resource "kubernetes_secret_v1" "yucca_metrics_rgw" {
   data = {
     AccessKey = var.sietch_metrics_worker_access_key
     SecretKey = var.sietch_metrics_worker_secret_key
+  }
+}
+
+# yucca-api / yucca-admin-api: the RGW user with users+buckets admin caps, used
+# to create one S3 user per repository. Keys are AccessKey/SecretKey to match
+# the charts' radosSecretName lookup, as with yucca-metrics-rgw.
+resource "kubernetes_secret_v1" "yucca_provisioner_rgw" {
+  count = local.provision_secrets ? 1 : 0
+  metadata {
+    name      = "yucca-provisioner-rgw"
+    namespace = kubernetes_namespace_v1.yucca[0].metadata[0].name
+  }
+  data = {
+    AccessKey = var.sietch_provisioner_access_key
+    SecretKey = var.sietch_provisioner_secret_key
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.sietch_provisioner_access_key) > 0 && length(var.sietch_provisioner_secret_key) > 0
+      error_message = "sietch provisioner RGW keys are empty — run applies through tf/op-run.sh."
+    }
   }
 }
 

--- a/tf/deployment/staging/austin/talos/variables.tf
+++ b/tf/deployment/staging/austin/talos/variables.tf
@@ -210,3 +210,16 @@ variable "clusters" {
     config_patches = optional(list(string), [])
   }))
 }
+
+variable "sietch_provisioner_access_key" {
+  description = "Sietch RGW admin access key for the yucca APIs (creates one S3 user per repository)."
+  type        = string
+  default     = ""
+}
+
+variable "sietch_provisioner_secret_key" {
+  description = "Sietch RGW admin secret key for the yucca APIs."
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
Every repository gets its own RGW user, sealed into its restic token, so michael no longer holds a cluster-wide S3 credential.

- `main` <!-- branch-stack -->
  - \#433
    - \#431 :point\_left:
