### PR TITLE
feat(yucca-api): provision per-repository RGW users

### DIFF
--- a/.mise/tasks/test/integration/k3d
+++ b/.mise/tasks/test/integration/k3d
@@ -27,6 +27,7 @@ wait_for() {
 echo "==> wait for infra (tilt ci-infra returns before Rook mints the S3 user)"
 wait_for "CNPG cluster Ready"  kubectl -n yucca wait --for=condition=Ready cluster/yucca-db --timeout=5s
 wait_for "Ceph S3 user secret" kubectl -n yucca get secret rook-ceph-object-user-yucca-michael
+wait_for "Ceph provisioner secret" kubectl -n yucca get secret rook-ceph-object-user-yucca-provisioner
 wait_for "mock-oidc Available" kubectl -n yucca wait --for=condition=Available deploy/yucca-mock-oidc --timeout=5s
 
 echo "==> port-forward infra to the localhost ports the tests expect"
@@ -55,13 +56,24 @@ S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 export S3_ENDPOINT S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_REGION S3_FORCE_PATH_STYLE
 
-if kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics >/dev/null 2>&1; then
+# RADOS_* is the RGW admin credential. Prefer the provisioner user (users+buckets
+# caps — what yucca-api creates per-repository S3 users with, and a superset of
+# the read caps the metrics worker's suite needs); fall back to the metrics user.
+RADOS_SECRET_NAME=""
+for candidate in rook-ceph-object-user-yucca-provisioner rook-ceph-object-user-yucca-metrics; do
+  if kubectl -n yucca get secret "$candidate" >/dev/null 2>&1; then
+    RADOS_SECRET_NAME="$candidate"
+    break
+  fi
+done
+if [ -n "$RADOS_SECRET_NAME" ]; then
+  echo "==> RGW admin credential: $RADOS_SECRET_NAME"
   RADOS_ENDPOINT=http://localhost:9000
-  RADOS_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.AccessKey}' | base64 -d)"
-  RADOS_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-metrics -o jsonpath='{.data.SecretKey}' | base64 -d)"
+  RADOS_ACCESS_KEY_ID="$(kubectl -n yucca get secret "$RADOS_SECRET_NAME" -o jsonpath='{.data.AccessKey}' | base64 -d)"
+  RADOS_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret "$RADOS_SECRET_NAME" -o jsonpath='{.data.SecretKey}' | base64 -d)"
   export RADOS_ENDPOINT RADOS_ACCESS_KEY_ID RADOS_SECRET_ACCESS_KEY
 else
-  echo "==> rook-ceph-object-user-yucca-metrics not found; RGW integration tests will skip"
+  echo "==> no RGW admin object-user secret found; RGW integration tests will skip"
 fi
 
 # The deployed mock-oidc advertises its in-cluster name as the issuer; the dns

--- a/.mise/tasks/tilt/ci-infra
+++ b/.mise/tasks/tilt/ci-infra
@@ -2,7 +2,8 @@
 #MISE description="tilt ci for the infra subset only (no app images) — what integration tests need"
 #MISE dir="{{config_root}}"
 # The closure of every non-app resource: chart repos, operators, the Ceph dev
-# cluster + RGW user, CNPG database, mock-oidc and the victoria pair. Skipping
+# cluster + its RGW users (michael's bucket owner and the APIs' provisioner
+# admin), CNPG database, mock-oidc and the victoria pair. Skipping
 # the four heavy app images (yucca-api/admin/web/michael) saves ~10 min in CI;
 # integration tests boot those apps on the host themselves.
 set -euo pipefail
@@ -15,5 +16,5 @@ fi
 exec tilt ci --timeout 1800s \
   rook-release-repo helm-deps \
   cloudnative-pg rook-ceph-operator rook-ceph-cluster \
-  yucca-object-user yucca-database yucca-mock-oidc \
+  yucca-object-user yucca-provisioner-object-user yucca-database yucca-mock-oidc \
   yucca-victoria-metrics yucca-victoria-logs

--- a/.mise/tasks/yucca-api/env
+++ b/.mise/tasks/yucca-api/env
@@ -27,6 +27,16 @@ export OIDC_LOGOUT_REDIRECT_URI=${OIDC_LOGOUT_REDIRECT_URI:-http://localhost:360
 export OIDC_DEVICE_ISSUER=${OIDC_DEVICE_ISSUER:-http://localhost:8092}
 export OIDC_DEVICE_CLIENT_ID=${OIDC_DEVICE_CLIENT_ID:-device client ID}
 
+# Well-known local-dev keys. STORAGE_CREDENTIAL_SEAL_KEY is shared with michael
+# (.mise/tasks/restic-api/env); STORAGE_CREDENTIAL_KEY never leaves the API.
+export STORAGE_CREDENTIAL_KEY=${STORAGE_CREDENTIAL_KEY:-eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=}
+export STORAGE_CREDENTIAL_SEAL_KEY=${STORAGE_CREDENTIAL_SEAL_KEY:-eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=}
+
+# The compose stack stores into MinIO, which has no RGW admin API, so every
+# repository is handed the MinIO root credentials instead of its own user.
+export STORAGE_STATIC_ACCESS_KEY_ID=${STORAGE_STATIC_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-minio}}
+export STORAGE_STATIC_SECRET_ACCESS_KEY=${STORAGE_STATIC_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-miniominio}}
+
 export TOPOLOGY_FILE=${TOPOLOGY_FILE:-./topology.dev.json}
 export API_ROOT=${API_ROOT:-http://localhost:3020/api}
 export LEGACY_SITE_CODE=${LEGACY_SITE_CODE:-local}

--- a/Tiltfile
+++ b/Tiltfile
@@ -272,14 +272,16 @@ APP_WIRING = {
     # dev_env: receives the .env override Secret (see load_dev_env above).
     # dev_keypair: render the well-known dev JWT fixture into the chart Secret
     # (the chart default is useDevKeypair=false so real overlays fail loudly).
-    'yucca-api':              {'build': 'yucca-api',          'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-michael', 'yucca-topology'], 'dev_env': True, 'dev_keypair': True},
-    'yucca-admin-api':        {'build': 'yucca-admin-api',    'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-topology'], 'dev_keypair': True},
+    'yucca-api':              {'build': 'yucca-api',          'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-michael', 'yucca-topology', 'yucca-provisioner-object-user'], 'dev_env': True, 'dev_keypair': True},
+    'yucca-admin-api':        {'build': 'yucca-admin-api',    'deps': ['yucca-database', 'yucca-mock-oidc', 'yucca-topology', 'yucca-provisioner-object-user'], 'dev_keypair': True},
     'yucca-metrics-worker':   {'build': 'yucca-metrics-worker', 'deps': ['yucca-database', 'yucca-metrics-object-user', 'yucca-topology'], 'dev_env': True},
     'yucca-web':              {'build': 'web',                'deps': ['yucca-api']},
     # Stock upstream nginx serving the .well-known pointer — nothing to build,
     # nothing to wait for (it's a static file, deliberately independent of the
     # API whose URL it advertises).
     'yucca-meta':             {'build': None,                 'deps': []},
+    # yucca-object-user is no longer michael's credential — it owns the buckets
+    # created before per-repository users, and the e2e harness signs with it.
     'yucca-michael':          {'build': 'michael',            'deps': ['yucca-object-user'], 'dev_keypair': True},
     'yucca-mock-oidc':        {'build': 'mock-oidc-provider', 'deps': []},
     'yucca-database':         {'build': None,                 'deps': ['cloudnative-pg']},
@@ -291,6 +293,9 @@ APP_WIRING = {
     # come from the HelmRelease values, so dev must apply them (dev_values) or
     # both releases would default to userName=michael and collide.
     'yucca-metrics-object-user': {'build': None,              'deps': ['rook-ceph-cluster'], 'pod_readiness': 'ignore', 'dev_values': True},
+    # The RGW admin the APIs create per-repository S3 users with. Same chart,
+    # so its userName/caps also have to come from the HelmRelease values.
+    'yucca-provisioner-object-user': {'build': None,          'deps': ['rook-ceph-cluster'], 'pod_readiness': 'ignore', 'dev_values': True},
     # Rook spins up transient mon/osd "canary" pods and deletes them; Tilt's
     # pod tracking misreads those deletions as failures. Ignore pod readiness
     # here — real convergence is still gated downstream (object-user -> michael

--- a/charts/apps/yucca-api/templates/deployment.yaml
+++ b/charts/apps/yucca-api/templates/deployment.yaml
@@ -2,6 +2,8 @@
   (dict "name" "OIDC_ISSUER" "value" .Values.oidcIssuer)
   (dict "name" "OIDC_REDIRECT_URI" "value" .Values.oidcRedirectUri)
   (dict "name" "OIDC_LOGOUT_REDIRECT_URI" "value" .Values.oidcLogoutRedirectUri)
+  (dict "name" "RADOS_ACCESS_KEY_ID" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "AccessKey")))
+  (dict "name" "RADOS_SECRET_ACCESS_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "SecretKey")))
   (dict "name" "POSTGRES_HOST" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "host")))
   (dict "name" "POSTGRES_PORT" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "port")))
   (dict "name" "POSTGRES_DATABASE" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "dbname")))
@@ -11,7 +13,9 @@
 {{- /* extraEnvFrom comes after the chart secret: for duplicate keys Kubernetes
 takes the LAST envFrom source, so these act as overrides. */}}
 {{- $_ := set .Values "envFrom" (concat
-  (list (dict "secretRef" (dict "name" (include "yucca-common.fullname" .))))
+  (list
+    (dict "secretRef" (dict "name" (include "yucca-common.fullname" .)))
+    (dict "secretRef" (dict "name" .Values.radosSecretName)))
   (.Values.extraEnvFrom | default (list))) }}
 {{- $topology := (lookup "v1" "ConfigMap" .Release.Namespace "yucca-topology") | default dict }}
 {{- $topologyData := (get $topology "data") | default dict }}

--- a/charts/apps/yucca-api/templates/secret.yaml
+++ b/charts/apps/yucca-api/templates/secret.yaml
@@ -1,6 +1,9 @@
 {{- /* The dev JWT fixture only enters the Secret when explicitly opted in
 (useDevKeypair — dev/local overlay only); see values.yaml. */}}
 {{- if .Values.useDevKeypair }}
-{{- $_ := set .Values "secretData" (merge (dict "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey) (.Values.secretData | default dict)) }}
+{{- $_ := set .Values "secretData" (merge (dict
+  "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey
+  "STORAGE_CREDENTIAL_KEY" .Values.devStorageCredentialKey
+  "STORAGE_CREDENTIAL_SEAL_KEY" .Values.devStorageSealKey) (.Values.secretData | default dict)) }}
 {{- end }}
 {{- include "yucca-common.secret" . }}

--- a/charts/apps/yucca-api/values.yaml
+++ b/charts/apps/yucca-api/values.yaml
@@ -39,6 +39,13 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
+# RGW user with users+buckets admin caps: the API creates one S3 user per
+# repository with it, so michael never needs a cluster-wide credential. In dev
+# Rook writes the keys here as rook-ceph-object-user-<store>-<user>; prod points
+# this at the TF-provisioned yucca-provisioner-rgw Secret. Per-cluster overrides
+# ride in the same Secret as RADOS_ACCESS_KEY_ID_<CODE>/RADOS_SECRET_ACCESS_KEY_<CODE>.
+radosSecretName: rook-ceph-object-user-yucca-provisioner
+
 # CNPG-managed postgres Cluster name (see umbrella chart)
 postgresClusterName: yucca-db
 
@@ -60,6 +67,11 @@ secretData:
 # to provide a real key gets a loud missing-JWT_PRIVATE_KEY crash instead of
 # silently signing production tokens with a public fixture.
 useDevKeypair: false
+# The dev storage-credential keys, under the same opt-in. The seal half is
+# shared with michael (charts/apps/michael/values.yaml); the at-rest half never
+# leaves the APIs.
+devStorageCredentialKey: eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=
+devStorageSealKey: eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=
 devJwtPrivateKey: |
   -----BEGIN PRIVATE KEY-----
   MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgCla79+Sip4o2hZ1K

--- a/kubernetes/apps/base/yucca-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-api/helmrelease.yaml
@@ -40,6 +40,10 @@ spec:
     # secretData nulled: the chart's dev fixture (JWT + OIDC placeholders) is
     # replaced by the TF-provisioned `yucca-api` Secret (JWT_PRIVATE_KEY +
     # OIDC_CLIENT_ID/SECRET), picked up via the chart's envFrom: secretRef.
+    # RGW admin keys for per-repository S3 users: TF-provisioned into the
+    # yucca-provisioner-rgw Secret (tf .../talos/secrets.tf), like
+    # yucca-metrics-rgw. Additional clusters get RADOS_*_<CODE> pairs in it.
+    radosSecretName: yucca-provisioner-rgw
     secretData: null
     # Real IdP (no mock-oidc). Chart maps these onto explicit env (which beats
     # envFrom). Redirects target the staging ingress domain.

--- a/kubernetes/apps/dev/local/yucca/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./database/ks.yaml
   - ./object-user/ks.yaml
   - ./metrics-object-user/ks.yaml
+  - ./provisioner-object-user/ks.yaml
   - ./mock-oidc/ks.yaml
   - ./victoria-metrics/ks.yaml
   - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: yucca-provisioner-object-user
+  namespace: yucca
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: charts/platform/ceph-objectuser
+      sourceRef:
+        kind: GitRepository
+        name: yucca
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # RGW admin the APIs use to create one S3 user per repository, so michael can
+    # hold no storage credentials at all. Rook writes its keys to
+    # rook-ceph-object-user-yucca-provisioner. In prod this user is `users=*`
+    # only and bucket ops belong to a separate operator-held `yucca-migrator`;
+    # the dev lab collapses both into one so the integration suites have a single
+    # credential to reach for.
+    userName: provisioner
+    capabilities:
+      user: '*'
+      bucket: '*'

--- a/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/provisioner-object-user/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/dev/local/yucca/provisioner-object-user/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/provisioner-object-user/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: yucca-provisioner-object-user
+  namespace: flux-system
+spec:
+  targetNamespace: yucca
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: yucca-provisioner-object-user
+  path: ./kubernetes/apps/dev/local/yucca/provisioner-object-user/app
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: yucca
+  dependsOn:
+    - name: rook-ceph-cluster

--- a/packages/yucca-api/package.json
+++ b/packages/yucca-api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "catalog:",
     "@nestjs/swagger": "catalog:",
     "@opentelemetry/api": "catalog:",
+    "aws4fetch": "catalog:",
     "class-validator": "catalog:",
     "cookie": "catalog:",
     "event-iterator": "catalog:",

--- a/packages/yucca-api/src/app.module.ts
+++ b/packages/yucca-api/src/app.module.ts
@@ -17,6 +17,7 @@ import { OidcRepository } from './repositories/oidc.repository';
 import { RepositoryRepository } from './repositories/repository.repository';
 import { RepositoryMetricsRepository } from './repositories/repositoryMetrics.repository';
 import { RepositoryMetricsHistoryRepository } from './repositories/repositoryMetricsHistory.repository';
+import { RgwAdminRepository } from './repositories/rgwAdmin.repository';
 import { SessionRepository } from './repositories/session.repository';
 import { SettingsRepository } from './repositories/settings.repository';
 import { StorageRepository } from './repositories/storage.repository';
@@ -29,6 +30,7 @@ import { DatabaseService } from './services/database.service';
 import { MetaService } from './services/meta.service';
 import { MetricsService } from './services/metrics.service';
 import { RepositoryService } from './services/repository.service';
+import { StorageCredentialService } from './services/storageCredential.service';
 import { TopologyService } from './services/topology.service';
 import { getKyselyConfig } from './utils/database';
 
@@ -62,6 +64,7 @@ export const providers = [
   UserRepository,
   UserAllowlistRepository,
   RepositoryRepository,
+  RgwAdminRepository,
   RepositoryMetricsRepository,
   RepositoryMetricsHistoryRepository,
   SessionRepository,
@@ -70,6 +73,7 @@ export const providers = [
   TopologyService,
   MetricsService,
   RepositoryService,
+  StorageCredentialService,
   AuthService,
   ConnectionService,
   { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },

--- a/packages/yucca-api/src/env.ts
+++ b/packages/yucca-api/src/env.ts
@@ -1,3 +1,4 @@
+import { parseStorageCredentialKeys } from '@common/server';
 import type { StringValue } from 'ms';
 import { z } from 'zod';
 
@@ -43,6 +44,22 @@ const schema = z.object({
   OIDC_DEVICE_CLIENT_ID: z.string(),
   OIDC_DEVICE_ALLOW_INSECURE: z.coerce.boolean().default(false),
   OIDC_DEVICE_SCOPE: z.string().default('openid profile email'),
+
+  // At rest only. First key seals, the rest stay accepted so a rotation is a
+  // two-step deploy.
+  STORAGE_CREDENTIAL_KEY: z.string().transform(parseStorageCredentialKeys),
+  // Shared with michael: seals the credentials carried by a restic token.
+  STORAGE_CREDENTIAL_SEAL_KEY: z.string().transform(parseStorageCredentialKeys),
+
+  // Per-cluster overrides are read straight from the environment as
+  // RADOS_ACCESS_KEY_ID_<CLUSTER_CODE>, as in yucca-metrics-worker.
+  RADOS_ACCESS_KEY_ID: z.string().optional(),
+  RADOS_SECRET_ACCESS_KEY: z.string().optional(),
+
+  // Fallback for clusters with no rgw_admin_endpoint (MinIO has no admin API):
+  // every repository is handed these keys instead of its own.
+  STORAGE_STATIC_ACCESS_KEY_ID: z.string().optional(),
+  STORAGE_STATIC_SECRET_ACCESS_KEY: z.string().optional(),
 
   TOPOLOGY_FILE: z.string().default('./topology.dev.json'),
   API_ROOT: z.string().default('http://localhost:3020/api'),

--- a/packages/yucca-api/src/repositories/repository.repository.ts
+++ b/packages/yucca-api/src/repositories/repository.repository.ts
@@ -13,6 +13,18 @@ const metricsJson = (eb: ExpressionBuilder<DB, 'repositories' | 'repositoryMetri
     lastBackupDuration: eb.ref('repositoryMetrics.lastBackupDuration'),
   }).as('metrics');
 
+// Every read outside StorageCredentialService goes through this list: a
+// selectAll() would put the sealed secret straight into a JSON response.
+const columns = [
+  'repositories.id',
+  'repositories.userId',
+  'repositories.worm',
+  'repositories.name',
+  'repositories.siteCode',
+  'repositories.storageClusterCode',
+  'repositories.connectionId',
+] as const;
+
 const meterJson = (eb: ExpressionBuilder<DB, 'repositories' | 'repositoryMeter'>) =>
   jsonBuildObject({
     sizeBytes: eb.fn.coalesce('repositoryMeter.sizeBytes', eb.val(0)),
@@ -36,7 +48,7 @@ export class RepositoryRepository {
       .leftJoin('repositoryMetrics', 'repositoryMetrics.id', 'repositories.id')
       .leftJoin('repositoryMeter', 'repositoryMeter.repositoryId', 'repositories.id')
       .where('repositories.id', '=', id)
-      .selectAll('repositories')
+      .select(columns)
       .select('connections.type as connectionType')
       .select(metricsJson)
       .select(meterJson)
@@ -50,7 +62,7 @@ export class RepositoryRepository {
       .leftJoin('repositoryMetrics', 'repositoryMetrics.id', 'repositories.id')
       .leftJoin('repositoryMeter', 'repositoryMeter.repositoryId', 'repositories.id')
       .where('repositories.userId', '=', userId)
-      .selectAll('repositories')
+      .select(columns)
       .select('connections.type as connectionType')
       .select(metricsJson)
       .select(meterJson)
@@ -67,7 +79,22 @@ export class RepositoryRepository {
   }
 
   getByIds(ids: string[]) {
-    return this.db.selectFrom('repositories').selectAll().where('id', 'in', ids).execute();
+    return this.db.selectFrom('repositories').select(columns).where('repositories.id', 'in', ids).execute();
+  }
+
+  getStorageOwner(id: string) {
+    return this.db
+      .selectFrom('repositories')
+      .select(['id', 'storageClusterCode', 'storageAccessKeyId', 'storageSecretAccessKey'])
+      .where('id', '=', id)
+      .executeTakeFirstOrThrow();
+  }
+
+  async setStorageCredentials(
+    id: string,
+    credentials: Pick<RepositoryTable, 'storageAccessKeyId' | 'storageSecretAccessKey'>,
+  ) {
+    await this.db.updateTable('repositories').where('id', '=', id).set(credentials).execute();
   }
 
   async reparent(ids: string[], connectionId: string) {

--- a/packages/yucca-api/src/repositories/rgwAdmin.repository.ts
+++ b/packages/yucca-api/src/repositories/rgwAdmin.repository.ts
@@ -1,0 +1,163 @@
+import { Injectable } from '@nestjs/common';
+import { AwsClient } from 'aws4fetch';
+import { env } from 'src/env';
+import { TopologyStorageCluster } from 'src/repositories/topology.repository';
+
+export type StorageUserKeys = { accessKeyId: string; secretAccessKey: string };
+
+type RgwKey = { user: string; access_key: string; secret_key: string };
+type RgwUser = { user_id: string; keys?: RgwKey[] };
+type RgwResponse = { status: number; ok: boolean; body: any };
+
+// The admin credential lives here, in the control plane; michael only ever sees
+// the keys of the one repository a request is for.
+@Injectable()
+export class RgwAdminRepository {
+  private clients = new Map<string, AwsClient>();
+
+  supports(cluster: TopologyStorageCluster): boolean {
+    return Boolean(cluster.rgw_admin_endpoint);
+  }
+
+  async ensureUser(cluster: TopologyStorageCluster, uid: string, displayName: string): Promise<StorageUserKeys> {
+    // max-buckets=1: the user owns exactly the one bucket backing its
+    // repository, so a leaked key cannot stand up storage of its own.
+    const created = await this.request(cluster, 'PUT', '/admin/user', {
+      uid,
+      'display-name': displayName,
+      'max-buckets': '1',
+    });
+    if (created.ok) {
+      return this.firstKey(cluster, uid, created.body as RgwUser);
+    }
+    if (errorCode(created) !== 'UserAlreadyExists') {
+      throw rgwError('create user', uid, created);
+    }
+
+    const existing = await this.request(cluster, 'GET', '/admin/user', { uid });
+    if (!existing.ok) {
+      throw rgwError('read user', uid, existing);
+    }
+    return this.firstKey(cluster, uid, existing.body as RgwUser);
+  }
+
+  // Drops every other key, so the credentials an already-minted token carries
+  // stop working.
+  async rotateKeys(cluster: TopologyStorageCluster, uid: string): Promise<StorageUserKeys> {
+    const before = await this.request(cluster, 'GET', '/admin/user', { uid });
+    if (!before.ok) {
+      throw rgwError('read user', uid, before);
+    }
+    const stale = new Set(((before.body as RgwUser).keys ?? []).map((key) => key.access_key));
+
+    const generated = await this.request(cluster, 'PUT', '/admin/user', { key: '', uid, 'generate-key': 'True' });
+    if (!generated.ok) {
+      throw rgwError('generate key', uid, generated);
+    }
+
+    const fresh = (generated.body as RgwKey[]).find((key) => !stale.has(key.access_key));
+    if (!fresh) {
+      throw new Error(`RGW generated no new key for user '${uid}' on cluster '${cluster.code}'`);
+    }
+
+    for (const accessKey of stale) {
+      await this.removeKey(cluster, uid, accessKey);
+    }
+    return { accessKeyId: fresh.access_key, secretAccessKey: fresh.secret_key };
+  }
+
+  // The bucket is left alone: deleting a repository has never deleted its data,
+  // and it must not start here.
+  async revokeKeys(cluster: TopologyStorageCluster, uid: string): Promise<void> {
+    const user = await this.request(cluster, 'GET', '/admin/user', { uid });
+    if (!user.ok) {
+      if (errorCode(user) === 'NoSuchUser') {
+        return;
+      }
+      throw rgwError('read user', uid, user);
+    }
+
+    for (const key of (user.body as RgwUser).keys ?? []) {
+      await this.removeKey(cluster, uid, key.access_key);
+    }
+  }
+
+  private async removeKey(cluster: TopologyStorageCluster, uid: string, accessKey: string): Promise<void> {
+    const removed = await this.request(cluster, 'DELETE', '/admin/user', {
+      key: '',
+      uid,
+      'access-key': accessKey,
+    });
+    if (!removed.ok && errorCode(removed) !== 'InvalidAccessKeyId') {
+      throw rgwError('remove key', uid, removed);
+    }
+  }
+
+  private async firstKey(cluster: TopologyStorageCluster, uid: string, user: RgwUser): Promise<StorageUserKeys> {
+    const key = user.keys?.find((key) => key.user === uid) ?? user.keys?.[0];
+    if (key) {
+      return { accessKeyId: key.access_key, secretAccessKey: key.secret_key };
+    }
+    return this.rotateKeys(cluster, uid);
+  }
+
+  private async request(
+    cluster: TopologyStorageCluster,
+    method: string,
+    path: string,
+    query: Record<string, string>,
+  ): Promise<RgwResponse> {
+    const url = new URL(cluster.rgw_admin_endpoint!);
+    url.pathname = path;
+    url.search = new URLSearchParams(query).toString();
+
+    const response = await this.client(cluster).fetch(url.toString(), { method });
+    const text = await response.text();
+    let body: any = undefined;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    return { status: response.status, ok: response.ok, body };
+  }
+
+  private client(cluster: TopologyStorageCluster): AwsClient {
+    const endpoint = cluster.rgw_admin_endpoint;
+    if (!endpoint) {
+      throw new Error(`Storage cluster '${cluster.code}' has no rgw_admin_endpoint`);
+    }
+
+    const cacheKey = `${cluster.code}:${endpoint}`;
+    const cached = this.clients.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Same per-cluster override convention as yucca-metrics-worker, so one
+    // object-user Secret can be mounted with envFrom under these exact names.
+    const suffix = cluster.code.toUpperCase().replaceAll('-', '_');
+    const accessKeyId = process.env[`RADOS_ACCESS_KEY_ID_${suffix}`] ?? env.RADOS_ACCESS_KEY_ID;
+    const secretAccessKey = process.env[`RADOS_SECRET_ACCESS_KEY_${suffix}`] ?? env.RADOS_SECRET_ACCESS_KEY;
+    if (!accessKeyId || !secretAccessKey) {
+      throw new Error(
+        `No RGW admin credentials for cluster '${cluster.code}' ` +
+          `(set RADOS_ACCESS_KEY_ID_${suffix}/RADOS_SECRET_ACCESS_KEY_${suffix} or the RADOS_* fallback)`,
+      );
+    }
+
+    const client = new AwsClient({ accessKeyId, secretAccessKey, service: 's3', region: 'rgw' });
+    this.clients.set(cacheKey, client);
+    return client;
+  }
+}
+
+const errorCode = (response: RgwResponse): string | undefined =>
+  typeof response.body === 'object' && response.body !== null ? (response.body.Code as string) : undefined;
+
+const rgwError = (action: string, uid: string, response: RgwResponse): Error =>
+  new Error(
+    `RGW admin failed to ${action} '${uid}': ${response.status} ${errorCode(response) ?? JSON.stringify(response.body)}`,
+  );

--- a/packages/yucca-api/src/repositories/topology.repository.ts
+++ b/packages/yucca-api/src/repositories/topology.repository.ts
@@ -15,8 +15,10 @@ const storageClusterSchema = z
         endpoint: z.url(),
         region: z.string().min(1).default('us-east-1'),
         force_path_style: z.boolean().default(true),
-        access_key_env: envNameSchema,
-        secret_key_env: envNameSchema,
+        // Accepted but unread: michael takes its credentials from the token
+        // now, so nothing resolves these environment variable names.
+        access_key_env: envNameSchema.optional(),
+        secret_key_env: envNameSchema.optional(),
         backend_source: z.enum(['file', 'dns']).optional(),
         backend_file: z.string().min(1).optional(),
         backend_dns_host: z.string().min(1).optional(),
@@ -150,6 +152,17 @@ export class TopologyRepository {
 
   hasCluster(code: string): boolean {
     return this.get().sites.some((site) => site.clusters.some((cluster) => cluster.code === code));
+  }
+
+  getCluster(code: string): TopologyStorageCluster {
+    for (const site of this.get().sites) {
+      const cluster = site.clusters.find((cluster) => cluster.code === code);
+      if (cluster) {
+        return cluster;
+      }
+    }
+
+    throw new BadRequestException(`Unknown storage cluster '${code}'`);
   }
 
   getActiveCluster(site: TopologySite): TopologyStorageCluster {

--- a/packages/yucca-api/src/schema/migrations/20260804120000-AddRepositoryStorageCredentials.ts
+++ b/packages/yucca-api/src/schema/migrations/20260804120000-AddRepositoryStorageCredentials.ts
@@ -1,0 +1,11 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "repositories" ADD "storageAccessKeyId" text;`.execute(db);
+  await sql`ALTER TABLE "repositories" ADD "storageSecretAccessKey" text;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "repositories" DROP COLUMN "storageSecretAccessKey";`.execute(db);
+  await sql`ALTER TABLE "repositories" DROP COLUMN "storageAccessKeyId";`.execute(db);
+}

--- a/packages/yucca-api/src/schema/tables/repository.table.ts
+++ b/packages/yucca-api/src/schema/tables/repository.table.ts
@@ -24,4 +24,12 @@ export class RepositoryTable {
 
   @ForeignKeyColumn(() => ConnectionTable, { onUpdate: 'CASCADE', onDelete: 'RESTRICT', index: true })
   connectionId!: string;
+
+  @Column({ type: 'text', nullable: true })
+  storageAccessKeyId!: string | null;
+
+  // Sealed with STORAGE_CREDENTIAL_KEY, never the key michael holds: a database
+  // dump is not enough to reach the bucket.
+  @Column({ type: 'text', nullable: true })
+  storageSecretAccessKey!: string | null;
 }

--- a/packages/yucca-api/src/services/repository.service.spec.ts
+++ b/packages/yucca-api/src/services/repository.service.spec.ts
@@ -28,6 +28,7 @@ describe(RepositoryService.name, () => {
       mocks.wideContext as never,
       mocks.connection as never,
       mocks.topology as never,
+      mocks.storageCredential as never,
     );
   });
 
@@ -36,7 +37,7 @@ describe(RepositoryService.name, () => {
       mocks.topology.getSite.mockReturnValue(site);
       mocks.topology.getActiveCluster.mockReturnValue(site.clusters[0]);
       mocks.connection.getOrCreateDefault.mockResolvedValue({ id: 'conn', type: 'immich' } as never);
-      mocks.repository.create.mockResolvedValue({ id: 'repo' } as never);
+      mocks.repository.create.mockResolvedValue({ id: 'repo', storageClusterCode: 'father-spice' } as never);
 
       await sut.create(auth, { name: 'backup', worm: false, site: 'father' });
 
@@ -48,6 +49,12 @@ describe(RepositoryService.name, () => {
         worm: false,
         siteCode: 'father',
         storageClusterCode: 'father-spice',
+      });
+      expect(mocks.storageCredential.ensure).toHaveBeenCalledWith({
+        id: 'repo',
+        storageClusterCode: 'father-spice',
+        storageAccessKeyId: null,
+        storageSecretAccessKey: null,
       });
     });
 
@@ -75,6 +82,12 @@ describe(RepositoryService.name, () => {
         connectionType: 'immich',
       } as never);
       mocks.topology.getSite.mockReturnValue(site);
+      mocks.repository.getStorageOwner.mockResolvedValue({
+        id: repoId,
+        storageClusterCode: 'father-spice',
+        storageAccessKeyId: 'access',
+        storageSecretAccessKey: 'sealed-at-rest',
+      } as never);
       mocks.jwt.signAsync.mockResolvedValue('signed-token');
 
       const { url } = await sut.createUrl(auth, repoId);
@@ -86,6 +99,7 @@ describe(RepositoryService.name, () => {
         writeOnce: true,
         storageCluster: 'father-spice',
         connection: 'immich',
+        storageCredentials: 'sealed',
       });
       expect(url).toBe(`rest:https://restic:signed-token@rest.htz-fsn1.backups.futo.cloud/${repoId}`);
     });

--- a/packages/yucca-api/src/services/repository.service.ts
+++ b/packages/yucca-api/src/services/repository.service.ts
@@ -6,6 +6,7 @@ import { RepositoryCreateRequestDto, RepositoryUpdateRequestDto } from 'src/dto/
 import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { TopologyRepository } from 'src/repositories/topology.repository';
+import { StorageCredentialService } from 'src/services/storageCredential.service';
 
 @Injectable({ scope: Scope.REQUEST })
 export class RepositoryService {
@@ -15,6 +16,7 @@ export class RepositoryService {
     private readonly wideContext: WideContextRepository,
     private readonly connection: ConnectionRepository,
     private readonly topology: TopologyRepository,
+    private readonly storageCredentials: StorageCredentialService,
   ) {}
 
   async create(auth: AuthDto, { site: siteCode, ...dto }: RepositoryCreateRequestDto) {
@@ -27,13 +29,24 @@ export class RepositoryService {
       connectionId = connection.id;
     }
 
-    return this.repositoryRepository.create({
+    const repository = await this.repositoryRepository.create({
       userId: auth.id,
       connectionId,
       ...dto,
       siteCode: site.code,
       storageClusterCode: cluster.code,
     });
+
+    // Eager, so a storage cluster that cannot issue an identity fails the
+    // create rather than the first backup.
+    await this.storageCredentials.ensure({
+      id: repository.id,
+      storageClusterCode: repository.storageClusterCode,
+      storageAccessKeyId: null,
+      storageSecretAccessKey: null,
+    });
+
+    return repository;
   }
 
   async get(auth: AuthDto, id: string) {
@@ -64,12 +77,16 @@ export class RepositoryService {
 
     const site = this.topology.getSite(repository.siteCode);
 
+    const owner = await this.repositoryRepository.getStorageOwner(repository.id);
+    const credentials = await this.storageCredentials.ensure(owner);
+
     const token = await this.jwt.signAsync({
       user: auth.id,
       repository: repository.id,
       writeOnce: repository.worm,
       storageCluster: repository.storageClusterCode,
       connection: repository.connectionType,
+      storageCredentials: this.storageCredentials.seal(repository.id, credentials),
     });
 
     this.wideContext.addContext('repositoryId', repository.id);
@@ -88,6 +105,7 @@ export class RepositoryService {
       throw new BadRequestException('Refusing to delete write-only repository');
     }
 
+    await this.storageCredentials.revoke(await this.repositoryRepository.getStorageOwner(id));
     await this.repositoryRepository.delete(id);
   }
 }

--- a/packages/yucca-api/src/services/storageCredential.service.spec.ts
+++ b/packages/yucca-api/src/services/storageCredential.service.spec.ts
@@ -1,0 +1,105 @@
+import { openStorageCredentials } from '@common/server';
+import { env } from 'src/env';
+import { StorageCredentialService, storageUserId } from 'src/services/storageCredential.service';
+import { Mocks, newMocks } from '../../test/mocks';
+
+const repoId = 'e2b47875-91a9-4c67-a3cd-fd6c0a5b6d11';
+
+const cluster = { code: 'father-spice', display_name: 'Spice', active: true, rgw_admin_endpoint: 'https://rgw.test' };
+
+const unprovisioned = {
+  id: repoId,
+  storageClusterCode: 'father-spice',
+  storageAccessKeyId: null,
+  storageSecretAccessKey: null,
+};
+
+const credentials = { accessKeyId: 'AKIAREPO', secretAccessKey: 's3cret' };
+
+describe(StorageCredentialService.name, () => {
+  let sut: StorageCredentialService;
+  let mocks: Mocks;
+
+  beforeEach(() => {
+    mocks = newMocks();
+    mocks.topology.getCluster.mockReturnValue(cluster);
+    sut = new StorageCredentialService(mocks.rgwAdmin as never, mocks.repository as never, mocks.topology as never);
+  });
+
+  describe('ensure', () => {
+    it('creates the repository RGW user and stores the keys sealed', async () => {
+      mocks.rgwAdmin.ensureUser.mockResolvedValue(credentials);
+
+      await expect(sut.ensure(unprovisioned)).resolves.toEqual(credentials);
+
+      expect(mocks.rgwAdmin.ensureUser).toHaveBeenCalledWith(cluster, storageUserId(repoId), expect.any(String));
+
+      const [, stored] = mocks.repository.setStorageCredentials.mock.calls[0];
+      expect(stored.storageAccessKeyId).toBe('AKIAREPO');
+      expect(stored.storageSecretAccessKey).not.toContain('s3cret');
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repoId, stored.storageSecretAccessKey!)).toEqual(
+        credentials,
+      );
+    });
+
+    it('reuses the stored credentials without touching RGW', async () => {
+      mocks.rgwAdmin.ensureUser.mockResolvedValue(credentials);
+      await sut.ensure(unprovisioned);
+      const [, stored] = mocks.repository.setStorageCredentials.mock.calls[0];
+      mocks.rgwAdmin.ensureUser.mockClear();
+
+      await expect(
+        sut.ensure({ ...unprovisioned, storageSecretAccessKey: stored.storageSecretAccessKey }),
+      ).resolves.toEqual(credentials);
+
+      expect(mocks.rgwAdmin.ensureUser).not.toHaveBeenCalled();
+    });
+
+    // The compose stack runs against MinIO, which has no RGW admin API.
+    it('falls back to the static keys on a cluster without an admin endpoint', async () => {
+      mocks.rgwAdmin.supports.mockReturnValue(false);
+
+      await expect(sut.ensure(unprovisioned)).resolves.toEqual({
+        accessKeyId: env.STORAGE_STATIC_ACCESS_KEY_ID,
+        secretAccessKey: env.STORAGE_STATIC_SECRET_ACCESS_KEY,
+      });
+      expect(mocks.rgwAdmin.ensureUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rotate', () => {
+    it('issues a fresh key pair and re-seals it', async () => {
+      const rotated = { accessKeyId: 'AKIANEW', secretAccessKey: 'newsecret' };
+      mocks.rgwAdmin.rotateKeys.mockResolvedValue(rotated);
+
+      await expect(sut.rotate(unprovisioned)).resolves.toEqual(rotated);
+
+      const [, stored] = mocks.repository.setStorageCredentials.mock.calls[0];
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repoId, stored.storageSecretAccessKey!)).toEqual(
+        rotated,
+      );
+    });
+  });
+
+  describe('revoke', () => {
+    it('drops the RGW keys and clears the stored ones', async () => {
+      await sut.revoke({ ...unprovisioned, storageAccessKeyId: 'AKIAREPO', storageSecretAccessKey: 'sealed' });
+
+      expect(mocks.rgwAdmin.revokeKeys).toHaveBeenCalledWith(cluster, storageUserId(repoId));
+      expect(mocks.repository.setStorageCredentials).toHaveBeenCalledWith(repoId, {
+        storageAccessKeyId: null,
+        storageSecretAccessKey: null,
+      });
+    });
+  });
+
+  describe('seal', () => {
+    it('seals against the repository it was minted for', () => {
+      const sealed = sut.seal(repoId, credentials);
+
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, repoId, sealed)).toEqual(credentials);
+      expect(() => openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, 'another-repository', sealed)).toThrow();
+      expect(() => openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repoId, sealed)).toThrow();
+    });
+  });
+});

--- a/packages/yucca-api/src/services/storageCredential.service.ts
+++ b/packages/yucca-api/src/services/storageCredential.service.ts
@@ -1,0 +1,78 @@
+import { openStorageCredentials, sealStorageCredentials, StorageCredentials } from '@common/server';
+import { Injectable } from '@nestjs/common';
+import { env } from 'src/env';
+import { RepositoryRepository } from 'src/repositories/repository.repository';
+import { RgwAdminRepository } from 'src/repositories/rgwAdmin.repository';
+import { TopologyRepository, TopologyStorageCluster } from 'src/repositories/topology.repository';
+
+export type StorageCredentialOwner = {
+  id: string;
+  storageClusterCode: string;
+  storageAccessKeyId: string | null;
+  storageSecretAccessKey: string | null;
+};
+
+export const storageUserId = (repositoryId: string) => `yucca-repo-${repositoryId}`;
+
+@Injectable()
+export class StorageCredentialService {
+  constructor(
+    private readonly rgw: RgwAdminRepository,
+    private readonly repositoryRepository: RepositoryRepository,
+    private readonly topology: TopologyRepository,
+  ) {}
+
+  async ensure(repository: StorageCredentialOwner): Promise<StorageCredentials> {
+    if (repository.storageSecretAccessKey) {
+      return openStorageCredentials(env.STORAGE_CREDENTIAL_KEY, repository.id, repository.storageSecretAccessKey);
+    }
+    return this.provision(repository, (cluster) =>
+      this.rgw.ensureUser(cluster, storageUserId(repository.id), `yucca repository ${repository.id}`),
+    );
+  }
+
+  async rotate(repository: StorageCredentialOwner): Promise<StorageCredentials> {
+    return this.provision(repository, (cluster) => this.rgw.rotateKeys(cluster, storageUserId(repository.id)));
+  }
+
+  async revoke(repository: StorageCredentialOwner): Promise<void> {
+    const cluster = this.topology.getCluster(repository.storageClusterCode);
+    if (this.rgw.supports(cluster)) {
+      await this.rgw.revokeKeys(cluster, storageUserId(repository.id));
+    }
+    await this.repositoryRepository.setStorageCredentials(repository.id, {
+      storageAccessKeyId: null,
+      storageSecretAccessKey: null,
+    });
+  }
+
+  seal(repositoryId: string, credentials: StorageCredentials): string {
+    return sealStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY[0], repositoryId, credentials);
+  }
+
+  private async provision(
+    repository: StorageCredentialOwner,
+    issue: (cluster: TopologyStorageCluster) => Promise<StorageCredentials>,
+  ): Promise<StorageCredentials> {
+    const cluster = this.topology.getCluster(repository.storageClusterCode);
+    const credentials = this.rgw.supports(cluster) ? await issue(cluster) : staticCredentials(cluster);
+
+    await this.repositoryRepository.setStorageCredentials(repository.id, {
+      storageAccessKeyId: credentials.accessKeyId,
+      storageSecretAccessKey: sealStorageCredentials(env.STORAGE_CREDENTIAL_KEY[0], repository.id, credentials),
+    });
+    return credentials;
+  }
+}
+
+const staticCredentials = (cluster: TopologyStorageCluster): StorageCredentials => {
+  const accessKeyId = env.STORAGE_STATIC_ACCESS_KEY_ID;
+  const secretAccessKey = env.STORAGE_STATIC_SECRET_ACCESS_KEY;
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error(
+      `Storage cluster '${cluster.code}' has no rgw_admin_endpoint and no ` +
+        `STORAGE_STATIC_ACCESS_KEY_ID/STORAGE_STATIC_SECRET_ACCESS_KEY to fall back to`,
+    );
+  }
+  return { accessKeyId, secretAccessKey };
+};

--- a/packages/yucca-api/test/mocks.ts
+++ b/packages/yucca-api/test/mocks.ts
@@ -4,11 +4,13 @@ import type { CryptoRepository } from 'src/repositories/crypto.repository';
 import type { DatabaseRepository } from 'src/repositories/database.repository';
 import type { OidcRepository } from 'src/repositories/oidc.repository';
 import type { RepositoryRepository } from 'src/repositories/repository.repository';
+import type { RgwAdminRepository } from 'src/repositories/rgwAdmin.repository';
 import type { SessionRepository } from 'src/repositories/session.repository';
 import type { SettingsRepository } from 'src/repositories/settings.repository';
 import type { TopologyRepository } from 'src/repositories/topology.repository';
 import type { UserRepository } from 'src/repositories/user.repository';
 import type { UserAllowlistRepository } from 'src/repositories/userAllowlist.repository';
+import type { StorageCredentialService } from 'src/services/storageCredential.service';
 
 export type RepositoryInterface<T extends object> = Pick<T, keyof T>;
 
@@ -65,8 +67,30 @@ export const newRepositoryRepositoryMock = (): jest.Mocked<RepositoryInterface<R
     create: jest.fn(),
     get: jest.fn(),
     getByUser: jest.fn(),
+    getByIds: jest.fn(),
+    getStorageOwner: jest.fn(),
+    setStorageCredentials: jest.fn(),
+    reparent: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+  };
+};
+
+export const newRgwAdminRepositoryMock = (): jest.Mocked<RepositoryInterface<RgwAdminRepository>> => {
+  return {
+    supports: jest.fn().mockReturnValue(true),
+    ensureUser: jest.fn(),
+    rotateKeys: jest.fn(),
+    revokeKeys: jest.fn(),
+  };
+};
+
+export const newStorageCredentialServiceMock = (): jest.Mocked<RepositoryInterface<StorageCredentialService>> => {
+  return {
+    ensure: jest.fn().mockResolvedValue({ accessKeyId: 'access', secretAccessKey: 'secret' }),
+    rotate: jest.fn(),
+    revoke: jest.fn(),
+    seal: jest.fn().mockReturnValue('sealed'),
   };
 };
 
@@ -97,6 +121,7 @@ export const newTopologyRepositoryMock = (): jest.Mocked<RepositoryInterface<Top
     load: jest.fn(),
     get: jest.fn(),
     getSite: jest.fn(),
+    getCluster: jest.fn(),
     hasSite: jest.fn(),
     hasCluster: jest.fn(),
     getActiveCluster: jest.fn(),
@@ -140,6 +165,8 @@ export const newMocks = () => {
     user: newUserRepositoryMock(),
     userAllowlist: newUserAllowlistRepositoryMock(),
     repository: newRepositoryRepositoryMock(),
+    rgwAdmin: newRgwAdminRepositoryMock(),
+    storageCredential: newStorageCredentialServiceMock(),
     settings: newSettingsRepositoryMock(),
     topology: newTopologyRepositoryMock(),
     logger: newLoggerRepositoryMock(),

--- a/packages/yucca-api/test/repository.integration-spec.ts
+++ b/packages/yucca-api/test/repository.integration-spec.ts
@@ -1,9 +1,11 @@
+import { openStorageCredentials } from '@common/server';
 import { MetricService } from '@common/server/otel';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { controllers, imports, providers } from '../src/app.module';
+import { env } from '../src/env';
 import { newMetricServiceMock } from './mocks';
 import { testUtils } from './testUtils';
 
@@ -156,6 +158,27 @@ describe('RepositoryController (e2e)', () => {
         writeOnce: false,
         connection: 'immich',
       });
+    });
+
+    // Without this claim michael 401s every request for the repository.
+    it('carries the repository storage credentials, sealed', async () => {
+      const { body } = await request(app.getHttpServer())
+        .post(`/api/repository/${repository.id}/restic`)
+        .set('Cookie', `yucca-access-token=${session.accessToken}`)
+        .expect(201);
+
+      const token = new URL((body.url as string).slice('rest:'.length)).password;
+      const claims = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as Record<string, unknown>;
+
+      const sealed = claims.storageCredentials as string;
+      expect(sealed).toEqual(expect.any(String));
+      expect(openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, repository.id, sealed)).toEqual({
+        accessKeyId: expect.any(String),
+        secretAccessKey: expect.any(String),
+      });
+      expect(() =>
+        openStorageCredentials(env.STORAGE_CREDENTIAL_SEAL_KEY, '00000000-0000-0000-0000-000000000000', sealed),
+      ).toThrow();
     });
   });
 

--- a/packages/yucca-api/test/rgwAdmin.integration-spec.ts
+++ b/packages/yucca-api/test/rgwAdmin.integration-spec.ts
@@ -1,0 +1,82 @@
+import { AwsClient } from 'aws4fetch';
+import { RgwAdminRepository } from 'src/repositories/rgwAdmin.repository';
+import { TopologyStorageCluster } from 'src/repositories/topology.repository';
+
+// Needs a real RadosGW: `mise k3d:up && mise tilt:ci-infra`, then
+// `mise test:integration:k3d` (which exports RADOS_*). Skipped otherwise —
+// MinIO has no admin API to run this against.
+const endpoint = process.env.RADOS_ENDPOINT;
+const configured = Boolean(endpoint && process.env.RADOS_ACCESS_KEY_ID && process.env.RADOS_SECRET_ACCESS_KEY);
+const describeRgw = configured ? describe : describe.skip;
+
+const cluster = {
+  code: 'local-dev',
+  display_name: 'Local development storage',
+  active: true,
+  rgw_admin_endpoint: endpoint,
+} as TopologyStorageCluster;
+
+describeRgw('RgwAdminRepository (integration)', () => {
+  const repository = new RgwAdminRepository();
+  const uid = `yucca-repo-it-${Date.now()}`;
+  const bucket = `${uid}-bucket`;
+
+  const canWrite = async (keys: { accessKeyId: string; secretAccessKey: string }, method: string) => {
+    const client = new AwsClient({ ...keys, service: 's3', region: 'rgw' });
+    const response = await client.fetch(new URL(`/${bucket}`, endpoint).toString(), { method });
+    return response.status;
+  };
+
+  afterAll(async () => {
+    if (!configured) {
+      return;
+    }
+    await repository.revokeKeys(cluster, uid).catch(() => undefined);
+  });
+
+  it('creates the user and returns keys that can stand up its bucket', async () => {
+    const keys = await repository.ensureUser(cluster, uid, 'integration test repository');
+
+    expect(keys.accessKeyId).toEqual(expect.any(String));
+    expect(keys.secretAccessKey).toEqual(expect.any(String));
+    // 200 proves RGW accepted a request signed with the freshly minted keys.
+    await expect(canWrite(keys, 'PUT')).resolves.toBe(200);
+  });
+
+  it('is idempotent: a second ensure returns the same key', async () => {
+    const first = await repository.ensureUser(cluster, uid, 'integration test repository');
+    const second = await repository.ensureUser(cluster, uid, 'integration test repository');
+
+    expect(second.accessKeyId).toBe(first.accessKeyId);
+  });
+
+  // Rotation answers a leaked credential, so the old key has to stop working,
+  // not merely be superseded.
+  it('rotate issues a new key and invalidates the old one', async () => {
+    const before = await repository.ensureUser(cluster, uid, 'integration test repository');
+    const after = await repository.rotateKeys(cluster, uid);
+
+    expect(after.accessKeyId).not.toBe(before.accessKeyId);
+    await expect(canWrite(after, 'HEAD')).resolves.toBe(200);
+    await expect(canWrite(before, 'HEAD')).resolves.toBe(403);
+  });
+
+  it('revoke leaves the bucket but kills every key', async () => {
+    const keys = await repository.ensureUser(cluster, uid, 'integration test repository');
+    await repository.revokeKeys(cluster, uid);
+
+    await expect(canWrite(keys, 'HEAD')).resolves.toBe(403);
+
+    // The bucket is still there — deleting a repository has never deleted data.
+    const admin = new AwsClient({
+      accessKeyId: process.env.RADOS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.RADOS_SECRET_ACCESS_KEY!,
+      service: 's3',
+      region: 'rgw',
+    });
+    const stats = await admin.fetch(
+      `${endpoint!.replace(/\/$/, '')}/admin/bucket?${new URLSearchParams({ bucket, format: 'json' })}`,
+    );
+    expect(stats.status).toBe(200);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,6 +850,9 @@ importers:
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.0
+      aws4fetch:
+        specifier: 'catalog:'
+        version: 1.0.20
       class-validator:
         specifier: 'catalog:'
         version: 0.14.3


### PR DESCRIPTION
Each repository gets its own RGW user, stored sealed and sealed again into the restic token it mints.

- `main` <!-- branch-stack -->
  - \#433
    - \#437
      - \#438 :point\_left:
        - \#439
          - \#440
            - \#441
              - \#442
                - \#446
