### PR TITLE
feat(yucca-admin-api): provision and mint per-repository credentials

### DIFF
--- a/.mise/tasks/yucca-admin-api/env
+++ b/.mise/tasks/yucca-admin-api/env
@@ -20,6 +20,13 @@ Ls1C0ncCcmRhqKA7UxLknn0ji5FcKaku1zBOhxQYcxFVmsYtAxZ1ljgN
 # Dev restic minting: the same dev keypair signs repo tokens (michael's dev
 # public key matches), pointed at the local michael.
 export RESTIC_JWT_PRIVATE_KEY=${RESTIC_JWT_PRIVATE_KEY:-$JWT_PRIVATE_KEY}
+# Same well-known local-dev keys as .mise/tasks/yucca-api/env: both APIs mint
+# restic tokens, so both seal credentials into them.
+export STORAGE_CREDENTIAL_KEY=${STORAGE_CREDENTIAL_KEY:-eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=}
+export STORAGE_CREDENTIAL_SEAL_KEY=${STORAGE_CREDENTIAL_SEAL_KEY:-eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=}
+export STORAGE_STATIC_ACCESS_KEY_ID=${STORAGE_STATIC_ACCESS_KEY_ID:-${S3_ACCESS_KEY_ID:-minio}}
+export STORAGE_STATIC_SECRET_ACCESS_KEY=${STORAGE_STATIC_SECRET_ACCESS_KEY:-${S3_SECRET_ACCESS_KEY:-miniominio}}
+
 export TOPOLOGY_FILE=${TOPOLOGY_FILE:-./topology.dev.json}
 export LEGACY_SITE_CODE=${LEGACY_SITE_CODE:-local}
 export LEGACY_STORAGE_CLUSTER_CODE=${LEGACY_STORAGE_CLUSTER_CODE:-local-dev}

--- a/charts/apps/yucca-admin-api/templates/deployment.yaml
+++ b/charts/apps/yucca-admin-api/templates/deployment.yaml
@@ -2,13 +2,17 @@
   (dict "name" "OIDC_ADMIN_ISSUER" "value" .Values.oidcIssuer)
   (dict "name" "OIDC_ADMIN_REDIRECT_URI" "value" .Values.oidcRedirectUri)
   (dict "name" "OIDC_ADMIN_LOGOUT_REDIRECT_URI" "value" .Values.oidcLogoutRedirectUri)
+  (dict "name" "RADOS_ACCESS_KEY_ID" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "AccessKey")))
+  (dict "name" "RADOS_SECRET_ACCESS_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" .Values.radosSecretName "key" "SecretKey")))
   (dict "name" "POSTGRES_HOST" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "host")))
   (dict "name" "POSTGRES_PORT" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "port")))
   (dict "name" "POSTGRES_DATABASE" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "dbname")))
   (dict "name" "POSTGRES_USERNAME" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "username")))
   (dict "name" "POSTGRES_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" (printf "%s-app" .Values.postgresClusterName) "key" "password")))
 )) }}
-{{- $_ := set .Values "envFrom" (list (dict "secretRef" (dict "name" (include "yucca-common.fullname" .)))) }}
+{{- $_ := set .Values "envFrom" (list
+  (dict "secretRef" (dict "name" (include "yucca-common.fullname" .)))
+  (dict "secretRef" (dict "name" .Values.radosSecretName))) }}
 {{- $topology := (lookup "v1" "ConfigMap" .Release.Namespace "yucca-topology") | default dict }}
 {{- $topologyData := (get $topology "data") | default dict }}
 {{- $_ := set .Values "podAnnotations" (merge

--- a/charts/apps/yucca-admin-api/templates/secret.yaml
+++ b/charts/apps/yucca-admin-api/templates/secret.yaml
@@ -3,6 +3,10 @@
 {{- if .Values.useDevKeypair }}
 {{- /* The dev keypair doubles as the restic signing key: michael's dev public
 key is its counterpart, so admin-minted repo URLs work against dev michael. */}}
-{{- $_ := set .Values "secretData" (merge (dict "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey "RESTIC_JWT_PRIVATE_KEY" .Values.devJwtPrivateKey) (.Values.secretData | default dict)) }}
+{{- $_ := set .Values "secretData" (merge (dict
+  "JWT_PRIVATE_KEY" .Values.devJwtPrivateKey
+  "RESTIC_JWT_PRIVATE_KEY" .Values.devJwtPrivateKey
+  "STORAGE_CREDENTIAL_KEY" .Values.devStorageCredentialKey
+  "STORAGE_CREDENTIAL_SEAL_KEY" .Values.devStorageSealKey) (.Values.secretData | default dict)) }}
 {{- end }}
 {{- include "yucca-common.secret" . }}

--- a/charts/apps/yucca-admin-api/values.yaml
+++ b/charts/apps/yucca-admin-api/values.yaml
@@ -31,6 +31,13 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
+# RGW user with users+buckets admin caps: the API creates one S3 user per
+# repository with it, so michael never needs a cluster-wide credential. In dev
+# Rook writes the keys here as rook-ceph-object-user-<store>-<user>; prod points
+# this at the TF-provisioned yucca-provisioner-rgw Secret. Per-cluster overrides
+# ride in the same Secret as RADOS_ACCESS_KEY_ID_<CODE>/RADOS_SECRET_ACCESS_KEY_<CODE>.
+radosSecretName: rook-ceph-object-user-yucca-provisioner
+
 # CNPG-managed postgres Cluster name (shares yucca-api's database)
 postgresClusterName: yucca-db
 
@@ -51,6 +58,11 @@ secretData:
 # provide a real key gets a loud missing-JWT_PRIVATE_KEY crash instead of
 # silently signing admin tokens with a public fixture.
 useDevKeypair: false
+# The dev storage-credential keys, under the same opt-in. The seal half is
+# shared with michael (charts/apps/michael/values.yaml); the at-rest half never
+# leaves the APIs.
+devStorageCredentialKey: eXVjY2EtZGV2LXN0b3JhZ2UtY3JlZGVudGlhbC1rZXk=
+devStorageSealKey: eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=
 devJwtPrivateKey: |
   -----BEGIN PRIVATE KEY-----
   MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgCla79+Sip4o2hZ1K

--- a/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
@@ -33,6 +33,10 @@ spec:
       tag: ${YUCCA_IMAGE_TAG:=}
     # secretData nulled: replaced by the TF-provisioned `yucca-admin-api` Secret
     # (OIDC_ADMIN_CLIENT_ID/SECRET) via the chart's envFrom: secretRef.
+    # RGW admin keys for per-repository S3 users: TF-provisioned into the
+    # yucca-provisioner-rgw Secret (tf .../talos/secrets.tf), like
+    # yucca-metrics-rgw. Additional clusters get RADOS_*_<CODE> pairs in it.
+    radosSecretName: yucca-provisioner-rgw
     secretData: null
     # Not publicly routed — reached over the NetBird overlay at
     # ${YUCCA_ADMIN_HOST} (per-cluster, from cluster-settings). Admin auth uses

--- a/packages/yucca-admin-api/openapi-specs.json
+++ b/packages/yucca-admin-api/openapi-specs.json
@@ -685,6 +685,46 @@
         ]
       }
     },
+    "/api/repository/{id}/storage-credentials": {
+      "post": {
+        "operationId": "repositoryStorageCredentials",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepositoryStorageCredentialsRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryStorageCredentialsResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Repository"
+        ]
+      }
+    },
     "/api/allowlist": {
       "get": {
         "operationId": "listAllowlist",
@@ -835,6 +875,88 @@
         },
         "tags": [
           "Allowlist"
+        ]
+      }
+    },
+    "/api/settings": {
+      "get": {
+        "operationId": "listSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SettingsListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Settings"
+        ]
+      }
+    },
+    "/api/settings/{scope}": {
+      "put": {
+        "operationId": "setSettings",
+        "parameters": [
+          {
+            "name": "scope",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SettingsValueDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SettingsEntryResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Settings"
+        ]
+      },
+      "delete": {
+        "operationId": "deleteSettings",
+        "parameters": [
+          {
+            "name": "scope",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -1268,6 +1390,14 @@
           "worm": {
             "type": "boolean"
           },
+          "siteCode": {
+            "type": "string",
+            "description": "Stable internal site code"
+          },
+          "storageClusterCode": {
+            "type": "string",
+            "description": "Stable, globally unique internal storage cluster code"
+          },
           "connectionId": {
             "type": "string"
           },
@@ -1285,6 +1415,8 @@
           "id",
           "name",
           "worm",
+          "siteCode",
+          "storageClusterCode",
           "connectionId",
           "connectionType",
           "user",
@@ -1321,6 +1453,10 @@
           },
           "worm": {
             "type": "boolean"
+          },
+          "site": {
+            "type": "string",
+            "description": "Internal site code to place the repository in; defaults to the topology default site"
           },
           "connectionType": {
             "type": "string",
@@ -1366,6 +1502,35 @@
         },
         "required": [
           "url"
+        ]
+      },
+      "RepositoryStorageCredentialsRequestDto": {
+        "type": "object",
+        "properties": {
+          "rotate": {
+            "type": "boolean",
+            "description": "Issue a fresh key pair, invalidating the credentials already minted"
+          }
+        }
+      },
+      "RepositoryStorageCredentialsResponseDto": {
+        "type": "object",
+        "properties": {
+          "storageUserId": {
+            "type": "string",
+            "description": "RGW user that owns the repository bucket"
+          },
+          "storageClusterCode": {
+            "type": "string"
+          },
+          "accessKeyId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "storageUserId",
+          "storageClusterCode",
+          "accessKeyId"
         ]
       },
       "RepositoryUpdateRequestDto": {
@@ -1506,6 +1671,63 @@
         },
         "required": [
           "count"
+        ]
+      },
+      "SettingsValueDto": {
+        "type": "object",
+        "properties": {
+          "restic_pack_size_mib": {
+            "type": "number"
+          },
+          "connections_math": {
+            "type": "string",
+            "description": "Client-evaluated expression: integers, cores, min, max, + - * /"
+          }
+        }
+      },
+      "SettingsEntryDto": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string",
+            "description": "'global', 'site:<code>' or 'cluster:<code>'"
+          },
+          "value": {
+            "$ref": "#/components/schemas/SettingsValueDto"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope",
+          "value",
+          "updatedAt"
+        ]
+      },
+      "SettingsListResponseDto": {
+        "type": "object",
+        "properties": {
+          "settings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SettingsEntryDto"
+            }
+          }
+        },
+        "required": [
+          "settings"
+        ]
+      },
+      "SettingsEntryResponseDto": {
+        "type": "object",
+        "properties": {
+          "entry": {
+            "$ref": "#/components/schemas/SettingsEntryDto"
+          }
+        },
+        "required": [
+          "entry"
         ]
       },
       "FeatureFlagDefDto": {

--- a/packages/yucca-admin-api/package.json
+++ b/packages/yucca-admin-api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "catalog:",
     "@nestjs/swagger": "catalog:",
     "@opentelemetry/api": "catalog:",
+    "aws4fetch": "catalog:",
     "class-validator": "catalog:",
     "cookie": "catalog:",
     "event-iterator": "catalog:",

--- a/packages/yucca-admin-api/src/app.module.ts
+++ b/packages/yucca-admin-api/src/app.module.ts
@@ -18,6 +18,7 @@ import { DatabaseRepository } from './repositories/database.repository';
 import { FeatureFlagRepository } from './repositories/featureFlag.repository';
 import { OidcRepository } from './repositories/oidc.repository';
 import { RepositoryRepository } from './repositories/repository.repository';
+import { RgwAdminRepository } from './repositories/rgwAdmin.repository';
 import { SessionRepository } from './repositories/session.repository';
 import { SettingsRepository } from './repositories/settings.repository';
 import { StorageRepository } from './repositories/storage.repository';
@@ -31,6 +32,7 @@ import { FeaturesService } from './services/features.service';
 import { RepositoryService } from './services/repository.service';
 import { SessionService } from './services/session.service';
 import { SettingsService } from './services/settings.service';
+import { StorageCredentialService } from './services/storageCredential.service';
 import { TopologyService } from './services/topology.service';
 import { UserService } from './services/user.service';
 import { getKyselyConfig } from './utils/database';
@@ -68,6 +70,7 @@ export const providers = [
   UserAllowlistRepository,
   SessionRepository,
   RepositoryRepository,
+  RgwAdminRepository,
   SettingsRepository,
   StorageRepository,
   TopologyRepository,
@@ -80,6 +83,7 @@ export const providers = [
   SettingsService,
   TopologyService,
   RepositoryService,
+  StorageCredentialService,
   FeaturesService,
   { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },
   { provide: APP_GUARD, useClass: AuthGuard },

--- a/packages/yucca-admin-api/src/controllers/repository.controller.ts
+++ b/packages/yucca-admin-api/src/controllers/repository.controller.ts
@@ -6,6 +6,8 @@ import {
   RepositoryGetResponseDto,
   RepositoryListQueryDto,
   RepositoryListResponseDto,
+  RepositoryStorageCredentialsRequestDto,
+  RepositoryStorageCredentialsResponseDto,
   RepositoryUpdateRequestDto,
   RepositoryUpdateResponseDto,
   RepositoryUrlResponseDto,
@@ -43,6 +45,16 @@ export class RepositoryController {
   @ApiOkResponse({ type: RepositoryUrlResponseDto })
   repositoryUrl(@Param('id') id: string): Promise<RepositoryUrlResponseDto> {
     return this.repository.url(id);
+  }
+
+  @Post('/:id/storage-credentials')
+  @AuthRoute()
+  @ApiOkResponse({ type: RepositoryStorageCredentialsResponseDto })
+  repositoryStorageCredentials(
+    @Param('id') id: string,
+    @Body() dto: RepositoryStorageCredentialsRequestDto,
+  ): Promise<RepositoryStorageCredentialsResponseDto> {
+    return this.repository.provisionStorageCredentials(id, dto);
   }
 
   @Patch('/:id')

--- a/packages/yucca-admin-api/src/dto/repository.dto.ts
+++ b/packages/yucca-admin-api/src/dto/repository.dto.ts
@@ -142,3 +142,21 @@ export class RepositoryUpdateResponseDto {
   @ApiProperty()
   repository!: RepositoryAdminDto;
 }
+
+export class RepositoryStorageCredentialsRequestDto {
+  @ApiProperty({ required: false, description: 'Issue a fresh key pair, invalidating the credentials already minted' })
+  @IsOptional()
+  @IsBoolean()
+  rotate?: boolean;
+}
+
+export class RepositoryStorageCredentialsResponseDto {
+  @ApiProperty({ description: 'RGW user that owns the repository bucket' })
+  storageUserId!: string;
+
+  @ApiProperty()
+  storageClusterCode!: string;
+
+  @ApiProperty()
+  accessKeyId!: string;
+}

--- a/packages/yucca-admin-api/src/env.ts
+++ b/packages/yucca-admin-api/src/env.ts
@@ -1,3 +1,4 @@
+import { parseStorageCredentialKeys } from '@common/server';
 import type { StringValue } from 'ms';
 import { z } from 'zod';
 
@@ -29,6 +30,17 @@ const schema = z.object({
     .regex(/^\d+\s*(ms|s|m|h|d|w|y)$/i, 'Expected a duration like "1d", "30m", "3600s"')
     .default('1d')
     .transform((value): StringValue => value as StringValue),
+
+  // First key seals, the rest stay accepted so a rotation is a two-step deploy.
+  // Only the SEAL key is shared with michael.
+  STORAGE_CREDENTIAL_KEY: z.string().transform(parseStorageCredentialKeys),
+  STORAGE_CREDENTIAL_SEAL_KEY: z.string().transform(parseStorageCredentialKeys),
+
+  RADOS_ACCESS_KEY_ID: z.string().optional(),
+  RADOS_SECRET_ACCESS_KEY: z.string().optional(),
+
+  STORAGE_STATIC_ACCESS_KEY_ID: z.string().optional(),
+  STORAGE_STATIC_SECRET_ACCESS_KEY: z.string().optional(),
 
   TOPOLOGY_FILE: z.string().default('./topology.dev.json'),
   LEGACY_SITE_CODE: z.string(),

--- a/packages/yucca-admin-api/src/repositories/repository.repository.ts
+++ b/packages/yucca-admin-api/src/repositories/repository.repository.ts
@@ -84,6 +84,21 @@ export class RepositoryRepository {
     return this.get(id);
   }
 
+  getStorageOwner(id: string) {
+    return this.db
+      .selectFrom('repositories')
+      .select(['id', 'storageClusterCode', 'storageAccessKeyId', 'storageSecretAccessKey'])
+      .where('id', '=', id)
+      .executeTakeFirstOrThrow();
+  }
+
+  async setStorageCredentials(
+    id: string,
+    credentials: Pick<RepositoryTable, 'storageAccessKeyId' | 'storageSecretAccessKey'>,
+  ) {
+    await this.db.updateTable('repositories').where('id', '=', id).set(credentials).execute();
+  }
+
   async delete(id: string) {
     await this.db.deleteFrom('repositories').where('id', '=', id).execute();
   }

--- a/packages/yucca-admin-api/src/repositories/rgwAdmin.repository.ts
+++ b/packages/yucca-admin-api/src/repositories/rgwAdmin.repository.ts
@@ -1,0 +1,1 @@
+../../../yucca-api/src/repositories/rgwAdmin.repository.ts

--- a/packages/yucca-admin-api/src/services/repository.service.spec.ts
+++ b/packages/yucca-admin-api/src/services/repository.service.spec.ts
@@ -35,11 +35,25 @@ describe(RepositoryService.name, () => {
   let users: { [k: string]: jest.Mock };
   let topology: { [k: string]: jest.Mock };
   let connections: { [k: string]: jest.Mock };
+  let storageCredentials: { [k: string]: jest.Mock };
   let jwt: JwtService;
   let sut: RepositoryService;
 
   beforeEach(() => {
-    repositories = { list: jest.fn(), get: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+    repositories = {
+      list: jest.fn(),
+      get: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      getStorageOwner: jest.fn().mockResolvedValue({
+        id: repositoryRow.id,
+        storageClusterCode: repositoryRow.storageClusterCode,
+        storageAccessKeyId: 'access',
+        storageSecretAccessKey: 'sealed-at-rest',
+      }),
+      setStorageCredentials: jest.fn(),
+    };
     users = { getBySub: jest.fn(), create: jest.fn() };
     topology = {
       getSite: jest.fn().mockReturnValue(site),
@@ -48,8 +62,21 @@ describe(RepositoryService.name, () => {
       hasCluster: jest.fn(),
     };
     connections = { getByUser: jest.fn(), getOrCreateByType: jest.fn().mockResolvedValue({ id: 'connection-id' }) };
+    storageCredentials = {
+      ensure: jest.fn().mockResolvedValue({ accessKeyId: 'access', secretAccessKey: 'secret' }),
+      rotate: jest.fn(),
+      revoke: jest.fn(),
+      seal: jest.fn().mockReturnValue('sealed'),
+    };
     jwt = newJwtService();
-    sut = new RepositoryService(repositories as never, users as never, connections as never, jwt, topology as never);
+    sut = new RepositoryService(
+      repositories as never,
+      users as never,
+      connections as never,
+      jwt,
+      topology as never,
+      storageCredentials as never,
+    );
   });
 
   describe('create', () => {

--- a/packages/yucca-admin-api/src/services/repository.service.ts
+++ b/packages/yucca-admin-api/src/services/repository.service.ts
@@ -6,6 +6,8 @@ import {
   RepositoryGetResponseDto,
   RepositoryListQueryDto,
   RepositoryListResponseDto,
+  RepositoryStorageCredentialsRequestDto,
+  RepositoryStorageCredentialsResponseDto,
   RepositoryUpdateRequestDto,
   RepositoryUpdateResponseDto,
   RepositoryUrlResponseDto,
@@ -15,6 +17,7 @@ import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { RepositoryRepository } from 'src/repositories/repository.repository';
 import { TopologyRepository } from 'src/repositories/topology.repository';
 import { UserRepository } from 'src/repositories/user.repository';
+import { StorageCredentialService, storageUserId } from 'src/services/storageCredential.service';
 import { resolveLimit } from 'src/utils/pagination';
 
 const serviceUser = {
@@ -31,6 +34,7 @@ export class RepositoryService {
     private readonly connections: ConnectionRepository,
     private readonly jwt: JwtService,
     private readonly topology: TopologyRepository,
+    private readonly storageCredentials: StorageCredentialService,
   ) {}
 
   list(query: RepositoryListQueryDto): Promise<RepositoryListResponseDto> {
@@ -69,6 +73,12 @@ export class RepositoryService {
       siteCode: site.code,
       storageClusterCode: cluster.code,
     });
+    await this.storageCredentials.ensure({
+      id: repository.id,
+      storageClusterCode: repository.storageClusterCode,
+      storageAccessKeyId: null,
+      storageSecretAccessKey: null,
+    });
     return { repository };
   }
 
@@ -78,6 +88,7 @@ export class RepositoryService {
     }
     const repository = await this.repositories.get(id);
     const site = this.topology.getSite(repository.siteCode);
+    const credentials = await this.storageCredentials.ensure(await this.repositories.getStorageOwner(id));
     const token = await this.jwt.signAsync(
       {
         user: repository.user.id,
@@ -85,6 +96,7 @@ export class RepositoryService {
         writeOnce: repository.worm,
         storageCluster: repository.storageClusterCode,
         connection: repository.connectionType,
+        storageCredentials: this.storageCredentials.seal(repository.id, credentials),
       },
       { privateKey: env.RESTIC_JWT_PRIVATE_KEY, algorithm: 'ES256', expiresIn: env.RESTIC_JWT_EXPIRES_IN },
     );
@@ -95,6 +107,22 @@ export class RepositoryService {
     url.pathname = repository.id;
 
     return { url: `rest:${url.href}` };
+  }
+
+  // Drives `yuctl repos migrate-storage-credentials`.
+  async provisionStorageCredentials(
+    id: string,
+    dto: RepositoryStorageCredentialsRequestDto,
+  ): Promise<RepositoryStorageCredentialsResponseDto> {
+    const owner = await this.repositories.getStorageOwner(id);
+    const credentials = dto.rotate
+      ? await this.storageCredentials.rotate(owner)
+      : await this.storageCredentials.ensure(owner);
+    return {
+      storageUserId: storageUserId(id),
+      storageClusterCode: owner.storageClusterCode,
+      accessKeyId: credentials.accessKeyId,
+    };
   }
 
   async update(id: string, dto: RepositoryUpdateRequestDto): Promise<RepositoryUpdateResponseDto> {

--- a/packages/yucca-admin-api/src/services/storageCredential.service.ts
+++ b/packages/yucca-admin-api/src/services/storageCredential.service.ts
@@ -1,0 +1,1 @@
+../../../yucca-api/src/services/storageCredential.service.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,6 +726,9 @@ importers:
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.0
+      aws4fetch:
+        specifier: 'catalog:'
+        version: 1.0.20
       class-validator:
         specifier: 'catalog:'
         version: 0.14.3


### PR DESCRIPTION
Mirrors yucca-api's provisioning and adds the endpoint the yuctl migration drives.

- `main` <!-- branch-stack -->
  - \#433
    - \#437
      - \#438
        - \#439 :point\_left:
          - \#440
            - \#441
              - \#442
                - \#446
