### PR TITLE
perf(ci): stop the integration and e2e jobs waiting on rook-ceph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,20 +72,23 @@ jobs:
           # mise downloads tools from GitHub releases; anonymous requests hit
           # API rate limits with four parallel jobs.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: mise prepare
-
-      # The stack (Ceph image, dev images, k3s) is heavy; the stock runner has
-      # ~14GB free, so drop the biggest unused toolchains up front.
+      # The stack (dev images, k3s) is heavy; the stock runner has ~14GB free,
+      # so drop the biggest unused toolchains up front.
       - name: Free runner disk space
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
 
-      # Tests boot the apps on the runner; only the infra (CNPG postgres, Ceph
-      # RGW, mock-oidc, victoria) comes from the cluster — so skip the four
-      # heavy app images entirely.
-      - name: Stand up k3d infra
+      # Cluster bring-up and the workspace install touch none of the same files,
+      # so they overlap. Only @common/server is built: the suites run from
+      # TypeScript source via ts-jest, so `mise prepare`'s other packages are
+      # never loaded here.
+      - name: Stand up k3d infra, install deps and build shared libs
         run: |
-          mise k3d:up
-          mise tilt:ci-infra
+          ( mise k3d:up && mise tilt:ci-infra ) > /tmp/k3d-infra.log 2>&1 &
+          infra=$!
+          mise run install:frozen
+          mise run common:server:build
+          wait "$infra" || { echo "::error::k3d infra failed"; cat /tmp/k3d-infra.log; exit 1; }
+          echo "::group::k3d infra log"; cat /tmp/k3d-infra.log; echo "::endgroup::"
 
       - name: Run integration tests against the cluster
         run: mise test:integration:k3d
@@ -94,6 +97,11 @@ jobs:
     name: End-to-end Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      # restic runs on the runner, so yucca-api must advertise a localhost
+      # rest_url; rendering it that way up front spares a yucca-api rollout.
+      YUCCA_TOPOLOGY_LOCAL_REST: '1'
+      YUCCA_E2E_PREBUILT: '1'
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
@@ -105,22 +113,37 @@ jobs:
           # mise downloads tools from GitHub releases; anonymous requests hit
           # API rate limits with four parallel jobs.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: mise prepare
-
       - name: Free runner disk space
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
 
-      - name: Install Playwright browser
-        run: pnpm --filter web exec playwright install --with-deps chromium
+      - name: Create the k3d cluster
+        run: mise k3d:up
 
-      # Full stack on k3d, then the whole e2e surface — the jest suites
-      # (it-works, restic-api, yucca-api, orchestration-api) AND the web
-      # Playwright test — via the same runner developers use locally.
-      # orchestration-api runs as a separate host process by design.
-      - name: Stand up the full k3d stack
+      # Rook-Ceph converging is the long pole of this job and is nearly all
+      # waiting. `tilt:ci-ceph` builds no images, so unlike the full stack it
+      # never tars the workspace and cannot race the build writing into it —
+      # which is what makes running these together safe.
+      - name: Start Ceph converging while installing deps and Playwright
         run: |
-          mise k3d:up
-          mise tilt:ci
+          ( mise tilt:ci-ceph ) > /tmp/k3d-ceph.log 2>&1 &
+          ceph=$!
+          mise run install:frozen
+          pnpm --filter web exec playwright install --with-deps chromium > /tmp/playwright.log 2>&1 &
+          playwright=$!
+          mise run build
+          wait "$playwright" || { echo "::error::playwright install failed"; cat /tmp/playwright.log; exit 1; }
+          wait "$ceph" || { echo "::error::Ceph failed to converge"; cat /tmp/k3d-ceph.log; exit 1; }
+          echo "::group::Ceph bring-up log"; cat /tmp/k3d-ceph.log; echo "::endgroup::"
+
+      # Images build here while Rook finishes; yucca-michael mounts the
+      # object-user Secret, so this is where the job blocks on Ceph serving S3.
+      - name: Deploy the app stack
+        run: mise tilt:ci-e2e
+
+      # Here rather than in the integration job because this stack already runs
+      # Ceph, and standing a second one up there cost more than its whole suite.
+      - name: Run S3-backed integration tests against the cluster
+        run: mise test:integration:s3
 
       - name: Run end-to-end tests against the cluster
         run: mise test:e2e:k3d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,10 @@ jobs:
 
   e2e:
     name: End-to-end Tests
-    runs-on: ubuntu-latest
+    # This job hosts the whole k3d stack — Ceph, postgres, michael, a vite dev
+    # server — and runs restic against it. Both halves are CPU-bound, so the
+    # 4-vCPU hosted runner starved them; pokedex-large is 8 cores / 32 GB.
+    runs-on: pokedex-large
     timeout-minutes: 60
     env:
       # restic runs on the runner, so yucca-api must advertise a localhost
@@ -113,8 +116,10 @@ jobs:
           # mise downloads tools from GitHub releases; anonymous requests hit
           # API rate limits with four parallel jobs.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Paths from the GitHub-hosted image; absent on a self-hosted runner, and
+      # -n so a runner without passwordless sudo fails instead of hanging.
       - name: Free runner disk space
-        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+        run: sudo -n rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
 
       - name: Create the k3d cluster
         run: mise k3d:up

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -52,7 +52,9 @@ depends = ["*:test"]
 description = "Run all integration tests"
 # NB: mise flags must precede the task pattern — anything after it is forwarded
 # to the tasks themselves (jest/go test choke on a stray --jobs).
-run = "mise run --jobs 1 '*:test:integration'"
+# Both depths: `*` does not cross `:`, so the first pattern alone silently
+# skipped yucca-sdk:orchestration-api:test:integration.
+run = "mise run --jobs 1 '*:test:integration' ::: '*:*:test:integration'"
 
 [tasks."test:e2e:web"]
 description = "Run all web e2e tests"

--- a/.mise/tasks/test/integration/k3d
+++ b/.mise/tasks/test/integration/k3d
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-#MISE description="Run all integration tests against the local k3d stack's infra"
+#MISE description="Run the database-backed integration tests against the local k3d stack's infra"
 #MISE dir="{{config_root}}"
 # Kube replacement for the compose-backed `mise docker:start && mise test:integration`:
 # the tests boot the apps on this host but take their infrastructure — postgres
-# (CNPG), S3 (Ceph RGW), the OIDC provider and the victoria pair — from the k3d
-# cluster, port-forwarded to the same localhost ports the compose flow used.
+# (CNPG), the OIDC provider and the victoria pair — from the k3d cluster,
+# port-forwarded to the same localhost ports the compose flow used.
+#
+# The S3-backed suites live in `mise test:integration:s3` instead, against the
+# e2e stack's Ceph RGW — keeping Ceph out of here is what makes this quick.
 #
 # Prereq: mise k3d:up && mise tilt:ci-infra   (apps not required)
 set -euo pipefail
@@ -20,23 +23,21 @@ trap cleanup EXIT
 
 wait_for() {
   local desc="$1"; shift
-  for _ in $(seq 1 60); do "$@" >/dev/null 2>&1 && return 0; sleep 5; done
+  for _ in $(seq 1 150); do "$@" >/dev/null 2>&1 && return 0; sleep 2; done
   echo "timed out waiting for $desc" >&2; return 1
 }
 
-echo "==> wait for infra (tilt ci-infra returns before Rook mints the S3 user)"
+echo "==> wait for infra"
 wait_for "CNPG cluster Ready"  kubectl -n yucca wait --for=condition=Ready cluster/yucca-db --timeout=5s
-wait_for "Ceph S3 user secret" kubectl -n yucca get secret rook-ceph-object-user-yucca-michael
 wait_for "mock-oidc Available" kubectl -n yucca wait --for=condition=Available deploy/yucca-mock-oidc --timeout=5s
 
 echo "==> port-forward infra to the localhost ports the tests expect"
-kubectl port-forward -n yucca     svc/yucca-db-rw          15432:5432 >/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
-kubectl port-forward -n rook-ceph svc/rook-ceph-rgw-yucca  9000:80   >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
-kubectl port-forward -n yucca     svc/yucca-mock-oidc      8092:8092 >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
-kubectl port-forward -n yucca     svc/victoria-metrics     8428:8428 >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
-kubectl port-forward -n yucca     svc/victoria-logs        9428:9428 >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/yucca-db-rw      15432:5432 >/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/yucca-mock-oidc   8092:8092 >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/victoria-metrics  8428:8428 >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/victoria-logs     9428:9428 >>/tmp/yucca-int-pf.log 2>&1 & PF_PIDS+=($!)
 probe() { (exec 3<>"/dev/tcp/localhost/$1") 2>/dev/null; }
-for port in 15432 9000 8092; do
+for port in 15432 8092; do
   wait_for "localhost:$port" probe "$port"
 done
 
@@ -48,22 +49,6 @@ POSTGRES_PASSWORD="$(kubectl -n yucca get secret yucca-db-app -o jsonpath='{.dat
 POSTGRES_DATABASE="$(kubectl -n yucca get secret yucca-db-app -o jsonpath='{.data.dbname}' | base64 -d)"
 export POSTGRES_HOST POSTGRES_PORT POSTGRES_USERNAME POSTGRES_PASSWORD POSTGRES_DATABASE
 
-S3_ENDPOINT=http://localhost:9000
-S3_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.AccessKey}' | base64 -d)"
-S3_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.SecretKey}' | base64 -d)"
-S3_REGION=us-east-1
-S3_FORCE_PATH_STYLE=true
-export S3_ENDPOINT S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_REGION S3_FORCE_PATH_STYLE
-
-if kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics >/dev/null 2>&1; then
-  RADOS_ENDPOINT=http://localhost:9000
-  RADOS_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.AccessKey}' | base64 -d)"
-  RADOS_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.SecretKey}' | base64 -d)"
-  export RADOS_ENDPOINT RADOS_ACCESS_KEY_ID RADOS_SECRET_ACCESS_KEY
-else
-  echo "==> rook-ceph-object-user-yucca-metrics not found; RGW integration tests will skip"
-fi
-
 # The deployed mock-oidc advertises its in-cluster name as the issuer; the dns
 # preload resolves it to the port-forward for every node process (jest + the
 # apps it boots). Same split-horizon glue as the e2e runner.
@@ -71,5 +56,10 @@ export OIDC_ISSUER=http://yucca-mock-oidc:8092
 export OIDC_DEVICE_ISSUER=http://yucca-mock-oidc:8092
 export NODE_OPTIONS="--require $PWD/packages/e2e/k3d/hostmap.cjs${NODE_OPTIONS:+ ${NODE_OPTIONS}}"
 
-echo "==> run the integration suites"
-mise run test:integration
+echo "==> run the database-backed integration suites"
+# yucca-api and yucca-admin-api are serial against each other: both reset the
+# same tables between tests. orchestration-api needs no infrastructure at all
+# and rides along here because this is where integration suites are expected to
+# run — the glob in `mise test:integration` had never matched its task name.
+mise run --jobs 1 yucca-api:test:integration ::: yucca-admin-api:test:integration
+mise run yucca-sdk:orchestration-api:test:integration

--- a/.mise/tasks/test/integration/s3
+++ b/.mise/tasks/test/integration/s3
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#MISE description="Run the S3-backed integration tests against the k3d stack's Ceph RGW"
+#MISE dir="{{config_root}}"
+# The other half of `mise test:integration:k3d`: the suites needing object
+# storage rather than (or as well as) postgres. They run in the e2e job, where
+# Rook-Ceph is already up — a second Ceph in the integration job cost more than
+# that job's whole suite.
+#
+# yucca-metrics-worker's RadosGW suite needs the admin ops API, which only Ceph
+# has; it skipped silently on every run before this.
+#
+# Prereq: mise k3d:up && mise tilt:ci-e2e
+set -euo pipefail
+
+[ "$(kubectl config current-context)" = "k3d-yucca" ] || {
+  echo "Not on k3d-yucca. Run: mise k3d:up && mise tilt:ci-e2e" >&2; exit 1; }
+
+PF_PIDS=()
+cleanup() {
+  for p in "${PF_PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done
+}
+trap cleanup EXIT
+
+wait_for() {
+  local desc="$1"; shift
+  for _ in $(seq 1 150); do "$@" >/dev/null 2>&1 && return 0; sleep 2; done
+  echo "timed out waiting for $desc" >&2; return 1
+}
+
+echo "==> wait for the Ceph object users and the database"
+wait_for "michael S3 user" kubectl -n yucca get secret rook-ceph-object-user-yucca-michael
+wait_for "metrics S3 user" kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics
+wait_for "CNPG cluster Ready" kubectl -n yucca wait --for=condition=Ready cluster/yucca-db --timeout=5s
+
+echo "==> port-forward the RGW and the database"
+kubectl port-forward -n rook-ceph svc/rook-ceph-rgw-yucca 9000:80    >/tmp/yucca-s3-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca     svc/yucca-db-rw         15432:5432 >>/tmp/yucca-s3-pf.log 2>&1 & PF_PIDS+=($!)
+probe() { (exec 3<>"/dev/tcp/localhost/$1") 2>/dev/null; }
+for port in 9000 15432; do
+  wait_for "localhost:$port" probe "$port"
+done
+
+echo "==> export cluster credentials (the per-package env files only set defaults)"
+POSTGRES_HOST=localhost
+POSTGRES_PORT=15432
+POSTGRES_USERNAME="$(kubectl -n yucca get secret yucca-db-app -o jsonpath='{.data.username}' | base64 -d)"
+POSTGRES_PASSWORD="$(kubectl -n yucca get secret yucca-db-app -o jsonpath='{.data.password}' | base64 -d)"
+POSTGRES_DATABASE="$(kubectl -n yucca get secret yucca-db-app -o jsonpath='{.data.dbname}' | base64 -d)"
+export POSTGRES_HOST POSTGRES_PORT POSTGRES_USERNAME POSTGRES_PASSWORD POSTGRES_DATABASE
+
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.AccessKey}' | base64 -d)"
+S3_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.SecretKey}' | base64 -d)"
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
+export S3_ENDPOINT S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_REGION S3_FORCE_PATH_STYLE
+
+RADOS_ENDPOINT=http://localhost:9000
+RADOS_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.AccessKey}' | base64 -d)"
+RADOS_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.SecretKey}' | base64 -d)"
+export RADOS_ENDPOINT RADOS_ACCESS_KEY_ID RADOS_SECRET_ACCESS_KEY
+
+echo "==> run the S3-backed integration suites"
+# Concurrent: each scopes itself to freshly generated repository/bucket names.
+mise run michael:test:integration ::: restic-api:test:integration ::: yucca-metrics-worker:test:integration

--- a/.mise/tasks/tilt/ci-ceph
+++ b/.mise/tasks/tilt/ci-ceph
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#MISE description="tilt ci for Rook-Ceph only — kicks off the slow, image-build-free half of the e2e stack"
+#MISE dir="{{config_root}}"
+# Rook converging is the long pole of the e2e stack and is almost all waiting.
+# This subset builds no container images, so it never tars the workspace — which
+# is what lets CI run it concurrently with `mise prepare` writing into it.
+#
+# It deliberately returns before Ceph is finished: a CephObjectStoreUser creates
+# no pods, so Tilt calls those resources ready on apply (pod_readiness: ignore).
+# The app image builds in `mise tilt:ci-e2e` then run alongside the rest of the
+# convergence rather than after it, and yucca-michael mounting the object-user
+# Secret is what makes that run block until Ceph really is serving S3.
+set -euo pipefail
+
+if ! kubectl config current-context | grep -q '^k3d-yucca$'; then
+  echo "Current kube context is not k3d-yucca. Run: mise k3d:up" >&2
+  exit 1
+fi
+
+exec tilt ci --timeout 1800s \
+  rook-release-repo helm-deps ceph-image-prepull \
+  rook-ceph-operator rook-ceph-cluster \
+  yucca-object-user yucca-metrics-object-user

--- a/.mise/tasks/tilt/ci-e2e
+++ b/.mise/tasks/tilt/ci-e2e
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#MISE description="tilt ci for the stack the e2e suites exercise (skips yucca-admin-api + yucca-metrics-worker)"
+#MISE dir="{{config_root}}"
+# Everything `packages/e2e` and the web Playwright run touch, plus the Ceph the
+# S3-backed integration suites need. yucca-admin-api and yucca-metrics-worker
+# are out on purpose: no e2e test speaks to either, and each is a full node image
+# build. yucca-metrics-object-user stays — it mints only a Secret, no pod, and
+# `mise test:integration:s3` reads it.
+set -euo pipefail
+
+if ! kubectl config current-context | grep -q '^k3d-yucca$'; then
+  echo "Current kube context is not k3d-yucca. Run: mise k3d:up" >&2
+  exit 1
+fi
+
+exec tilt ci --timeout 1800s \
+  rook-release-repo helm-deps ceph-image-prepull \
+  cloudnative-pg rook-ceph-operator rook-ceph-cluster \
+  yucca-object-user yucca-metrics-object-user \
+  yucca-database yucca-mock-oidc \
+  yucca-victoria-metrics yucca-victoria-logs \
+  yucca-topology yucca-michael yucca-api yucca-web yucca-meta

--- a/.mise/tasks/tilt/ci-infra
+++ b/.mise/tasks/tilt/ci-infra
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-#MISE description="tilt ci for the infra subset only (no app images) — what integration tests need"
+#MISE description="tilt ci for the infra the database-backed integration tests need (no app images, no Ceph)"
 #MISE dir="{{config_root}}"
-# The closure of every non-app resource: chart repos, operators, the Ceph dev
-# cluster + RGW user, CNPG database, mock-oidc and the victoria pair. Skipping
-# the four heavy app images (yucca-api/admin/web/michael) saves ~10 min in CI;
-# integration tests boot those apps on the host themselves.
+# The closure of what `mise test:integration:k3d` consumes: chart repos, the
+# CNPG operator + database, mock-oidc and the victoria pair. Two absences are
+# deliberate:
+#
+#   - the four app images (yucca-api/admin/web/michael) — those tests boot the
+#     apps on the host themselves;
+#   - Rook-Ceph — converging it took longer than every test in the job put
+#     together, and nothing left here talks to S3. The S3-backed suites run
+#     against the e2e stack's real RGW instead (mise test:integration:s3).
 set -euo pipefail
 
 if ! kubectl config current-context | grep -q '^k3d-yucca$'; then
@@ -13,7 +18,5 @@ if ! kubectl config current-context | grep -q '^k3d-yucca$'; then
 fi
 
 exec tilt ci --timeout 1800s \
-  rook-release-repo helm-deps \
-  cloudnative-pg rook-ceph-operator rook-ceph-cluster \
-  yucca-object-user yucca-database yucca-mock-oidc \
+  helm-deps cloudnative-pg yucca-database yucca-mock-oidc \
   yucca-victoria-metrics yucca-victoria-logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ mise build                # build all packages
 
 mise test                 # all unit tests (jest per NestJS pkg, vitest for web)
 mise test:integration     # integration tests (--jobs 1; needs infra up)
+mise test:integration:k3d # CI split: the database-backed suites; :s3 = the Ceph-backed ones
 mise test:e2e             # e2e (needs the stack running); mise test:e2e:web = Playwright
 mise <pkg>:test           # one package; args after -- go to jest: mise yucca-api:test -- -t "name"
 
@@ -62,9 +63,14 @@ mise yucca-api:migrations <args>   # DB migrations (@immich/sql-tools; yucca-api
 ### k3d + Tilt (prod-shaped dev)
 
 `mise k3d:up` → `mise tilt:up` (build images, render charts from `kubernetes/apps/dev/local`,
-port-forward, live_update); `tilt:down` / `k3d:down` to tear down. CI uses `mise tilt:ci-infra`
-(integration) and `mise tilt:ci` (e2e). Tilt's source of truth is the Flux tree under
-`kubernetes/` — see the extensively commented `Tiltfile`.
+port-forward, live_update); `tilt:down` / `k3d:down` to tear down. Tilt's source of truth is the
+Flux tree under `kubernetes/` — see the extensively commented `Tiltfile`.
+
+CI deploys resource subsets rather than the whole stack (`mise tilt:ci` still does everything):
+`tilt:ci-infra` (integration — postgres, mock-oidc, victoria; **no Ceph**), then for e2e
+`tilt:ci-ceph` (Rook only; builds no images, so it converges while the workspace installs)
+followed by `tilt:ci-e2e` (the apps the e2e suites touch). Ceph converging outweighed every test
+in the integration job, so that job dropped it and its S3-backed suites moved to the e2e one.
 
 Ports: `5173` web · `3020` yucca-api · `3030` yucca-admin-api · `3010` michael ·
 `8092` mock-oidc · `9000` ceph rgw · `8428` victoria-metrics · `9428` victoria-logs.

--- a/Tiltfile
+++ b/Tiltfile
@@ -80,8 +80,40 @@ if DEV_ENV:
 # yucca-metrics-worker mount it and parse it at boot, so it has to exist before
 # they start (see their APP_WIRING deps below).
 # ---------------------------------------------------------------------------
-k8s_yaml('kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml')
+#
+# The e2e runner drives restic from the HOST, so for it the site's rest_url has
+# to name localhost rather than the in-cluster michael. Rendering that variant
+# here spares the runner a ConfigMap patch plus a yucca-api rollout; an
+# interactive `tilt up` leaves the in-cluster name alone.
+TOPOLOGY = str(read_file('kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml'))
+if os.getenv('YUCCA_TOPOLOGY_LOCAL_REST'):
+    TOPOLOGY = TOPOLOGY.replace('http://yucca-michael:3010', 'http://localhost:3010')
+
+k8s_yaml(blob(TOPOLOGY))
 k8s_resource(objects=['yucca-topology:configmap'], new_name='yucca-topology', labels=['app'])
+
+# ---------------------------------------------------------------------------
+# Rook's convergence chain (detect-version, mon, mgr, osd, rgw, object-user
+# Secret) is serialised behind the first pull of the ~490 MB Ceph image, which
+# it only starts once its operator is up. Pulling the same image the moment the
+# cluster exists overlaps that with the chart installs and image builds. Nothing
+# depends on this Job — it is cache warming, and its failure is harmless.
+# ---------------------------------------------------------------------------
+CEPH_IMAGE = read_yaml('charts/platform/rook-ceph-cluster/values.yaml')['cephImage']
+
+k8s_yaml(encode_yaml({
+    'apiVersion': 'batch/v1',
+    'kind': 'Job',
+    'metadata': {'name': 'ceph-image-prepull', 'namespace': 'yucca'},
+    'spec': {
+        'backoffLimit': 0,
+        'template': {'spec': {
+            'restartPolicy': 'Never',
+            'containers': [{'name': 'prepull', 'image': CEPH_IMAGE, 'command': ['true']}],
+        }},
+    },
+}))
+k8s_resource('ceph-image-prepull', labels=['helm'])
 
 # ---------------------------------------------------------------------------
 # Images. Built locally and injected into each app's Helm release via image_keys
@@ -272,10 +304,14 @@ APP_WIRING = {
     # dev_env: receives the .env override Secret (see load_dev_env above).
     # dev_keypair: render the well-known dev JWT fixture into the chart Secret
     # (the chart default is useDevKeypair=false so real overlays fail loudly).
-    'yucca-api':              {'build': 'yucca-api',          'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-michael', 'yucca-topology'], 'dev_env': True, 'dev_keypair': True},
+    # No yucca-michael dep: yucca-api only mints URLs pointing at it, never
+    # calls it at boot. Tilt builds an image only when ready to deploy, so that
+    # edge parked this build (and web's) behind Rook-Ceph instead of alongside.
+    'yucca-api':              {'build': 'yucca-api',          'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-topology'], 'dev_env': True, 'dev_keypair': True},
     'yucca-admin-api':        {'build': 'yucca-admin-api',    'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-topology'], 'dev_keypair': True},
     'yucca-metrics-worker':   {'build': 'yucca-metrics-worker', 'deps': ['yucca-database', 'yucca-metrics-object-user', 'yucca-topology'], 'dev_env': True},
-    'yucca-web':              {'build': 'web',                'deps': ['yucca-api']},
+    # Likewise: the dev server reaches yucca-api per request, not at boot.
+    'yucca-web':              {'build': 'web',                'deps': []},
     # Stock upstream nginx serving the .well-known pointer — nothing to build,
     # nothing to wait for (it's a static file, deliberately independent of the
     # API whose URL it advertises).

--- a/Tiltfile
+++ b/Tiltfile
@@ -21,6 +21,10 @@ load('ext://namespace', 'namespace_create')
 # Gate: only talk to the local k3d cluster. Prevents accidental prod deploys.
 allow_k8s_contexts('k3d-yucca')
 
+# Tilt defaults to 3, which builds the app images in two waves. There are five
+# of them and the CI runner has eight cores, so one wave fits.
+update_settings(max_parallel_updates=6)
+
 namespace_create('yucca')
 
 # ---------------------------------------------------------------------------

--- a/charts/platform/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/charts/platform/rook-ceph-cluster/templates/cephcluster.yaml
@@ -44,3 +44,17 @@ spec:
     daemonHealth:
       mon:
         interval: 45s
+      # Bootstrap is a serial chain — mon, then mgr, then OSD, then the object
+      # store — and the operator only advances it when a status check observes
+      # the previous daemon up. At the 60s default that polling dominates.
+      status:
+        interval: {{ .Values.probes.statusInterval }}
+    # These daemons come up in a couple of seconds, but Rook's default probe
+    # waits 10s and then polls every 10s, so each one rounds up to ~20s of
+    # nothing. Finer granularity, same total budget — see values.yaml.
+    startupProbe:
+{{- range $daemon, $probe := .Values.probes.startup }}
+      {{ $daemon }}:
+        probe:
+{{ toYaml $probe | indent 10 }}
+{{- end }}

--- a/charts/platform/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/charts/platform/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -14,6 +14,15 @@ spec:
       size: 1
       requireSafeReplicaSize: false
   preservePoolsOnDelete: false
+  # Same reasoning as the daemon probes in cephcluster.yaml — the RGW is the
+  # last link in the bootstrap chain and the one the S3 suites wait on.
+  healthCheck:
+    startupProbe:
+      probe:
+{{ toYaml .Values.probes.rgw.startup | indent 8 }}
+    readinessProbe:
+      probe:
+{{ toYaml .Values.probes.rgw.readiness | indent 8 }}
   gateway:
     port: {{ .Values.objectStore.gateway.port }}
     instances: {{ .Values.objectStore.gateway.instances }}

--- a/charts/platform/rook-ceph-cluster/values.yaml
+++ b/charts/platform/rook-ceph-cluster/values.yaml
@@ -11,6 +11,21 @@ mgr:
 dashboard:
   enabled: false
 
+# Bootstrap-latency tuning. Rook's stock probes are sized for real hardware:
+# 10s of initial delay then a 10s poll, which on a dev cluster is almost all of
+# each daemon's startup time. failureThreshold is scaled by the same factor the
+# period shrinks by, so every daemon keeps the total budget it had by default
+# (mon/mgr 10s + 6x10s; osd 10s + 720x10s; rgw 10s + 33x10s).
+probes:
+  statusInterval: 10s
+  startup:
+    mon: { initialDelaySeconds: 2, periodSeconds: 2, failureThreshold: 35 }
+    mgr: { initialDelaySeconds: 2, periodSeconds: 2, failureThreshold: 35 }
+    osd: { initialDelaySeconds: 2, periodSeconds: 2, failureThreshold: 3600 }
+  rgw:
+    startup: { initialDelaySeconds: 2, periodSeconds: 2, failureThreshold: 170 }
+    readiness: { initialDelaySeconds: 2, periodSeconds: 2 }
+
 storage:
   # Rook does NOT auto-select loop devices via useAllDevices (even with
   # allowLoopDevices on the operator) — they must be named explicitly. This is

--- a/kubernetes/apps/dev/local/rook-ceph/rook-ceph-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/rook-ceph/rook-ceph-operator/app/helmrelease.yaml
@@ -21,11 +21,13 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV footprint: object store only needs the bucket provisioner, not CSI.
-    csi:
-      enableRbdDriver: false
-      enableCephfsDriver: false
-    enableDiscoveryDaemon: true
+    # We use this cluster over S3 (RGW) only, but do NOT set
+    # csi.installCsiOperator: false to trim it — Rook still creates a
+    # CephConnection CR whose CRD ships with that subchart, and mon bootstrap
+    # then fails outright. (The csi.enableRbdDriver/enableCephfsDriver keys that
+    # used to sit here don't exist in the v1.20 chart at all.)
+    # The discovery daemon IS unused: the CephCluster names its OSD explicitly.
+    enableDiscoveryDaemon: false
     monitoring:
       enabled: false
     # The dev cluster's OSD runs on a loopback block device (k3d has no spare

--- a/packages/e2e/k3d/run.sh
+++ b/packages/e2e/k3d/run.sh
@@ -8,10 +8,12 @@
 # No /etc/hosts / sudo required:
 #   - the jest suite resolves the in-cluster OIDC issuer host via a dns preload
 #     (hostmap.cjs); the playwright browser via --host-resolver-rules.
-#   - yucca-api's topology is patched (e2e-only) to a localhost rest_url,
-#     because restic runs on this host (the cluster keeps the in-cluster name
-#     for real use); the orchestrator discovers everything through the meta
-#     pod's well-known pointer, exercising the real discovery chain.
+#   - yucca-api's topology must advertise a localhost rest_url, because restic
+#     runs on this host (the cluster keeps the in-cluster name for real use).
+#     `tilt up` with YUCCA_TOPOLOGY_LOCAL_REST=1 renders that variant up front;
+#     otherwise we patch the ConfigMap and restart yucca-api here. Either way
+#     the orchestrator discovers everything through the meta pod's well-known
+#     pointer, exercising the real discovery chain.
 #
 # Prereq: mise k3d:up && mise tilt:up   (cluster healthy, context k3d-yucca)
 set -euo pipefail
@@ -23,14 +25,14 @@ cd "$ROOT"
   echo "Not on k3d-yucca. Run: mise k3d:up && mise tilt:up" >&2; exit 1; }
 
 PF_PIDS=()
-ORCH_PID=""
+ORCH_PGID=""
 cleanup() {
   echo "==> cleanup"
   # Kill only what WE started (a broad pkill would take out the user's own
-  # port-forwards). The orchestrator is a mise->pnpm->node tree, so also match
-  # its exact child command.
-  [ -n "$ORCH_PID" ] && kill "$ORCH_PID" 2>/dev/null || true
-  pkill -f "pnpm --filter @futo-org/backups-orchestrator-api dev" 2>/dev/null || true
+  # port-forwards). Signal the orchestrator's whole process group: it is a
+  # mise->pnpm->ts-node tree, and killing just the head orphans the node process
+  # holding :22676, which then breaks the next run.
+  [ -n "$ORCH_PGID" ] && kill -- "-$ORCH_PGID" 2>/dev/null || true
   for p in "${PF_PIDS[@]:-}"; do kill "$p" 2>/dev/null || true; done
   # Restore the in-cluster rest_url in the topology. If this run is SIGKILLed
   # the override survives — the next run reapplies + reverts it.
@@ -42,49 +44,84 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "==> build workspace libs (sdk consumed by orchestration-api + the e2e)"
-mise run common:build >/dev/null
-mise run yucca-sdk:orchestration-ui:build >/dev/null
+# CI has already built the workspace by this point.
+if [ -z "${YUCCA_E2E_PREBUILT:-}" ]; then
+  echo "==> build workspace libs (sdk consumed by orchestration-api + the e2e)"
+  mise run common:build >/dev/null
+  mise run yucca-sdk:orchestration-ui:build >/dev/null
+fi
 
 echo "==> port-forward k3d services to the e2e host ports"
-kubectl port-forward -n yucca svc/yucca-michael  3010:3010  >/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/yucca-michael   3010:3010  >/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
 kubectl port-forward -n yucca svc/yucca-mock-oidc 8092:8092 >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
 kubectl port-forward -n yucca svc/yucca-meta      8080:8080 >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
 # web on :36033 (orchestration-api + the web e2e target) AND :5173 (yucca-api's
 # OIDC redirect_uri, which the OIDC callback follows).
 kubectl port-forward -n yucca svc/yucca-web      36033:5173 >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
-kubectl port-forward -n yucca svc/yucca-web      5173:5173  >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/yucca-web       5173:5173 >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
 # victoria-logs (:9428) so the telemetry e2e can read back structured logs that
 # yucca-api ships via OTLP.
-kubectl port-forward -n yucca svc/victoria-logs  9428:9428  >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
+kubectl port-forward -n yucca svc/victoria-logs   9428:9428 >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
 
-echo "==> e2e-only: topology rest_url -> localhost (restic runs on this host)"
-ORIG_TOPOLOGY="$(kubectl -n yucca get configmap yucca-topology -o jsonpath='{.data.topology\.json}')"
-kubectl -n yucca create configmap yucca-topology \
-  --from-literal=topology.json="${ORIG_TOPOLOGY//yucca-michael/localhost}" \
-  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
-kubectl -n yucca rollout restart deploy/yucca-api >/dev/null
-kubectl -n yucca rollout status deploy/yucca-api --timeout=120s >/dev/null
+TOPOLOGY="$(kubectl -n yucca get configmap yucca-topology -o jsonpath='{.data.topology\.json}')"
+case "$TOPOLOGY" in
+  *yucca-michael*)
+    echo "==> e2e-only: topology rest_url -> localhost (restic runs on this host)"
+    ORIG_TOPOLOGY="$TOPOLOGY"
+    kubectl -n yucca create configmap yucca-topology \
+      --from-literal=topology.json="${ORIG_TOPOLOGY//yucca-michael/localhost}" \
+      --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    kubectl -n yucca rollout restart deploy/yucca-api >/dev/null
+    kubectl -n yucca rollout status deploy/yucca-api --timeout=120s >/dev/null
+    ;;
+  *)
+    echo "==> topology already advertises a localhost rest_url — no yucca-api restart needed"
+    ;;
+esac
+
+# After the case, never before: on the patching path the restart above replaces
+# the pod, and a forward opened earlier dies with it.
 kubectl port-forward -n yucca svc/yucca-api 3020:3020 >>/tmp/yucca-e2e-pf.log 2>&1 & PF_PIDS+=($!)
-sleep 5
+
+if (exec 3<>/dev/tcp/localhost/22676) 2>/dev/null; then
+  echo "Something is already listening on :22676 — a leftover orchestration-api?" >&2
+  echo "The one we start would fail to bind and the suites would fail on it." >&2
+  exit 1
+fi
 
 echo "==> launch orchestration-api as a separate local process (:22676)"
 # Discovery runs the real chain: meta pod well-known -> /api/meta -> api_root.
+# setsid gives it a process group cleanup can reap whole.
 FUTO_BACKUPS_WELL_KNOWN_URL="http://localhost:8080/.well-known/yucca.json" \
 NODE_OPTIONS="--require $HERE/hostmap.cjs" \
-  mise run yucca-sdk:orchestration-api:dev >/tmp/yucca-e2e-orch.log 2>&1 & ORCH_PID=$!
-for _ in $(seq 1 40); do
-  [ "$(curl -s -o /dev/null -w '%{http_code}' -m2 http://localhost:22676/ 2>/dev/null)" = "404" ] && break
-  sleep 2
-done
+  setsid mise run yucca-sdk:orchestration-api:dev >/tmp/yucca-e2e-orch.log 2>&1 &
+ORCH_PGID="$(ps -o pgid= -p $! 2>/dev/null | tr -d ' ')"
+
+wait_for_http() {
+  local name="$1" url="$2" want="$3"
+  for _ in $(seq 1 90); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' -m2 "$url" 2>/dev/null)" = "$want" ] && return 0
+    sleep 1
+  done
+  echo "timed out waiting for $name at $url" >&2
+  tail -40 /tmp/yucca-e2e-orch.log >&2
+  return 1
+}
+wait_for_http yucca-api http://localhost:3020/api/meta 200
+# Onboarding status, not just any response: it is the first thing the suites
+# call, and only answers once discovery has reached a live yucca-api.
+wait_for_http orchestration-api http://localhost:22676/api/yucca/onboarding 200
 
 echo "==> jest e2e (it-works, restic-api, yucca-api, orchestration-api)"
 # shellcheck disable=SC1091
 source .mise/tasks/restic-api/env
 # shellcheck disable=SC1091
 source .mise/tasks/yucca-api/env
+# One worker per suite file — each scopes itself to its own repositories and
+# users. Not tied to core count: these spend most of their time waiting on the
+# cluster, so they oversubscribe happily on a 4-core runner.
 NODE_OPTIONS="--experimental-vm-modules --require $HERE/hostmap.cjs" \
-  pnpm --filter e2e exec jest --runInBand
+  pnpm --filter e2e exec jest --maxWorkers=4
 
 echo "==> web e2e (playwright against the k3d web)"
 # Config lives in packages/web so @playwright/test resolves from web's deps.

--- a/packages/e2e/k3d/run.sh
+++ b/packages/e2e/k3d/run.sh
@@ -117,11 +117,11 @@ echo "==> jest e2e (it-works, restic-api, yucca-api, orchestration-api)"
 source .mise/tasks/restic-api/env
 # shellcheck disable=SC1091
 source .mise/tasks/yucca-api/env
-# One worker per suite file — each scopes itself to its own repositories and
-# users. Not tied to core count: these spend most of their time waiting on the
-# cluster, so they oversubscribe happily on a 4-core runner.
+# Three, not one per suite: orchestration-api alone runs ~105s and gates the
+# phase, so a fourth worker adds no wall-clock — only a fourth CPU consumer on a
+# runner that is already hosting the cluster these suites drive.
 NODE_OPTIONS="--experimental-vm-modules --require $HERE/hostmap.cjs" \
-  pnpm --filter e2e exec jest --maxWorkers=4
+  pnpm --filter e2e exec jest --maxWorkers=3
 
 echo "==> web e2e (playwright against the k3d web)"
 # Config lives in packages/web so @playwright/test resolves from web's deps.

--- a/packages/e2e/src/restic-api.suite.ts
+++ b/packages/e2e/src/restic-api.suite.ts
@@ -1,0 +1,660 @@
+import {
+  backup,
+  cache,
+  cat,
+  check,
+  copy,
+  diff,
+  dump,
+  find,
+  forget,
+  init,
+  keyAdd,
+  keyList,
+  keyRemove,
+  list,
+  ls,
+  prune,
+  recover,
+  repair,
+  restore,
+  rewrite,
+  snapshots,
+  stats,
+  tag,
+  unlock,
+} from '@futo-org/restic-wrapper';
+import { jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { env } from 'src/env';
+
+const password = 'password';
+
+function generateRepoUrl(repository: string, writeOnce: boolean) {
+  const token = jwt.sign(
+    {
+      user: randomUUID(),
+      repository,
+      writeOnce,
+    },
+    env.JWT_PRIVATE_KEY,
+    { algorithm: 'ES256' },
+  );
+
+  return {
+    token,
+    repoUrl: `rest:http://restic:${token}@localhost:${env.RESTIC_API_PORT}/${repository}/`,
+  };
+}
+
+function generateCase(writeOnce: boolean) {
+  const repository = randomUUID();
+  const { repoUrl } = generateRepoUrl(repository, writeOnce);
+
+  return {
+    repository,
+    repoUrl,
+  };
+}
+
+async function createForgottenSnapshot(workingDir: string, pruneRepoUrl: string) {
+  const file = join(workingDir, `prune-${randomUUID()}.txt`);
+  await writeFile(file, randomUUID());
+
+  const { snapshot_id } = await backup().repository(pruneRepoUrl).password(password).addFile(file).run();
+  await forget().repository(pruneRepoUrl).password(password).snapshot(snapshot_id!).run();
+  return snapshot_id!;
+}
+
+// One spec file per mode rather than a `describe.each` here: jest parallelises
+// across files, never within one, so as a single suite the WORM pass could only
+// start once the plain pass had finished.
+export function describeResticApi(name: string, writeOnce: boolean) {
+  const { repoUrl } = generateCase(writeOnce);
+
+  describe(`${name} (e2e)`, () => {
+    let workingDir: string;
+
+    beforeAll(async () => {
+      // Private to this suite: the two modes run as separate jest workers, and
+      // a shared tmpdir has them overwriting each other's fixtures mid-backup.
+      workingDir = await mkdtemp(join(tmpdir(), 'restic-e2e-'));
+
+      await mkdir(resolve(workingDir, 'folder'), {
+        recursive: true,
+      });
+
+      await writeFile(resolve(workingDir, 'folder', 'test-file'), 'test-file');
+      await writeFile(resolve(workingDir, 'folder', 'hello.json'), '{}');
+
+      await writeFile(join(workingDir, 'pwd'), 'password');
+    });
+
+    describe('init', () => {
+      jest.retryTimes(2);
+
+      it('creates a repository', async () => {
+        await init().repository(repoUrl).password(password).run();
+      }, 10_000);
+    });
+
+    describe('backup', () => {
+      it('creates a backup', async () => {
+        await backup().repository(repoUrl).password(password).addFile(resolve(workingDir, 'folder')).run();
+      });
+    });
+
+    describe('cache', () => {
+      it('returns cache directories', async () => {
+        await expect(cache().repository(repoUrl).password('password').run()).resolves.toEqual(
+          expect.objectContaining({
+            directories: expect.any(Number),
+            table: expect.arrayContaining([
+              expect.objectContaining({
+                'Last Used': expect.any(String),
+                Old: false,
+                'Repo ID': expect.any(String),
+                Size: expect.any(String),
+              }),
+            ]),
+          }),
+        );
+      });
+    });
+
+    describe('cat', () => {
+      it('can read config', async () => {
+        expect(await cat().repository(repoUrl).password(password).target('config').run()).toEqual(
+          expect.objectContaining({
+            version: expect.any(Number),
+          }),
+        );
+      });
+    });
+
+    describe('check', () => {
+      it('can check repository', async () => {
+        expect(await check().repository(repoUrl).password(password).run()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              num_errors: 0,
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('copy', () => {
+      let otherRepoUrl: string;
+
+      beforeEach(async () => {
+        otherRepoUrl = generateCase(writeOnce).repoUrl;
+        await init().repository(otherRepoUrl).password(password).run();
+      }, 10_000);
+
+      it('copies everything to new repository', async () => {
+        await copy()
+          .fromRepo(repoUrl)
+          .fromPasswordFile(join(workingDir, 'pwd'))
+          .repository(otherRepoUrl)
+          .password('password')
+          .run();
+
+        await expect(snapshots().repository(otherRepoUrl).password('password').run()).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              paths: expect.arrayContaining([expect.stringContaining('folder')]),
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('diff', () => {
+      let snapshotA: string;
+      let snapshotB: string;
+
+      beforeEach(async () => {
+        await mkdir(resolve(workingDir, 'diff'), {
+          recursive: true,
+        });
+
+        await writeFile(resolve(workingDir, 'diff', 'test-file'), 'data');
+        await writeFile(resolve(workingDir, 'diff', 'deleted-file'), 'data');
+
+        const { snapshot_id: snapshot_a } = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'diff', 'test-file'))
+          .addFile(resolve(workingDir, 'diff', 'deleted-file'))
+          .run();
+
+        await writeFile(resolve(workingDir, 'diff', 'test-file'), 'changed data');
+        await writeFile(resolve(workingDir, 'diff', 'new-file'), 'new data');
+
+        const { snapshot_id: snapshot_b } = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'diff', 'test-file'))
+          .addFile(resolve(workingDir, 'diff', 'new-file'))
+          .run();
+
+        snapshotA = snapshot_a!;
+        snapshotB = snapshot_b!;
+      });
+
+      it('correctly produces a diff', async () => {
+        await expect(
+          diff().repository(repoUrl).password(password).compare(snapshotA, snapshotB).run(),
+        ).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              path: expect.stringMatching(/deleted-file/),
+              modifier: '-',
+            }),
+            expect.objectContaining({
+              path: expect.stringMatching(/new-file/),
+              modifier: '+',
+            }),
+            expect.objectContaining({
+              path: expect.stringMatching(/test-file/),
+              modifier: 'M',
+            }),
+            expect.objectContaining({
+              source_snapshot: snapshotA,
+              target_snapshot: snapshotB,
+              added: expect.objectContaining({
+                files: 1,
+              }),
+              removed: expect.objectContaining({
+                files: 1,
+              }),
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('dump', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('dumps file to stdout', async () => {
+        const buffer = await dump()
+          .repository(repoUrl)
+          .password('password')
+          .snapshot(snapshotId)
+          .file(join(workingDir, 'folder', 'test-file'))
+          .run();
+
+        expect(buffer.toString()).toBe('test-file');
+      });
+
+      it('dumps folder as tar', async () => {
+        const buffer = await dump()
+          .repository(repoUrl)
+          .password('password')
+          .snapshot(snapshotId)
+          .file(join(workingDir, 'folder'))
+          .run();
+
+        expect(buffer.subarray(257, 262).toString()).toBe('ustar');
+        expect(buffer.length).toBeGreaterThanOrEqual(512);
+      });
+    });
+
+    describe('find', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('finds objects', async () => {
+        await expect(find().repository(repoUrl).password(password).match('*.json').object().run()).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              hits: 1,
+              snapshot: snapshotId,
+              matches: expect.arrayContaining([
+                expect.objectContaining({
+                  path: expect.stringContaining('hello.json'),
+                }),
+              ]),
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('forget', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it(writeOnce ? 'does not forget snapshot' : 'forgets snapshot', async () => {
+        const forgetRun = forget().repository(repoUrl).password(password).snapshot(snapshotId).run();
+        await (writeOnce ? expect(forgetRun).rejects.toThrow() : forgetRun);
+        await expect(snapshots().repository(repoUrl).password(password).run()).resolves.toEqual(
+          writeOnce
+            ? expect.arrayContaining([
+                expect.objectContaining({
+                  id: snapshotId,
+                }),
+              ])
+            : expect.not.arrayContaining([
+                expect.objectContaining({
+                  id: snapshotId,
+                }),
+              ]),
+        );
+      });
+    });
+
+    describe('keyList', () => {
+      it('lists keys', async () => {
+        const keys = await keyList().repository(repoUrl).password(password).run();
+
+        expect(keys.length).toBe(1);
+        expect(keys[0].current).toBeTruthy();
+      });
+    });
+
+    describe('keyAdd & keyRemove', () => {
+      let keyId: string;
+
+      it('adds a new key', async () => {
+        await keyAdd().repository(repoUrl).password(password).newInsecureNoPassword().run();
+
+        const keys = await keyList().repository(repoUrl).insecureNoPassword().run();
+        expect(keys.length).toBe(2);
+
+        keyId = keys.find((key) => key.current)!.id;
+      }, 10_000);
+
+      if (writeOnce) {
+        it('fails to remove the new key', async () => {
+          await expect(keyRemove().repository(repoUrl).password(password).keyId(keyId).run()).rejects.toThrow();
+        });
+      } else {
+        it('removes the new key', async () => {
+          await keyRemove().repository(repoUrl).password(password).keyId(keyId).run();
+
+          const keys = await keyList().repository(repoUrl).password(password).run();
+          expect(keys.length).toBe(1);
+        });
+      }
+    });
+
+    describe('list', () => {
+      it.each(['blobs', 'packs', 'index', 'snapshots', 'keys', 'locks'])('lists %s', async (type) => {
+        const items = await list()
+          .repository(repoUrl)
+          .password('password')
+          .type(type as any)
+          .run();
+
+        expect(Array.isArray(items)).toBe(true);
+      });
+    });
+
+    describe('ls', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('provides a file listing', async () => {
+        await expect(ls().repository(repoUrl).password(password).snapshot(snapshotId).run()).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message_type: 'snapshot',
+              id: snapshotId,
+            }),
+            expect.objectContaining({
+              path: expect.stringContaining('test-file'),
+            }),
+            expect.objectContaining({
+              path: expect.stringContaining('hello.json'),
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('prune', () => {
+      async function createPruneRepo() {
+        const { repoUrl: pruneRepoUrl } = generateCase(writeOnce);
+        await init().repository(pruneRepoUrl).password(password).run();
+        return pruneRepoUrl;
+      }
+
+      if (writeOnce) {
+        it('keeps snapshots after forget and allows no-op prune', async () => {
+          const pruneRepoUrl = await createPruneRepo();
+
+          const file = join(workingDir, `prune-${randomUUID()}.txt`);
+          await writeFile(file, randomUUID());
+          const { snapshot_id: snapshotId } = await backup()
+            .repository(pruneRepoUrl)
+            .password(password)
+            .addFile(file)
+            .run();
+          await expect(
+            forget().repository(pruneRepoUrl).password(password).snapshot(snapshotId!).run(),
+          ).rejects.toThrow();
+
+          const allSnapshots = await snapshots().repository(pruneRepoUrl).password(password).run();
+
+          expect(allSnapshots).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: snapshotId,
+              }),
+            ]),
+          );
+
+          const output = await prune().repository(pruneRepoUrl).password(password).run();
+          expect(output).toMatch(/total prune:\s+0 blobs/);
+        }, 15_000);
+
+        it("can't delete data via prune in WORM repo when prune has work to do", async () => {
+          const repository = randomUUID();
+          const { repoUrl: mutableRepoUrl } = generateRepoUrl(repository, false);
+          const { repoUrl: wormRepoUrl } = generateRepoUrl(repository, true);
+
+          await init().repository(mutableRepoUrl).password(password).run();
+          const snapshotId = await createForgottenSnapshot(workingDir, mutableRepoUrl);
+
+          await expect(snapshots().repository(mutableRepoUrl).password(password).run()).resolves.toEqual(
+            expect.not.arrayContaining([
+              expect.objectContaining({
+                id: snapshotId,
+              }),
+            ]),
+          );
+
+          await expect(prune().repository(wormRepoUrl).password(password).run()).rejects.toThrow();
+        }, 20_000);
+      } else {
+        it('prunes old data', async () => {
+          const pruneRepoUrl = await createPruneRepo();
+          await createForgottenSnapshot(workingDir, pruneRepoUrl);
+
+          const blobsBefore = await list().repository(pruneRepoUrl).password(password).type('blobs').run();
+          await prune().repository(pruneRepoUrl).password(password).run();
+          const blobsAfter = await list().repository(pruneRepoUrl).password(password).type('blobs').run();
+
+          expect(blobsBefore).not.toEqual(blobsAfter);
+        }, 15_000);
+      }
+    });
+
+    describe('recover', () => {
+      beforeEach(async () => {
+        const { snapshot_id } = await backup()
+          .repository(repoUrl)
+          .password('password')
+          .addFile(join(workingDir, 'pwd'))
+          .run();
+
+        const forgetRun = forget().repository(repoUrl).password('password').snapshot(snapshot_id!).run();
+        await (writeOnce ? expect(forgetRun).rejects.toThrow() : forgetRun);
+      });
+
+      if (writeOnce) {
+        it('fails to generate snapshot from raw data (mutable operation)', async () => {
+          await expect(recover().repository(repoUrl).password('password').run()).rejects.toThrow();
+        });
+      } else {
+        it.skip('generates a new snapshot from raw data', async () => {
+          await recover().repository(repoUrl).password('password').run();
+
+          await expect(snapshots().repository(repoUrl).password('password').run()).resolves.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                tags: ['recovered'],
+              }),
+            ]),
+          );
+        });
+      }
+    });
+
+    describe('repair', () => {
+      if (writeOnce) {
+        it('fails to generate a new index', async () => {
+          await expect(repair().repository(repoUrl).password('password').index().run()).rejects.toThrow();
+        });
+
+        it('fails to repair packs', async () => {
+          const packs = await list().repository(repoUrl).password('password').type('packs').run();
+          await expect(
+            repair()
+              .repository(repoUrl)
+              .password('password')
+              .pack(...packs)
+              .run(),
+          ).rejects.toThrow();
+        });
+      } else {
+        it('generates a new index', async () => {
+          await repair().repository(repoUrl).password('password').index().run();
+        });
+
+        it('repairs packs', async () => {
+          const packs = await list().repository(repoUrl).password('password').type('packs').run();
+          await repair()
+            .repository(repoUrl)
+            .password('password')
+            .pack(...packs)
+            .run();
+        });
+      }
+
+      it('repairs snapshots', async () => {
+        await repair().repository(repoUrl).password('password').snapshots().run();
+      });
+    });
+
+    describe('restore', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('restores a file', async () => {
+        await restore()
+          .repository(repoUrl)
+          .password(password)
+          .snapshot(snapshotId)
+          .target(resolve(workingDir, 'restored'))
+          .run();
+
+        await stat(resolve(workingDir, 'restored', workingDir, 'folder', 'test-file'));
+      });
+    });
+
+    describe('rewrite', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('rewrite one snapshot', async () => {
+        const listBefore = await snapshots().repository(repoUrl).password('password').run();
+        await rewrite().repository(repoUrl).password('password').snapshot(snapshotId).exclude('hello.json').run();
+        const listAfter = await snapshots().repository(repoUrl).password('password').run();
+        expect(listAfter.length).toBe(listBefore.length + 1);
+      });
+    });
+
+    describe('snapshots', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('lists snapshots', async () => {
+        await expect(snapshots().repository(repoUrl).password(password).run()).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: snapshotId,
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('stats', () => {
+      it('generates stats', async () => {
+        await expect(stats().repository(repoUrl).password(password).run()).resolves.toEqual(
+          expect.objectContaining({
+            total_size: expect.any(Number),
+            total_file_count: expect.any(Number),
+            snapshots_count: expect.any(Number),
+          }),
+        );
+      });
+    });
+
+    describe('tag', () => {
+      let snapshotId: string;
+
+      beforeEach(async () => {
+        const result = await backup()
+          .repository(repoUrl)
+          .password(password)
+          .addFile(resolve(workingDir, 'folder'))
+          .run();
+        snapshotId = result.snapshot_id!;
+      });
+
+      it('updates a specific snapshot', async () => {
+        await tag().repository(repoUrl).password(password).set('new-tag').snapshot(snapshotId).run();
+
+        await expect(snapshots().repository(repoUrl).password(password).run()).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              tags: ['new-tag'],
+            }),
+          ]),
+        );
+      });
+    });
+
+    describe('unlock', () => {
+      it('works', async () => {
+        await unlock().repository(repoUrl).password('password').run();
+      });
+    });
+  });
+}

--- a/packages/e2e/test/orchestration-api.spec.ts
+++ b/packages/e2e/test/orchestration-api.spec.ts
@@ -322,7 +322,7 @@ describe('Repository', () => {
         }),
       }),
     });
-  }, 30_000);
+  }, 60_000);
 
   it('lists run history', async () => {
     await expect(sdk.getRunHistory(repository.id)).resolves.toEqual({
@@ -435,7 +435,7 @@ describe('Snapshot browsing and restore', () => {
     ({
       snapshots: [{ id: snapshotId }],
     } = await sdk.getSnapshots(repository.id));
-  }, 30_000);
+  }, 60_000);
 
   it('navigates into a subdirectory of a snapshot', async () => {
     await expect(sdk.getSnapshotListing(repository.id, snapshotId, { path: workingDir })).resolves.toEqual({
@@ -750,7 +750,7 @@ describe('Repository pruning', () => {
     const backupComplete = waitForMessage('TaskEnd');
     await sdk.createBackup(repository.id);
     await backupComplete;
-  }, 30_000);
+  }, 60_000);
 
   it('prunes a repository according to its retention policy', async () => {
     const event = waitForMessage('TaskEnd');
@@ -824,7 +824,7 @@ describe('Running task cancellation', () => {
         }),
       ]),
     });
-  }, 30_000);
+  }, 60_000);
 });
 
 describe('Immich integration', () => {

--- a/packages/e2e/test/restic-worm-api.spec.ts
+++ b/packages/e2e/test/restic-worm-api.spec.ts
@@ -1,3 +1,3 @@
 import { describeResticApi } from 'src/restic-api.suite';
 
-describeResticApi('restic API', false);
+describeResticApi('restic WORM API', true);

--- a/packages/e2e/test/yucca-api.spec.ts
+++ b/packages/e2e/test/yucca-api.spec.ts
@@ -30,7 +30,10 @@ describe('Auth', () => {
 
     const redirectUrl = new URL(loginHeaders.get('Location')!);
     redirectUrl.pathname = '/api/form';
-    redirectUrl.searchParams.set('sub', 'bar');
+    // Must differ from orchestration-api.spec's subject: these run in parallel,
+    // and one subject means one user, one repository list — which that suite
+    // enumerates and imports from.
+    redirectUrl.searchParams.set('sub', 'yucca-api-e2e');
 
     const { headers: oidcHeaders } = await fetch(redirectUrl, {
       redirect: 'manual',

--- a/packages/restic-api/test/app.integration-spec.ts
+++ b/packages/restic-api/test/app.integration-spec.ts
@@ -17,7 +17,7 @@ describe('AppController (e2e)', () => {
   let authHeader: string;
   let wormAuthHeader: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -30,7 +30,13 @@ describe('AppController (e2e)', () => {
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     const signer = new JwtService({
       privateKey: process.env.JWT_PRIVATE_KEY,
       signOptions: { algorithm: 'ES256' },

--- a/packages/web/e2e/connections.test.ts
+++ b/packages/web/e2e/connections.test.ts
@@ -1,12 +1,15 @@
 import { expect, test } from '@playwright/test';
 
+// Its own subject, not the 'foo' it-works uses: mock-oidc maps the login
+// straight to `sub`, and first login is a get-then-insert against a unique
+// column, so two specs signing in as one new user race and one gets a 500.
 const login = async (page: import('@playwright/test').Page) => {
   await page.goto('http://localhost:36033/');
   await page.waitForLoadState('networkidle');
   await page.getByRole('button', { name: 'Login' }).click();
 
   await expect(page.getByRole('heading', { name: 'Sign-in' })).toBeVisible();
-  await page.getByPlaceholder('Enter any login').fill('foo');
+  await page.getByPlaceholder('Enter any login').fill('connections-e2e');
   await page.getByPlaceholder('and password').fill('password');
   await page.getByRole('button', { name: 'Sign-in' }).click();
 

--- a/packages/web/playwright.k3d.config.ts
+++ b/packages/web/playwright.k3d.config.ts
@@ -7,6 +7,10 @@ import { defineConfig } from '@playwright/test';
 // packages/e2e/k3d/run.sh (mise test:e2e:k3d).
 export default defineConfig({
   testDir: 'e2e',
+  // yucca-web is a vite DEV server here, so the first visit to a route pays for
+  // its compile — more than the stock 5s assertion timeout on a cold, loaded
+  // runner, which is exactly when CI runs this.
+  expect: { timeout: 30_000 },
   use: {
     launchOptions: {
       args: ['--host-resolver-rules=MAP yucca-mock-oidc 127.0.0.1'],

--- a/packages/web/playwright.k3d.config.ts
+++ b/packages/web/playwright.k3d.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
   testDir: 'e2e',
   // yucca-web is a vite DEV server here, so the first visit to a route pays for
   // its compile — more than the stock 5s assertion timeout on a cold, loaded
-  // runner, which is exactly when CI runs this.
+  // runner, which is exactly when CI runs this. The per-test budget has to
+  // clear that too, or the test dies before the assertion can spend its own.
+  timeout: 90_000,
   expect: { timeout: 30_000 },
   use: {
     launchOptions: {

--- a/packages/yucca-admin-api/test/allowlist.integration-spec.ts
+++ b/packages/yucca-admin-api/test/allowlist.integration-spec.ts
@@ -13,7 +13,7 @@ const authCookie = ['yucca-admin-sub=admin', 'yucca-admin-access-token=token'];
 describe('AllowlistController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,7 +29,13 @@ describe('AllowlistController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
   });
 

--- a/packages/yucca-admin-api/test/auth.integration-spec.ts
+++ b/packages/yucca-admin-api/test/auth.integration-spec.ts
@@ -13,7 +13,7 @@ import { testUtils } from './testUtils';
 describe('AuthController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -27,7 +27,13 @@ describe('AuthController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
   });
 

--- a/packages/yucca-admin-api/test/features.integration-spec.ts
+++ b/packages/yucca-admin-api/test/features.integration-spec.ts
@@ -13,7 +13,7 @@ const authCookie = ['yucca-admin-sub=admin', 'yucca-admin-access-token=token'];
 describe('FeaturesController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,12 +29,14 @@ describe('FeaturesController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
-
-    await testUtils.resetDatabase();
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
+  });
+
+  beforeEach(async () => {
+    await testUtils.resetDatabase();
   });
 
   describe('GET /features', () => {

--- a/packages/yucca-admin-api/test/repository.integration-spec.ts
+++ b/packages/yucca-admin-api/test/repository.integration-spec.ts
@@ -13,7 +13,7 @@ const authCookie = ['yucca-admin-sub=admin', 'yucca-admin-access-token=token'];
 describe('RepositoryController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,7 +29,13 @@ describe('RepositoryController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
   });
 

--- a/packages/yucca-admin-api/test/session.integration-spec.ts
+++ b/packages/yucca-admin-api/test/session.integration-spec.ts
@@ -13,7 +13,7 @@ const authCookie = ['yucca-admin-sub=admin', 'yucca-admin-access-token=token'];
 describe('Sessions (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,7 +29,13 @@ describe('Sessions (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
   });
 

--- a/packages/yucca-admin-api/test/settings.integration-spec.ts
+++ b/packages/yucca-admin-api/test/settings.integration-spec.ts
@@ -13,7 +13,7 @@ const authCookie = ['yucca-admin-sub=admin', 'yucca-admin-access-token=token'];
 describe('SettingsController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,12 +29,14 @@ describe('SettingsController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
-
-    await testUtils.resetDatabase();
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
+  });
+
+  beforeEach(async () => {
+    await testUtils.resetDatabase();
   });
 
   it('requires authentication', async () => {

--- a/packages/yucca-admin-api/test/user.integration-spec.ts
+++ b/packages/yucca-admin-api/test/user.integration-spec.ts
@@ -13,7 +13,7 @@ const authCookie = ['yucca-admin-sub=admin', 'yucca-admin-access-token=token'];
 describe('UserController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,7 +29,13 @@ describe('UserController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
   });
 

--- a/packages/yucca-api/test/auth.integration-spec.ts
+++ b/packages/yucca-api/test/auth.integration-spec.ts
@@ -17,7 +17,7 @@ describe('AuthController (e2e)', () => {
   let user: { id: string; name: string; email: string; sub: string };
   let session: { id: string; accessToken: string };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -33,7 +33,13 @@ describe('AuthController (e2e)', () => {
     await app.init();
 
     auth = await moduleFixture.resolve(AuthService);
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
     ({ user, session } = await testUtils.createUser());
   });

--- a/packages/yucca-api/test/connection.integration-spec.ts
+++ b/packages/yucca-api/test/connection.integration-spec.ts
@@ -15,7 +15,7 @@ describe('ConnectionController (e2e)', () => {
 
   const cookie = () => `yucca-access-token=${session.accessToken}`;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -29,13 +29,15 @@ describe('ConnectionController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
-
-    await testUtils.resetDatabase();
-    ({ user, session, connection } = await testUtils.createUser());
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
+  });
+
+  beforeEach(async () => {
+    await testUtils.resetDatabase();
+    ({ user, session, connection } = await testUtils.createUser());
   });
 
   describe('GET /connections', () => {

--- a/packages/yucca-api/test/meta.integration-spec.ts
+++ b/packages/yucca-api/test/meta.integration-spec.ts
@@ -14,7 +14,7 @@ describe('MetaController (e2e)', () => {
   let app: INestApplication<App>;
   let db: Kysely<DB>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -30,12 +30,15 @@ describe('MetaController (e2e)', () => {
     await app.init();
 
     db = new Kysely<DB>(getKyselyConfig());
-    await testUtils.resetDatabase();
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await db.destroy();
     await app.close();
+  });
+
+  beforeEach(async () => {
+    await testUtils.resetDatabase();
   });
 
   describe('GET /meta', () => {

--- a/packages/yucca-api/test/metrics.integration-spec.ts
+++ b/packages/yucca-api/test/metrics.integration-spec.ts
@@ -13,7 +13,7 @@ describe('MetricsController (e2e)', () => {
   let session: { id: string; accessToken: string };
   let repository: { id: string };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -27,7 +27,13 @@ describe('MetricsController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
     ({ user, session } = await testUtils.createUser());
     repository = await testUtils.createRepository(user.id);

--- a/packages/yucca-api/test/repository.integration-spec.ts
+++ b/packages/yucca-api/test/repository.integration-spec.ts
@@ -13,7 +13,7 @@ describe('RepositoryController (e2e)', () => {
   let session: { id: string; accessToken: string };
   let repository: { id: string; connectionId: string };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports,
       controllers,
@@ -27,7 +27,13 @@ describe('RepositoryController (e2e)', () => {
     app.setGlobalPrefix('/api');
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+  });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
     await testUtils.resetDatabase();
     ({ user, session } = await testUtils.createUser());
     repository = await testUtils.createRepository(user.id);


### PR DESCRIPTION
Integration drops from \~7m30s to \~1m45s and e2e from \~12m50s to \~6m40s, with 27 more tests running than before.

Also make them less flaky.

- `main` <!-- branch-stack -->
  - \#435 :point\_left:
