### PR TITLE
feat(ceph): provisioner RGW user for per-repository S3 credentials

### DIFF
--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -388,6 +388,25 @@ ceph_rgw_metrics_user_access_key: "{{ vault_metrics_worker_access_key }}"
 ceph_rgw_metrics_user_secret_key: "{{ vault_metrics_worker_secret_key }}"
 ceph_rgw_metrics_user_caps: "buckets=read;usage=read;metadata=read;users=read"
 
+# Provisioner RGW admin (read-write): yucca-api creates one S3 user per
+# repository with it. Keys are TF-minted (SPICE_PROVISIONER_*) and injected via
+# secrets.yml.tpl as vault_provisioner_*; rgw.yml (Step 14.6) creates the user.
+# Mirror of the sietch definition.
+ceph_rgw_provisioner_user_uid: yucca-provisioner
+ceph_rgw_provisioner_user_display_name: "yucca/api RGW admin (per-repository users)"
+ceph_rgw_provisioner_user_access_key: "{{ vault_provisioner_access_key }}"
+ceph_rgw_provisioner_user_secret_key: "{{ vault_provisioner_secret_key }}"
+ceph_rgw_provisioner_user_caps: "users=*"
+
+# Migrator RGW admin: bucket ops only, for `yuctl repos migrate-storage-credentials`.
+# Keys are TF-minted (SPICE_MIGRATOR_*) and read from 1Password by the operator —
+# deliberately never mounted into the cluster, unlike the provisioner.
+ceph_rgw_migrator_user_uid: yucca-migrator
+ceph_rgw_migrator_user_display_name: "yucca/migration RGW admin (bucket ops)"
+ceph_rgw_migrator_user_access_key: "{{ vault_migrator_access_key }}"
+ceph_rgw_migrator_user_secret_key: "{{ vault_migrator_secret_key }}"
+ceph_rgw_migrator_user_caps: "buckets=*"
+
 # === Monitoring Stack ===
 ceph_prometheus_port: 9095
 ceph_grafana_port: 3000

--- a/ansible/ceph/inventories/staging-austin/sietch/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/staging-austin/sietch/group_vars/all/vars.yml
@@ -112,6 +112,24 @@ ceph_rgw_metrics_user_access_key: "{{ vault_metrics_worker_access_key }}"
 ceph_rgw_metrics_user_secret_key: "{{ vault_metrics_worker_secret_key }}"
 ceph_rgw_metrics_user_caps: "buckets=read;usage=read;metadata=read;users=read"
 
+# Provisioner RGW admin (read-write). Keys TF-minted in 1P
+# (SIETCH_PROVISIONER_{ACCESS,SECRET}_KEY); yucca-api creates one S3 user per
+# repository with it, which is the credential michael no longer carries.
+ceph_rgw_provisioner_user_uid: yucca-provisioner
+ceph_rgw_provisioner_user_display_name: "yucca/api RGW admin (per-repository users)"
+ceph_rgw_provisioner_user_access_key: "{{ vault_provisioner_access_key }}"
+ceph_rgw_provisioner_user_secret_key: "{{ vault_provisioner_secret_key }}"
+ceph_rgw_provisioner_user_caps: "users=*"
+
+# Migrator RGW admin: bucket ops only, for `yuctl repos migrate-storage-credentials`.
+# Keys are TF-minted (SIETCH_MIGRATOR_*) and read from 1Password by the operator —
+# deliberately never mounted into the cluster, unlike the provisioner.
+ceph_rgw_migrator_user_uid: yucca-migrator
+ceph_rgw_migrator_user_display_name: "yucca/migration RGW admin (bucket ops)"
+ceph_rgw_migrator_user_access_key: "{{ vault_migrator_access_key }}"
+ceph_rgw_migrator_user_secret_key: "{{ vault_migrator_secret_key }}"
+ceph_rgw_migrator_user_caps: "buckets=*"
+
 # --- RGW DNS + TLS ---
 # Virtual-hosted S3 support: setting rgw_dns_name tells RGW to strip this
 # suffix from the Host header and treat the remainder as the bucket name.

--- a/ansible/ceph/roles/ceph_deploy/tasks/rgw.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/rgw.yml
@@ -917,6 +917,101 @@
   register: metrics_caps
   changed_when: "'CHANGED' in metrics_caps.stdout"
 
+# --- Step 14.6: Provisioner RGW admin user (read-write) ---
+#
+# The RGW admin the yucca APIs use to create one S3 user per repository, so a
+# restic token can carry credentials scoped to its own bucket and michael needs
+# none of its own. Keys are TF-minted in 1P
+# (<CLUSTER>_PROVISIONER_{ACCESS,SECRET}_KEY). max-buckets=0: this user manages
+# other users' buckets through the admin API and owns none itself.
+
+- name: Check if provisioner RGW user exists
+  ansible.builtin.command: "radosgw-admin user info --uid={{ ceph_rgw_provisioner_user_uid }}"
+  register: provisioner_user_check
+  when: inventory_hostname in groups['ceph_bootstrap']
+  changed_when: false
+  failed_when: false
+
+- name: Create provisioner RGW user with predetermined keys for {{ ceph_rgw_provisioner_user_uid }}
+  ansible.builtin.command: >
+    radosgw-admin user create
+    --uid={{ ceph_rgw_provisioner_user_uid }}
+    --display-name='{{ ceph_rgw_provisioner_user_display_name }}'
+    --access-key='{{ ceph_rgw_provisioner_user_access_key }}'
+    --secret-key='{{ ceph_rgw_provisioner_user_secret_key }}'
+    --max-buckets=0
+  register: provisioner_user_create
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - provisioner_user_check.rc != 0
+  changed_when: true
+  no_log: true
+
+- name: Ensure provisioner RGW user has users and buckets admin caps
+  ansible.builtin.shell: |
+    set -o pipefail
+    CAPS=$(radosgw-admin user info --uid={{ ceph_rgw_provisioner_user_uid }} --format json 2>/dev/null \
+      | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('caps',[])))")
+    if [ "$CAPS" -lt 1 ]; then
+      radosgw-admin caps add --uid={{ ceph_rgw_provisioner_user_uid }} \
+        --caps='{{ ceph_rgw_provisioner_user_caps }}' >/dev/null 2>&1
+      echo "CHANGED"
+    else
+      echo "OK"
+    fi
+  args:
+    executable: /bin/bash
+  when: inventory_hostname in groups['ceph_bootstrap']
+  register: provisioner_caps
+  changed_when: "'CHANGED' in provisioner_caps.stdout"
+
+# --- Step 14.7: Migrator RGW admin user (bucket ops) ---
+#
+# Hands buckets over to their repository's user during
+# `yuctl repos migrate-storage-credentials`. Split from the provisioner so the
+# credential the APIs hold online cannot touch buckets at all; this one lives in
+# 1Password and is only ever used by an operator.
+
+- name: Check if migrator RGW user exists
+  ansible.builtin.command: "radosgw-admin user info --uid={{ ceph_rgw_migrator_user_uid }}"
+  register: migrator_user_check
+  when: inventory_hostname in groups['ceph_bootstrap']
+  changed_when: false
+  failed_when: false
+
+- name: Create migrator RGW user with predetermined keys for {{ ceph_rgw_migrator_user_uid }}
+  ansible.builtin.command: >
+    radosgw-admin user create
+    --uid={{ ceph_rgw_migrator_user_uid }}
+    --display-name='{{ ceph_rgw_migrator_user_display_name }}'
+    --access-key='{{ ceph_rgw_migrator_user_access_key }}'
+    --secret-key='{{ ceph_rgw_migrator_user_secret_key }}'
+    --max-buckets=0
+  register: migrator_user_create
+  when:
+    - inventory_hostname in groups['ceph_bootstrap']
+    - migrator_user_check.rc != 0
+  changed_when: true
+  no_log: true
+
+- name: Ensure migrator RGW user has bucket admin caps
+  ansible.builtin.shell: |
+    set -o pipefail
+    CAPS=$(radosgw-admin user info --uid={{ ceph_rgw_migrator_user_uid }} --format json 2>/dev/null \
+      | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('caps',[])))")
+    if [ "$CAPS" -lt 1 ]; then
+      radosgw-admin caps add --uid={{ ceph_rgw_migrator_user_uid }} \
+        --caps='{{ ceph_rgw_migrator_user_caps }}' >/dev/null 2>&1
+      echo "CHANGED"
+    else
+      echo "OK"
+    fi
+  args:
+    executable: /bin/bash
+  when: inventory_hostname in groups['ceph_bootstrap']
+  register: migrator_caps
+  changed_when: "'CHANGED' in migrator_caps.stdout"
+
 # --- Step 15: Converge S3 user keys to the 1P canonical key (gated rotation) ---
 #
 # For clusters that predate the predetermined-keys pattern, the user exists

--- a/tf/deployment/prod/htz-fsn1/ceph/discovery.tf
+++ b/tf/deployment/prod/htz-fsn1/ceph/discovery.tf
@@ -38,6 +38,25 @@ output "discovery" {
           access_key = "op://${local._ceph_vaults[k]}/${m.secrets.metrics_worker_access}/password"
           secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.metrics_worker_secret}/password"
         }
+        # Full users+buckets RGW admin, used by the yucca APIs to create one S3
+        # user per repository and by `yuctl repos migrate-storage-credentials`.
+        # The S3 user that owns every bucket created before per-repository
+        # credentials existed; `yuctl repos migrate-storage-credentials` signs
+        # the bucket-ownership call with it before handing the bucket over.
+        s3_owner_cred_refs = {
+          access_key = "op://${local._ceph_vaults[k]}/${m.secrets.s3_restic_access}/password"
+          secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.s3_restic_secret}/password"
+        }
+        # Bucket ops for `yuctl repos migrate-storage-credentials`; never mounted
+        # into the cluster, unlike the provisioner.
+        s3_migrator_cred_refs = {
+          access_key = "op://${local._ceph_vaults[k]}/${m.secrets.migrator_access}/password"
+          secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.migrator_secret}/password"
+        }
+        s3_provisioner_cred_refs = {
+          access_key = "op://${local._ceph_vaults[k]}/${m.secrets.provisioner_access}/password"
+          secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.provisioner_secret}/password"
+        }
         secret_item_titles = m.secrets
         bootstrap_host     = m.bootstrap_host.hostname_short
       }

--- a/tf/deployment/prod/htz-fsn1/ceph/secrets.tf
+++ b/tf/deployment/prod/htz-fsn1/ceph/secrets.tf
@@ -32,13 +32,17 @@ locals {
 
   # Per-role generated-password length. ops is the break-glass account typed by
   # hand at the KVM/console, so keep it short; dashboard/grafana are web logins
-  # (paste-friendly) and stay long. The metrics-worker RGW keys follow the
-  # AWS/RGW key shape (20-char access id, 40-char secret). Roles not listed use
+  # (paste-friendly) and stay long. The metrics-worker and provisioner RGW keys
+  # follow the AWS/RGW key shape (20-char access id, 40-char secret). Roles not listed use
   # the default.
   ceph_password_length = {
     ops                   = 16
     metrics_worker_access = 20
     metrics_worker_secret = 40
+    provisioner_access    = 20
+    provisioner_secret    = 40
+    migrator_access       = 20
+    migrator_secret       = 40
   }
   ceph_password_default_length = 32
 

--- a/tf/deployment/staging/austin/ceph/discovery.tf
+++ b/tf/deployment/staging/austin/ceph/discovery.tf
@@ -38,6 +38,25 @@ output "discovery" {
           access_key = "op://${local._ceph_vaults[k]}/${m.secrets.metrics_worker_access}/password"
           secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.metrics_worker_secret}/password"
         }
+        # Full users+buckets RGW admin, used by the yucca APIs to create one S3
+        # user per repository and by `yuctl repos migrate-storage-credentials`.
+        # The S3 user that owns every bucket created before per-repository
+        # credentials existed; `yuctl repos migrate-storage-credentials` signs
+        # the bucket-ownership call with it before handing the bucket over.
+        s3_owner_cred_refs = {
+          access_key = "op://${local._ceph_vaults[k]}/${m.secrets.s3_restic_access}/password"
+          secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.s3_restic_secret}/password"
+        }
+        # Bucket ops for `yuctl repos migrate-storage-credentials`; never mounted
+        # into the cluster, unlike the provisioner.
+        s3_migrator_cred_refs = {
+          access_key = "op://${local._ceph_vaults[k]}/${m.secrets.migrator_access}/password"
+          secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.migrator_secret}/password"
+        }
+        s3_provisioner_cred_refs = {
+          access_key = "op://${local._ceph_vaults[k]}/${m.secrets.provisioner_access}/password"
+          secret_key = "op://${local._ceph_vaults[k]}/${m.secrets.provisioner_secret}/password"
+        }
         secret_item_titles = m.secrets
         bootstrap_host     = m.bootstrap_host.hostname_short
       }

--- a/tf/deployment/staging/austin/ceph/secrets.tf
+++ b/tf/deployment/staging/austin/ceph/secrets.tf
@@ -28,13 +28,17 @@ locals {
 
   # Per-role generated-password length. ops is the break-glass account typed by
   # hand at the KVM/console, so keep it short; dashboard/grafana are web logins
-  # (paste-friendly) and stay long. The metrics-worker RGW keys follow the
-  # AWS/RGW key shape (20-char access id, 40-char secret). Roles not listed use
+  # (paste-friendly) and stay long. The metrics-worker and provisioner RGW keys
+  # follow the AWS/RGW key shape (20-char access id, 40-char secret). Roles not listed use
   # the default.
   ceph_password_length = {
     ops                   = 16
     metrics_worker_access = 20
     metrics_worker_secret = 40
+    provisioner_access    = 20
+    provisioner_secret    = 40
+    migrator_access       = 20
+    migrator_secret       = 40
   }
   ceph_password_default_length = 32
 

--- a/tf/shared/modules/ceph-cluster/main.tf
+++ b/tf/shared/modules/ceph-cluster/main.tf
@@ -80,6 +80,15 @@ locals {
     # 1P contract, which is named by cluster, not by the ceph subsystem.
     metrics_worker_access = "${upper(var.cluster_name)}_METRICS_WORKER_ACCESS_KEY"
     metrics_worker_secret = "${upper(var.cluster_name)}_METRICS_WORKER_SECRET_KEY"
+    # RGW admin (users + buckets) keys for the yucca APIs, which create one S3
+    # user per repository. Titled by cluster for the same reason as the
+    # metrics-worker pair above.
+    provisioner_access = "${upper(var.cluster_name)}_PROVISIONER_ACCESS_KEY"
+    provisioner_secret = "${upper(var.cluster_name)}_PROVISIONER_SECRET_KEY"
+    # Bucket-only RGW admin for the storage-credential migration. Split from the
+    # provisioner so the credential the APIs hold online cannot reach buckets.
+    migrator_access = "${upper(var.cluster_name)}_MIGRATOR_ACCESS_KEY"
+    migrator_secret = "${upper(var.cluster_name)}_MIGRATOR_SECRET_KEY"
     },
     # Alertmanager receiver URL. Opt-in per cluster, and provisioned OUT OF BAND:
     # the value is an externally-issued webhook (Zulip/Opsgenie/etc), not a

--- a/tf/shared/modules/ceph-cluster/templates/secrets.yml.tpl.tftpl
+++ b/tf/shared/modules/ceph-cluster/templates/secrets.yml.tpl.tftpl
@@ -16,6 +16,10 @@ vault_s3_restic_access_key: op://${vault}/${secrets.s3_restic_access}/password
 vault_s3_restic_secret_key: op://${vault}/${secrets.s3_restic_secret}/password
 vault_metrics_worker_access_key: op://${vault}/${secrets.metrics_worker_access}/password
 vault_metrics_worker_secret_key: op://${vault}/${secrets.metrics_worker_secret}/password
+vault_provisioner_access_key: op://${vault}/${secrets.provisioner_access}/password
+vault_provisioner_secret_key: op://${vault}/${secrets.provisioner_secret}/password
+vault_migrator_access_key: op://${vault}/${secrets.migrator_access}/password
+vault_migrator_secret_key: op://${vault}/${secrets.migrator_secret}/password
 %{ if contains(keys(secrets), "alertmanager_webhook") ~}
 vault_alertmanager_webhook_url: op://${vault}/${secrets.alertmanager_webhook}/password
 %{ endif ~}


### PR DESCRIPTION
Mints the users+buckets RGW admin the APIs will create one S3 user per repository with; nothing consumes it yet.

- `main` <!-- branch-stack -->
  - \#433 :point\_left:
    - \#437
      - \#438
        - \#439
          - \#440
            - \#441
              - \#442
                - \#446
