### PR TITLE
feat(michael): take storage credentials from the token

### DIFF
--- a/.mise/tasks/restic-api/env
+++ b/.mise/tasks/restic-api/env
@@ -14,6 +14,12 @@ GS7NQtJ3AnJkYaigO1MS5J59I4uRXCmpLtcwTocUGHMRVZrGLQMWdZY4DQ==
 -----END PUBLIC KEY-----
 }
 
+# Shared with the APIs (.mise/tasks/yucca-api/env): opens the credentials a
+# restic token carries. michael has no S3 credentials of its own.
+export STORAGE_CREDENTIAL_SEAL_KEY=${STORAGE_CREDENTIAL_SEAL_KEY:-eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=}
+
+# For restic-api, the reference implementation, which still reads its S3
+# credentials from the environment. michael ignores these.
 export S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID:-minio}
 export S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY:-miniominio}
 export S3_REGION=${S3_REGION:-minio}

--- a/charts/apps/michael/templates/secret.yaml
+++ b/charts/apps/michael/templates/secret.yaml
@@ -1,6 +1,8 @@
-{{- /* The dev JWT public-key fixture only enters the Secret when explicitly
-opted in (useDevKeypair — dev/local overlay only); see values.yaml. */}}
+{{- /* The dev JWT public key and storage seal key only enter the Secret when
+explicitly opted in (useDevKeypair — dev/local overlay only); see values.yaml. */}}
 {{- if .Values.useDevKeypair }}
-{{- $_ := set .Values "secretData" (merge (dict "JWT_PUBLIC_KEY" .Values.devJwtPublicKey) (.Values.secretData | default dict)) }}
+{{- $_ := set .Values "secretData" (merge (dict
+  "JWT_PUBLIC_KEY" .Values.devJwtPublicKey
+  "STORAGE_CREDENTIAL_SEAL_KEY" .Values.devStorageSealKey) (.Values.secretData | default dict)) }}
 {{- end }}
 {{- include "yucca-common.secret" . }}

--- a/charts/apps/michael/values.yaml
+++ b/charts/apps/michael/values.yaml
@@ -41,6 +41,11 @@ volumeMounts:
 # fails loudly, instead of silently trusting tokens anyone can mint with the
 # committed private half. Prod provides the real key via ExternalSecret.
 useDevKeypair: false
+# The dev half of STORAGE_CREDENTIAL_SEAL_KEY, shared with the APIs
+# (charts/apps/yucca-api/values.yaml, .mise/tasks/*/env). Rendered under the
+# same opt-in as the verification key: without it michael cannot open the
+# credentials any token carries, and every request 401s.
+devStorageSealKey: eXVjY2EtZGV2LW1pY2hhZWwtc2VhbC1rZXktMDAwMDA=
 devJwtPublicKey: |
   -----BEGIN PUBLIC KEY-----
   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpLmwUSBO0p7P1UvGReVxFTvAsCfg
@@ -52,10 +57,9 @@ env:
     value: "3010"
   - name: LOG_LEVEL
     value: debug
-  # S3 object store = Rook-Ceph RGW. michael creates one bucket per restic
-  # repository, so it needs a full RGW user (CephObjectStoreUser via
-  # charts/ceph-objectuser), NOT a bucket-scoped ObjectBucketClaim. Rook writes
-  # the user's keys into this namespace as rook-ceph-object-user-<store>-<user>.
+  # S3 object store = Rook-Ceph RGW. michael configures NO credentials: each
+  # restic token carries its repository's own RGW keys, sealed with
+  # STORAGE_CREDENTIAL_SEAL_KEY, and michael can reach no bucket without one.
   # Must match the dev topology's cluster code (ConfigMap yucca-topology /
   # topology.dev.json): yucca-api mints restic tokens with
   # storageCluster=local-dev,
@@ -68,16 +72,6 @@ env:
     value: /etc/yucca/topology.json
   - name: S3_ENDPOINT
     value: http://rook-ceph-rgw-yucca.rook-ceph.svc:80
-  - name: S3_ACCESS_KEY_ID
-    valueFrom:
-      secretKeyRef:
-        name: rook-ceph-object-user-yucca-michael
-        key: AccessKey
-  - name: S3_SECRET_ACCESS_KEY
-    valueFrom:
-      secretKeyRef:
-        name: rook-ceph-object-user-yucca-michael
-        key: SecretKey
   - name: S3_REGION
     value: us-east-1
   - name: S3_FORCE_PATH_STYLE

--- a/kubernetes/apps/base/michael/helmrelease.yaml
+++ b/kubernetes/apps/base/michael/helmrelease.yaml
@@ -33,9 +33,11 @@ spec:
       # release-please-stamped in git. If unset, the empty default lets the
       # chart fall back to v<appVersion> — the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
-    # secretData nulled: the chart's dev JWT_PUBLIC_KEY fixture is replaced by
-    # the TF-provisioned `yucca-michael` Secret (JWT_PUBLIC_KEY + S3 creds),
-    # which the chart's `envFrom: secretRef: yucca-michael` picks up unchanged.
+    # secretData nulled: the chart's dev fixtures are replaced by the
+    # TF-provisioned `yucca-michael` Secret (JWT_PUBLIC_KEY +
+    # STORAGE_CREDENTIAL_SEAL_KEY), which the chart's
+    # `envFrom: secretRef: yucca-michael` picks up unchanged. No S3 credentials
+    # live here any more: each restic token carries its repository's own.
     secretData: null
     env:
       - name: RESTIC_API_PORT

--- a/kubernetes/apps/base/topology/configmap.yaml
+++ b/kubernetes/apps/base/topology/configmap.yaml
@@ -38,8 +38,6 @@ data:
                 "endpoint": "${S3_ENDPOINT}",
                 "region": "us-east-1",
                 "force_path_style": true,
-                "access_key_env": "S3_ACCESS_KEY_ID",
-                "secret_key_env": "S3_SECRET_ACCESS_KEY",
                 "backend_source": "dns",
                 "backend_dns_host": "${S3_HOST}",
                 "pin_host": true,

--- a/kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml
+++ b/kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml
@@ -38,8 +38,6 @@ data:
                 "endpoint": "http://rook-ceph-rgw-yucca.rook-ceph.svc:80",
                 "region": "us-east-1",
                 "force_path_style": true,
-                "access_key_env": "S3_ACCESS_KEY_ID",
-                "secret_key_env": "S3_SECRET_ACCESS_KEY",
                 "backend_source": "dns",
                 "backend_dns_host": "rook-ceph-rgw-yucca.rook-ceph.svc",
                 "probe_bucket": "michael-rgw-healthcheck"

--- a/packages/e2e/k3d/run.sh
+++ b/packages/e2e/k3d/run.sh
@@ -80,6 +80,12 @@ done
 
 echo "==> jest e2e (it-works, restic-api, yucca-api, orchestration-api)"
 # shellcheck disable=SC1091
+# michael takes its S3 credentials from the token, so the suites that mint their
+# own have to seal the REAL RGW user's keys — the cluster's, not the compose
+# MinIO defaults the env files fall back to.
+S3_ACCESS_KEY_ID="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.AccessKey}' | base64 -d)"
+S3_SECRET_ACCESS_KEY="$(kubectl -n yucca get secret rook-ceph-object-user-yucca-michael -o jsonpath='{.data.SecretKey}' | base64 -d)"
+export S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY
 source .mise/tasks/restic-api/env
 # shellcheck disable=SC1091
 source .mise/tasks/yucca-api/env

--- a/packages/e2e/src/env.ts
+++ b/packages/e2e/src/env.ts
@@ -5,6 +5,11 @@ const schema = z.object({
   YUCCA_API_PORT: z.coerce.number().min(1000),
 
   JWT_PRIVATE_KEY: z.string(),
+
+  // A restic token has to carry its repository's own S3 credentials, sealed.
+  STORAGE_CREDENTIAL_SEAL_KEY: z.string(),
+  S3_ACCESS_KEY_ID: z.string(),
+  S3_SECRET_ACCESS_KEY: z.string(),
 });
 
 export const env = schema.parse(process.env);

--- a/packages/e2e/test/restic-api.spec.ts
+++ b/packages/e2e/test/restic-api.spec.ts
@@ -1,3 +1,4 @@
+import { parseStorageCredentialKeys, sealStorageCredentials } from '@common/server';
 import {
   backup,
   cache,
@@ -34,12 +35,20 @@ import { env } from 'src/env';
 
 const password = 'password';
 
+const sealKey = parseStorageCredentialKeys(env.STORAGE_CREDENTIAL_SEAL_KEY)[0];
+
+// These suites drive michael's protocol directly rather than going through
+// yucca-api (yucca-api.spec covers that path), so they seal their own.
 function generateRepoUrl(repository: string, writeOnce: boolean) {
   const token = jwt.sign(
     {
       user: randomUUID(),
       repository,
       writeOnce,
+      storageCredentials: sealStorageCredentials(sealKey, repository, {
+        accessKeyId: env.S3_ACCESS_KEY_ID,
+        secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+      }),
     },
     env.JWT_PRIVATE_KEY,
     { algorithm: 'ES256' },

--- a/packages/michael/e2e_test.go
+++ b/packages/michael/e2e_test.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"michael/internal/config"
+	michaelcreds "michael/internal/credentials"
 	"michael/internal/handlers"
 	"michael/internal/storage"
 
@@ -71,14 +72,25 @@ func e2eEnv(t *testing.T, key string) string {
 	return v
 }
 
+// The harness's object-user keys reach michael the way real ones do: sealed
+// into the token.
+var e2eSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+func e2eCredentials(t *testing.T) michaelcreds.Credentials {
+	t.Helper()
+	return michaelcreds.Credentials{
+		AccessKeyID:     e2eEnv(t, "S3_ACCESS_KEY_ID"),
+		SecretAccessKey: e2eEnv(t, "S3_SECRET_ACCESS_KEY"),
+	}
+}
+
 func e2eConfig(t *testing.T) config.Config {
 	return config.Config{
-		JWTPublicKey:      e2ePublicKey,
-		S3AccessKeyID:     e2eEnv(t, "S3_ACCESS_KEY_ID"),
-		S3SecretAccessKey: e2eEnv(t, "S3_SECRET_ACCESS_KEY"),
-		S3Region:          envOrE2E("S3_REGION", "us-east-1"),
-		S3Endpoint:        e2eEnv(t, "S3_ENDPOINT"),
-		S3ForcePathStyle:  true,
+		JWTPublicKey:     e2ePublicKey,
+		StorageSealKeys:  e2eSealKeys,
+		S3Region:         envOrE2E("S3_REGION", "us-east-1"),
+		S3Endpoint:       e2eEnv(t, "S3_ENDPOINT"),
+		S3ForcePathStyle: true,
 	}
 }
 
@@ -99,11 +111,16 @@ func e2eJWT(t *testing.T, repo string, writeOnce bool) string {
 // minted before multi-cluster routing existed.
 func e2eJWTForCluster(t *testing.T, repo string, writeOnce bool, storageCluster string) string {
 	t.Helper()
+	sealed, err := michaelcreds.Seal(e2eSealKeys[0], repo, e2eCredentials(t))
+	if err != nil {
+		t.Fatalf("seal storage credentials: %v", err)
+	}
 	claims := jwt.MapClaims{
-		"user":       e2eUser,
-		"repository": repo,
-		"writeOnce":  writeOnce,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               e2eUser,
+		"repository":         repo,
+		"writeOnce":          writeOnce,
+		"storageCredentials": sealed,
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	}
 	if storageCluster != "" {
 		claims["storageCluster"] = storageCluster
@@ -281,10 +298,10 @@ func mustStatus(t *testing.T, resp *http.Response, want int, what string) {
 
 // rawClient builds an S3 client straight to the real RGW (not via the proxies),
 // used only for test bucket cleanup.
-func rawClient(cfg config.Config) *s3.Client {
+func rawClient(cfg config.Config, creds michaelcreds.Credentials) *s3.Client {
 	return s3.New(s3.Options{
 		Region:       cfg.S3Region,
-		Credentials:  credentials.NewStaticCredentialsProvider(cfg.S3AccessKeyID, cfg.S3SecretAccessKey, ""),
+		Credentials:  credentials.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, ""),
 		BaseEndpoint: aws.String(cfg.S3Endpoint),
 		UsePathStyle: true,
 	})
@@ -292,7 +309,7 @@ func rawClient(cfg config.Config) *s3.Client {
 
 func cleanupBucket(t *testing.T, cfg config.Config, bucket string) {
 	t.Helper()
-	c := rawClient(cfg)
+	c := rawClient(cfg, e2eCredentials(t))
 	ctx := context.Background()
 	out, err := c.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
 	if err == nil {
@@ -347,7 +364,7 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	}
 	t.Logf("pool up: 2 backends healthy against real RGW (%s)", cfg.S3Endpoint)
 
-	srv := httptest.NewServer(handlers.NewServer(pool, cfg.JWTPublicKey, nil).Handler())
+	srv := httptest.NewServer(handlers.NewServer(pool, cfg.JWTPublicKey, cfg.StorageSealKeys, nil).Handler())
 	defer srv.Close()
 	client := srv.Client()
 	auth := e2eJWT(t, repo, false)
@@ -524,7 +541,7 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	srv := httptest.NewServer(handlers.NewClusterServer(map[string]storage.Storage{
 		"default": defaultPool,
 		"spice":   spicePool,
-	}, "default", cfg.JWTPublicKey, nil).Handler())
+	}, "default", cfg.JWTPublicKey, cfg.StorageSealKeys, nil).Handler())
 	defer srv.Close()
 	client := srv.Client()
 

--- a/packages/michael/integration_test.go
+++ b/packages/michael/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"michael/internal/config"
+	"michael/internal/credentials"
 	"michael/internal/handlers"
 	"michael/internal/storage"
 
@@ -34,12 +35,22 @@ const (
 	testRepository = "00000000-0000-0000-0000-000000000002"
 )
 
+// Against the compose MinIO these are the root credentials the static dev
+// provider hands out.
+var testSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+func testStorageCredentials() credentials.Credentials {
+	return credentials.Credentials{
+		AccessKeyID:     envOrDefault("S3_ACCESS_KEY_ID", "minio"),
+		SecretAccessKey: envOrDefault("S3_SECRET_ACCESS_KEY", "miniominio"),
+	}
+}
+
 func integrationConfig() config.Config {
 	return config.Config{
 		Port:             3010,
 		JWTPublicKey:     testPublicKey,
-		S3AccessKeyID:    envOrDefault("S3_ACCESS_KEY_ID", "minio"),
-		S3SecretAccessKey: envOrDefault("S3_SECRET_ACCESS_KEY", "miniominio"),
+		StorageSealKeys:  testSealKeys,
 		S3Region:         envOrDefault("S3_REGION", "minio"),
 		S3Endpoint:       envOrDefault("S3_ENDPOINT", "http://localhost:9000"),
 		S3ForcePathStyle: true,
@@ -55,11 +66,16 @@ func envOrDefault(key, fallback string) string {
 
 func integrationJWT(t *testing.T, _ config.Config, repo string, writeOnce bool) string {
 	t.Helper()
+	sealed, err := credentials.Seal(testSealKeys[0], repo, testStorageCredentials())
+	if err != nil {
+		t.Fatalf("seal storage credentials: %v", err)
+	}
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"user":       testUser,
-		"repository": repo,
-		"writeOnce":  writeOnce,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         repo,
+		"writeOnce":          writeOnce,
+		"storageCredentials": sealed,
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	})
 	signed, err := token.SignedString(testPrivateKey)
 	if err != nil {
@@ -75,7 +91,7 @@ func integrationAuth(token string) string {
 func TestIntegration_FullWorkflow(t *testing.T) {
 	cfg := integrationConfig()
 	store := storage.NewS3Storage(cfg)
-	srv := handlers.NewServer(store, cfg.JWTPublicKey, nil)
+	srv := handlers.NewServer(store, cfg.JWTPublicKey, cfg.StorageSealKeys, nil)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -246,7 +262,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 func TestIntegration_WORM(t *testing.T) {
 	cfg := integrationConfig()
 	store := storage.NewS3Storage(cfg)
-	srv := handlers.NewServer(store, cfg.JWTPublicKey, nil)
+	srv := handlers.NewServer(store, cfg.JWTPublicKey, cfg.StorageSealKeys, nil)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 

--- a/packages/michael/internal/auth/auth.go
+++ b/packages/michael/internal/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"michael/internal/cluster"
+	"michael/internal/credentials"
 	"michael/internal/httputil"
 
 	"github.com/go-chi/chi/v5"
@@ -27,6 +28,9 @@ type Auth struct {
 	StorageCluster string `json:"storageCluster"`
 	Jti            string `json:"jti"`
 	Connection     string `json:"connection"`
+	// michael has no credentials of its own, so a token without these reaches no
+	// storage at all.
+	Credentials credentials.Credentials `json:"-"`
 }
 
 type contextKey string
@@ -59,15 +63,18 @@ const (
 // entries expire with the token's exp claim.
 type Verifier struct {
 	publicKey *ecdsa.PublicKey
+	sealKeys  [][]byte
 	cache     *tokenCache
 	onLookup  func(hit bool)
 }
 
 // NewVerifier builds a Verifier. onLookup, if non-nil, is called with the
-// cache outcome of every authenticated request.
-func NewVerifier(publicKey *ecdsa.PublicKey, onLookup func(hit bool)) *Verifier {
+// cache outcome of every authenticated request; a hit reuses the credentials
+// opened for the session's first request, so a restic run decrypts them once.
+func NewVerifier(publicKey *ecdsa.PublicKey, sealKeys [][]byte, onLookup func(hit bool)) *Verifier {
 	return &Verifier{
 		publicKey: publicKey,
+		sealKeys:  sealKeys,
 		cache:     newTokenCache(cacheSize),
 		onLookup:  onLookup,
 	}
@@ -86,7 +93,7 @@ func (v *Verifier) authenticate(r *http.Request) (Auth, *authError) {
 	}
 	v.lookup(false)
 
-	a, exp, err := extractAuth(r, v.publicKey)
+	a, exp, err := extractAuth(r, v.publicKey, v.sealKeys)
 	if err != nil {
 		return Auth{}, err
 	}
@@ -120,13 +127,14 @@ func (v *Verifier) Middleware() func(http.Handler) http.Handler {
 			}
 
 			ctx := context.WithValue(r.Context(), authContextKey, auth)
+			ctx = credentials.NewContext(ctx, auth.Credentials)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
-func Middleware(publicKey *ecdsa.PublicKey) func(http.Handler) http.Handler {
-	return NewVerifier(publicKey, nil).Middleware()
+func Middleware(publicKey *ecdsa.PublicKey, sealKeys [][]byte) func(http.Handler) http.Handler {
+	return NewVerifier(publicKey, sealKeys, nil).Middleware()
 }
 
 type authError struct {
@@ -140,7 +148,7 @@ func (e *authError) Error() string {
 
 // extractAuth verifies the request's token and returns the Auth plus the
 // token's exp claim (zero if absent).
-func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, *authError) {
+func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey, sealKeys [][]byte) (Auth, time.Time, *authError) {
 	header := r.Header.Get("Authorization")
 	if header == "" {
 		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Missing Authorization header"}
@@ -213,6 +221,16 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, 
 		}
 		auth.StorageCluster = storageCluster
 	}
+	sealed, ok := claims["storageCredentials"].(string)
+	if !ok || sealed == "" {
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Token carries no storage credentials"}
+	}
+	creds, err := credentials.Open(sealKeys, auth.Repository, sealed)
+	if err != nil {
+		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid storage credentials"}
+	}
+	auth.Credentials = creds
+
 	if jti, ok := claims["jti"].(string); ok {
 		auth.Jti = jti
 	}

--- a/packages/michael/internal/auth/auth_test.go
+++ b/packages/michael/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -10,6 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"michael/internal/credentials"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
@@ -37,18 +40,31 @@ func makeBasicAuth(token string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte("restic:"+token))
 }
 
+var testSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+var testCredentials = credentials.Credentials{AccessKeyID: "AKIAREPO", SecretAccessKey: "s3cret"}
+
+func sealedFor(repository string) string {
+	sealed, err := credentials.Seal(testSealKeys[0], repository, testCredentials)
+	if err != nil {
+		panic(err)
+	}
+	return sealed
+}
+
 func validClaims() jwt.MapClaims {
 	return jwt.MapClaims{
-		"user":       testUser,
-		"repository": testRepository,
-		"writeOnce":  false,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         testRepository,
+		"writeOnce":          false,
+		"storageCredentials": sealedFor(testRepository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	}
 }
 
 func TestAuthMissingHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for missing auth header")
 	}
@@ -60,7 +76,7 @@ func TestAuthMissingHeader(t *testing.T) {
 func TestAuthInvalidAuthType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", "Bearer some-token")
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for non-Basic auth")
 	}
@@ -73,7 +89,7 @@ func TestAuthMissingToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	// Basic auth with no password (just username, no colon)
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("restic")))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for missing token")
 	}
@@ -85,7 +101,7 @@ func TestAuthMissingToken(t *testing.T) {
 func TestAuthInvalidJWT(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth("not-a-valid-jwt"))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for invalid JWT")
 	}
@@ -103,7 +119,7 @@ func TestAuthInvalidPayloadNonUUID(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for non-UUID user")
 	}
@@ -120,7 +136,7 @@ func TestAuthInvalidPayloadMissingWriteOnce(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
-	_, _, err := extractAuth(req, testPublicKey)
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err == nil {
 		t.Fatal("expected error for missing writeOnce")
 	}
@@ -134,7 +150,7 @@ func TestAuthSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
 
-	a, _, err := extractAuth(req, testPublicKey)
+	a, _, err := extractAuth(req, testPublicKey, testSealKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -175,7 +191,7 @@ func TestAuthOptionalClaims(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 			req.Header.Set("Authorization", makeBasicAuth(token))
 
-			a, _, err := extractAuth(req, testPublicKey)
+			a, _, err := extractAuth(req, testPublicKey, testSealKeys)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -195,7 +211,7 @@ func TestAuthMiddlewareRepoMismatch(t *testing.T) {
 	// Create a chi router to test the middleware with path params
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(Middleware(testPublicKey))
+		r.Use(Middleware(testPublicKey, testSealKeys))
 		r.Get("/config", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -218,7 +234,7 @@ func TestAuthMiddlewareSuccess(t *testing.T) {
 	var gotAuth Auth
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(Middleware(testPublicKey))
+		r.Use(Middleware(testPublicKey, testSealKeys))
 		r.Get("/config", func(w http.ResponseWriter, r *http.Request) {
 			gotAuth = FromContext(r.Context())
 			w.WriteHeader(http.StatusOK)
@@ -242,7 +258,7 @@ func TestVerifierCachesVerifiedTokens(t *testing.T) {
 	token := makeJWT(t, validClaims())
 
 	var lookups []bool
-	v := NewVerifier(testPublicKey, func(hit bool) { lookups = append(lookups, hit) })
+	v := NewVerifier(testPublicKey, testSealKeys, func(hit bool) { lookups = append(lookups, hit) })
 
 	for range 3 {
 		req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
@@ -269,7 +285,7 @@ func TestVerifierCachesVerifiedTokens(t *testing.T) {
 
 func TestVerifierCacheHonorsExpiry(t *testing.T) {
 	token := makeJWT(t, validClaims())
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
@@ -299,7 +315,7 @@ func TestVerifierDoesNotCacheInvalidTokens(t *testing.T) {
 		return signed
 	}()
 
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(badToken))
 	if _, err := v.authenticate(req); err == nil {
@@ -308,5 +324,48 @@ func TestVerifierDoesNotCacheInvalidTokens(t *testing.T) {
 	key := sha256.Sum256([]byte(makeBasicAuth(badToken)))
 	if _, ok := v.cache.get(key, time.Now()); ok {
 		t.Fatal("invalid token must not be cached")
+	}
+}
+
+func TestAuthRejectsTokenWithoutStorageCredentials(t *testing.T) {
+	claims := validClaims()
+	delete(claims, "storageCredentials")
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, claims)))
+
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
+	if err == nil {
+		t.Fatal("expected a token without storage credentials to be rejected")
+	}
+	if err.code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", err.code)
+	}
+}
+
+func TestAuthRejectsStorageCredentialsSealedForAnotherRepository(t *testing.T) {
+	claims := validClaims()
+	claims["storageCredentials"] = sealedFor("00000000-0000-0000-0000-0000000000ff")
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, claims)))
+
+	_, _, err := extractAuth(req, testPublicKey, testSealKeys)
+	if err == nil {
+		t.Fatal("expected credentials sealed for another repository to be rejected")
+	}
+	if err.code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", err.code)
+	}
+}
+
+func TestAuthCarriesStorageCredentials(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/config", nil)
+	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, validClaims())))
+
+	a, _, err := extractAuth(req, testPublicKey, testSealKeys)
+	if err != nil {
+		t.Fatalf("extractAuth: %v", err)
+	}
+	if a.Credentials != testCredentials {
+		t.Errorf("expected the sealed credentials on the auth, got %+v", a.Credentials)
 	}
 }

--- a/packages/michael/internal/auth/cluster_test.go
+++ b/packages/michael/internal/auth/cluster_test.go
@@ -18,7 +18,7 @@ func authRequest(t *testing.T, claims jwt.MapClaims) *http.Request {
 }
 
 func TestAuthStorageClusterAbsent(t *testing.T) {
-	a, _, err := extractAuth(authRequest(t, validClaims()), testPublicKey)
+	a, _, err := extractAuth(authRequest(t, validClaims()), testPublicKey, testSealKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestAuthStorageClusterValid(t *testing.T) {
 	for _, code := range []string{"spice", "sietch-2", "a", strings.Repeat("x", 64)} {
 		claims := validClaims()
 		claims["storageCluster"] = code
-		a, _, err := extractAuth(authRequest(t, claims), testPublicKey)
+		a, _, err := extractAuth(authRequest(t, claims), testPublicKey, testSealKeys)
 		if err != nil {
 			t.Fatalf("code %q: unexpected error: %v", code, err)
 		}
@@ -56,7 +56,7 @@ func TestAuthStorageClusterInvalid(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			claims := validClaims()
 			claims["storageCluster"] = value
-			_, _, err := extractAuth(authRequest(t, claims), testPublicKey)
+			_, _, err := extractAuth(authRequest(t, claims), testPublicKey, testSealKeys)
 			if err == nil {
 				t.Fatal("expected an error for a malformed storageCluster claim")
 			}
@@ -71,7 +71,7 @@ func TestAuthStorageClusterInvalid(t *testing.T) {
 // only in storageCluster must not share an entry — a collision would serve one
 // user's repository out of another cluster.
 func TestVerifierCacheKeepsClustersDistinct(t *testing.T) {
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 
 	for _, code := range []string{"spice", "sietch", ""} {
 		claims := validClaims()
@@ -99,7 +99,7 @@ func TestVerifierCachesStorageCluster(t *testing.T) {
 	req := authRequest(t, claims)
 
 	var lookups []bool
-	v := NewVerifier(testPublicKey, func(hit bool) { lookups = append(lookups, hit) })
+	v := NewVerifier(testPublicKey, testSealKeys, func(hit bool) { lookups = append(lookups, hit) })
 
 	for range 2 {
 		a, err := v.authenticate(req)
@@ -122,7 +122,7 @@ func TestVerifierDoesNotCacheInvalidCluster(t *testing.T) {
 	claims["storageCluster"] = "NOT VALID"
 	req := authRequest(t, claims)
 
-	v := NewVerifier(testPublicKey, nil)
+	v := NewVerifier(testPublicKey, testSealKeys, nil)
 	for range 2 {
 		if _, err := v.authenticate(req); err == nil {
 			t.Fatal("expected an error for a malformed storageCluster claim")
@@ -137,7 +137,7 @@ func TestAuthMiddlewarePassesStorageCluster(t *testing.T) {
 	var got Auth
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
-		r.Use(Middleware(testPublicKey))
+		r.Use(Middleware(testPublicKey, testSealKeys))
 		r.Get("/config", func(w http.ResponseWriter, r *http.Request) {
 			got = FromContext(r.Context())
 			w.WriteHeader(http.StatusOK)
@@ -158,7 +158,7 @@ func TestAuthMiddlewarePassesStorageCluster(t *testing.T) {
 func TestAuthStorageClusterNullClaim(t *testing.T) {
 	claims := validClaims()
 	claims["storageCluster"] = nil
-	a, _, err := extractAuth(authRequest(t, claims), testPublicKey)
+	a, _, err := extractAuth(authRequest(t, claims), testPublicKey, testSealKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/packages/michael/internal/config/clusters_test.go
+++ b/packages/michael/internal/config/clusters_test.go
@@ -9,8 +9,6 @@ import (
 func testDefaultCluster() ClusterConfig {
 	return ClusterConfig{
 		Code:                "default",
-		S3AccessKeyID:       "default-key",
-		S3SecretAccessKey:   "default-secret",
 		S3Region:            "us-east-1",
 		S3Endpoint:          "https://s3.default.example",
 		S3ForcePathStyle:    true,
@@ -62,8 +60,6 @@ func TestParseClustersFull(t *testing.T) {
 
 	want := ClusterConfig{
 		Code:                "spice",
-		S3AccessKeyID:       "spice-key",
-		S3SecretAccessKey:   "spice-secret",
 		S3Region:            "spice-1",
 		S3Endpoint:          "https://s3.spice.example:8443",
 		S3ForcePathStyle:    false,
@@ -140,21 +136,6 @@ func TestParseClustersErrors(t *testing.T) {
 			wantErr: "endpoint is required",
 		},
 		{
-			name:    "missing credential env names",
-			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a"}]}`,
-			wantErr: "access_key_env and secret_key_env are required",
-		},
-		{
-			name:    "credential env unset",
-			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a","access_key_env":"MISSING","secret_key_env":"S"}]}`,
-			wantErr: "MISSING is unset or empty",
-		},
-		{
-			name:    "credential env empty",
-			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a","access_key_env":"K","secret_key_env":"EMPTY"}]}`,
-			wantErr: "EMPTY is unset or empty",
-		},
-		{
 			name:    "unknown backend source",
 			doc:     `{"clusters":[{"code":"spice","endpoint":"http://a","access_key_env":"K","secret_key_env":"S","backend_source":"consul"}]}`,
 			wantErr: "backend_source must be",
@@ -191,6 +172,20 @@ func TestParseClustersErrors(t *testing.T) {
 				t.Errorf("error %q does not mention %q", err, c.wantErr)
 			}
 		})
+	}
+}
+
+// Credential env names are accepted for compatibility but no longer resolved:
+// michael takes its credentials from the request's token.
+func TestParseClustersWithoutCredentialEnvNames(t *testing.T) {
+	doc := `{"clusters":[{"code":"spice","endpoint":"http://s3.spice.example"}]}`
+
+	got, err := ParseClusters([]byte(doc), testDefaultCluster(), testEnv(nil))
+	if err != nil {
+		t.Fatalf("ParseClusters: %v", err)
+	}
+	if len(got) != 1 || got[0].Code != "spice" {
+		t.Fatalf("unexpected clusters: %+v", got)
 	}
 }
 
@@ -255,7 +250,7 @@ func TestParseTopologyClusters(t *testing.T) {
 	if len(got) != 2 || got[0].Code != "father-spice" || got[1].Code != "father-pepper" {
 		t.Fatalf("unexpected topology clusters: %+v", got)
 	}
-	if got[1].S3AccessKeyID != "pepper-key" || got[1].S3Endpoint != "https://s3.pepper.example" {
+	if got[1].S3Endpoint != "https://s3.pepper.example" {
 		t.Fatalf("additional cluster configuration was not resolved: %+v", got[1])
 	}
 }
@@ -275,8 +270,6 @@ func TestParseTopologyClustersRejectsMismatch(t *testing.T) {
 
 func TestDefaultClusterFromFlatConfig(t *testing.T) {
 	cfg := Config{
-		S3AccessKeyID:       "key",
-		S3SecretAccessKey:   "secret",
 		S3Region:            "us-east-1",
 		S3Endpoint:          "https://s3.example",
 		S3ForcePathStyle:    true,
@@ -296,7 +289,7 @@ func TestDefaultClusterFromFlatConfig(t *testing.T) {
 	if got.Code != "sietch" {
 		t.Errorf("expected code sietch, got %q", got.Code)
 	}
-	if got.S3Endpoint != cfg.S3Endpoint || got.S3AccessKeyID != cfg.S3AccessKeyID || got.S3BackendDNSHost != cfg.S3BackendDNSHost {
+	if got.S3Endpoint != cfg.S3Endpoint || got.S3Region != cfg.S3Region || got.S3BackendDNSHost != cfg.S3BackendDNSHost {
 		t.Errorf("flat S3_* config not carried into the default cluster: %+v", got)
 	}
 }

--- a/packages/michael/internal/config/config.go
+++ b/packages/michael/internal/config/config.go
@@ -15,19 +15,21 @@ import (
 	"time"
 
 	"michael/internal/cluster"
+	"michael/internal/credentials"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 type Config struct {
-	Port              int
-	JWTPublicKey      *ecdsa.PublicKey
-	S3AccessKeyID     string
-	S3SecretAccessKey string
-	S3Region          string
-	S3Endpoint        string
-	S3ForcePathStyle  bool
+	Port         int
+	JWTPublicKey *ecdsa.PublicKey
+	// michael configures no S3 credentials of its own; these open the ones each
+	// token carries.
+	StorageSealKeys  [][]byte
+	S3Region         string
+	S3Endpoint       string
+	S3ForcePathStyle bool
 
 	// S3 load-balancing pool. When S3BackendSource is empty, michael talks to
 	// the single S3Endpoint (legacy behavior). When set to "file" or "dns", it
@@ -75,12 +77,10 @@ type Config struct {
 // flat S3_* environment variables describe the default cluster; S3_CLUSTERS_FILE
 // declares any additional ones.
 type ClusterConfig struct {
-	Code              string
-	S3AccessKeyID     string
-	S3SecretAccessKey string
-	S3Region          string
-	S3Endpoint        string
-	S3ForcePathStyle  bool
+	Code             string
+	S3Region         string
+	S3Endpoint       string
+	S3ForcePathStyle bool
 
 	S3BackendSource     string // "" | "file" | "dns"
 	S3BackendFile       string
@@ -98,8 +98,6 @@ type ClusterConfig struct {
 func (c Config) DefaultCluster() ClusterConfig {
 	return ClusterConfig{
 		Code:                c.S3DefaultCluster,
-		S3AccessKeyID:       c.S3AccessKeyID,
-		S3SecretAccessKey:   c.S3SecretAccessKey,
 		S3Region:            c.S3Region,
 		S3Endpoint:          c.S3Endpoint,
 		S3ForcePathStyle:    c.S3ForcePathStyle,
@@ -128,14 +126,9 @@ func LoadConfig() Config {
 
 	jwtPublicKey := parseES256PublicKey(os.Getenv("JWT_PUBLIC_KEY"))
 
-	s3AccessKeyID := os.Getenv("S3_ACCESS_KEY_ID")
-	if s3AccessKeyID == "" {
-		log.Fatal().Msg("S3_ACCESS_KEY_ID is required")
-	}
-
-	s3SecretAccessKey := os.Getenv("S3_SECRET_ACCESS_KEY")
-	if s3SecretAccessKey == "" {
-		log.Fatal().Msg("S3_SECRET_ACCESS_KEY is required")
+	sealKeys, err := credentials.ParseKeys(os.Getenv("STORAGE_CREDENTIAL_SEAL_KEY"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("STORAGE_CREDENTIAL_SEAL_KEY is required")
 	}
 
 	s3Region := os.Getenv("S3_REGION")
@@ -260,8 +253,7 @@ func LoadConfig() Config {
 	cfg := Config{
 		Port:                port,
 		JWTPublicKey:        jwtPublicKey,
-		S3AccessKeyID:       s3AccessKeyID,
-		S3SecretAccessKey:   s3SecretAccessKey,
+		StorageSealKeys:     sealKeys,
 		S3Region:            s3Region,
 		S3Endpoint:          s3Endpoint,
 		S3ForcePathStyle:    s3ForcePathStyle,
@@ -344,11 +336,10 @@ type topologyCluster struct {
 	S3               *clusterEntry `json:"s3"`
 }
 
-// clusterEntry is one cluster in S3_CLUSTERS_FILE. Credentials are named
-// indirectly — the entry gives the NAMES of the environment variables holding
-// them — so the file can be a plain ConfigMap while the secrets stay in a k8s
-// Secret. Pointer fields distinguish "absent, inherit the default cluster" from
-// an explicit false.
+// clusterEntry is one cluster in S3_CLUSTERS_FILE. Pointer fields distinguish
+// "absent, inherit the default cluster" from an explicit false. access_key_env
+// and secret_key_env are still accepted so existing topology documents parse,
+// but nothing reads them: credentials arrive per request, from the token.
 type clusterEntry struct {
 	Code           string `json:"code"`
 	Endpoint       string `json:"endpoint"`
@@ -486,18 +477,6 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 	if e.Endpoint == "" {
 		return ClusterConfig{}, fmt.Errorf("cluster %q: endpoint is required", e.Code)
 	}
-	if e.AccessKeyEnv == "" || e.SecretKeyEnv == "" {
-		return ClusterConfig{}, fmt.Errorf("cluster %q: access_key_env and secret_key_env are required", e.Code)
-	}
-	accessKey := getenv(e.AccessKeyEnv)
-	if accessKey == "" {
-		return ClusterConfig{}, fmt.Errorf("cluster %q: %s is unset or empty", e.Code, e.AccessKeyEnv)
-	}
-	secretKey := getenv(e.SecretKeyEnv)
-	if secretKey == "" {
-		return ClusterConfig{}, fmt.Errorf("cluster %q: %s is unset or empty", e.Code, e.SecretKeyEnv)
-	}
-
 	switch e.BackendSource {
 	case "":
 		// single-endpoint mode
@@ -523,8 +502,6 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 	scheme, port := schemeAndPort(e.Endpoint)
 	cc := ClusterConfig{
 		Code:                e.Code,
-		S3AccessKeyID:       accessKey,
-		S3SecretAccessKey:   secretKey,
 		S3Region:            firstNonEmpty(e.Region, def.S3Region),
 		S3Endpoint:          e.Endpoint,
 		S3ForcePathStyle:    boolOr(e.ForcePathStyle, def.S3ForcePathStyle),

--- a/packages/michael/internal/credentials/credentials.go
+++ b/packages/michael/internal/credentials/credentials.go
@@ -1,0 +1,158 @@
+// Package credentials opens the per-repository S3 credentials a restic token
+// carries. michael has none of its own, so a request reaches only the bucket
+// the token it presents was sealed for.
+package credentials
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Credentials struct {
+	AccessKeyID     string `json:"accessKeyId"`
+	SecretAccessKey string `json:"secretAccessKey"`
+}
+
+// Fingerprint keys a credential pair without retaining the secret.
+func (c Credentials) Fingerprint() [32]byte {
+	return sha256.Sum256([]byte(c.AccessKeyID + "\x00" + c.SecretAccessKey))
+}
+
+// Wire format, written by @common/server sealStorageCredentials:
+//
+//	base64url(version[1] || nonce[12] || ciphertext || tag[16])
+//
+// AES-256-GCM over the JSON above, with the repository id as additional
+// authenticated data — a blob lifted out of one repository's token does not
+// open against another's.
+const (
+	version    = 1
+	keyBytes   = 32
+	nonceBytes = 12
+	tagBytes   = 16
+)
+
+// Every key is accepted when opening, so the API can start sealing with a new
+// one before the old one is withdrawn.
+func ParseKeys(value string) ([][]byte, error) {
+	var keys [][]byte
+	for _, entry := range strings.Split(value, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		key, err := base64.StdEncoding.DecodeString(entry)
+		if err != nil {
+			return nil, fmt.Errorf("storage credential key is not valid base64: %w", err)
+		}
+		if len(key) != keyBytes {
+			return nil, fmt.Errorf("storage credential key must be %d bytes, got %d", keyBytes, len(key))
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("at least one storage credential key is required")
+	}
+	return keys, nil
+}
+
+// Seal exists only so the format can be round-tripped in tests; in production
+// the TypeScript side is the only writer.
+func Seal(key []byte, repositoryID string, creds Credentials) (string, error) {
+	if len(key) != keyBytes {
+		return "", fmt.Errorf("storage credential key must be %d bytes, got %d", keyBytes, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, nonceBytes)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	plaintext, err := json.Marshal(creds)
+	if err != nil {
+		return "", err
+	}
+
+	blob := append([]byte{version}, nonce...)
+	blob = gcm.Seal(blob, nonce, plaintext, []byte(repositoryID))
+	return base64.RawURLEncoding.EncodeToString(blob), nil
+}
+
+func Open(keys [][]byte, repositoryID, sealed string) (Credentials, error) {
+	blob, err := decode(sealed)
+	if err != nil {
+		return Credentials{}, err
+	}
+	if len(blob) < 1+nonceBytes+tagBytes {
+		return Credentials{}, errors.New("sealed storage credentials are truncated")
+	}
+	if blob[0] != version {
+		return Credentials{}, fmt.Errorf("unsupported sealed storage credential version %d", blob[0])
+	}
+
+	nonce := blob[1 : 1+nonceBytes]
+	ciphertext := blob[1+nonceBytes:]
+
+	for _, key := range keys {
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return Credentials{}, err
+		}
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return Credentials{}, err
+		}
+		plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte(repositoryID))
+		if err != nil {
+			continue
+		}
+
+		var creds Credentials
+		if err := json.Unmarshal(plaintext, &creds); err != nil {
+			return Credentials{}, fmt.Errorf("sealed storage credentials are malformed: %w", err)
+		}
+		if creds.AccessKeyID == "" || creds.SecretAccessKey == "" {
+			return Credentials{}, errors.New("sealed storage credentials are incomplete")
+		}
+		return creds, nil
+	}
+
+	return Credentials{}, errors.New("sealed storage credentials could not be opened with any configured key")
+}
+
+func decode(sealed string) ([]byte, error) {
+	if blob, err := base64.RawURLEncoding.DecodeString(sealed); err == nil {
+		return blob, nil
+	}
+	blob, err := base64.URLEncoding.DecodeString(sealed)
+	if err != nil {
+		return nil, fmt.Errorf("sealed storage credentials are not valid base64url: %w", err)
+	}
+	return blob, nil
+}
+
+type contextKey struct{}
+
+func NewContext(ctx context.Context, c Credentials) context.Context {
+	return context.WithValue(ctx, contextKey{}, c)
+}
+
+func FromContext(ctx context.Context) (Credentials, bool) {
+	c, ok := ctx.Value(contextKey{}).(Credentials)
+	return c, ok
+}

--- a/packages/michael/internal/credentials/credentials_test.go
+++ b/packages/michael/internal/credentials/credentials_test.go
@@ -1,0 +1,143 @@
+package credentials
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+var testKey = bytes.Repeat([]byte{0x2a}, 32)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	want := Credentials{AccessKeyID: "AKIAREPO", SecretAccessKey: "s3cret"}
+
+	sealed, err := Seal(testKey, "repo-1", want)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	got, err := Open([][]byte{testKey}, "repo-1", sealed)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got != want {
+		t.Errorf("round trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestOpenRejectsAnotherRepositorysBlob(t *testing.T) {
+	sealed, err := Seal(testKey, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if _, err := Open([][]byte{testKey}, "repo-2", sealed); err == nil {
+		t.Fatal("expected a blob sealed for repo-1 to fail against repo-2")
+	}
+}
+
+// A rotation runs with both keys configured, so neither side restarts first.
+func TestOpenAcceptsAnyConfiguredKey(t *testing.T) {
+	oldKey := bytes.Repeat([]byte{0x11}, 32)
+	newKey := bytes.Repeat([]byte{0x22}, 32)
+
+	for name, key := range map[string][]byte{"old": oldKey, "new": newKey} {
+		t.Run(name, func(t *testing.T) {
+			sealed, err := Seal(key, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+			if err != nil {
+				t.Fatalf("Seal: %v", err)
+			}
+			if _, err := Open([][]byte{newKey, oldKey}, "repo-1", sealed); err != nil {
+				t.Fatalf("Open with both keys configured: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenRejectsUnknownKey(t *testing.T) {
+	sealed, err := Seal(testKey, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	if _, err := Open([][]byte{bytes.Repeat([]byte{0x99}, 32)}, "repo-1", sealed); err == nil {
+		t.Fatal("expected an unknown key to fail")
+	}
+}
+
+// The producer is TypeScript (@common/server sealStorageCredentials) and the
+// consumer is this package, so the format is pinned by a fixture the TS side
+// actually emitted, not by this package's own round trip.
+func TestOpenTypeScriptFixture(t *testing.T) {
+	const sealed = "AU4he_wpRIQ5oOmfSJSMmHrxBGCCHG3VEIK6D_Y7ivi4y_rRLwGNK9Zk--dCK1apZ6d44R8y7CPhF4lVj8gu4LBJo1MSK5_FHGAQQV6-g24I4puAOLxt8uDh0E61"
+
+	got, err := Open([][]byte{testKey}, "repo-1234", sealed)
+	if err != nil {
+		t.Fatalf("Open TypeScript fixture: %v", err)
+	}
+	want := Credentials{AccessKeyID: "AKIAFIXTURE", SecretAccessKey: "fixture-secret"}
+	if got != want {
+		t.Errorf("fixture mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestOpenRejectsMalformedBlobs(t *testing.T) {
+	cases := map[string]string{
+		"not base64": "!!!not-base64!!!",
+		"truncated":  "AQID",
+		"wrong version": func() string {
+			sealed, err := Seal(testKey, "repo-1", Credentials{AccessKeyID: "a", SecretAccessKey: "b"})
+			if err != nil {
+				t.Fatalf("Seal: %v", err)
+			}
+			return "Ag" + sealed[2:]
+		}(),
+	}
+
+	for name, sealed := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Open([][]byte{testKey}, "repo-1", sealed); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestParseKeys(t *testing.T) {
+	first := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, 32))
+	second := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x22}, 32))
+
+	keys, err := ParseKeys(first + ", " + second)
+	if err != nil {
+		t.Fatalf("ParseKeys: %v", err)
+	}
+	if len(keys) != 2 || !bytes.Equal(keys[0], bytes.Repeat([]byte{0x11}, 32)) {
+		t.Fatalf("expected the first key to stay first, got %d keys", len(keys))
+	}
+
+	for name, value := range map[string]string{
+		"empty":      "",
+		"not base64": "@@@",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseKeys(value); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+
+	t.Run("wrong size", func(t *testing.T) {
+		if _, err := ParseKeys("c2hvcnQ="); err == nil || !strings.Contains(err.Error(), "32 bytes") {
+			t.Fatalf("expected a size error, got %v", err)
+		}
+	})
+}
+
+func TestFingerprintDistinguishesCredentials(t *testing.T) {
+	a := Credentials{AccessKeyID: "one", SecretAccessKey: "two"}
+	b := Credentials{AccessKeyID: "onetwo", SecretAccessKey: ""}
+
+	if a.Fingerprint() == b.Fingerprint() {
+		t.Error("fingerprint must not collide across a shifted field boundary")
+	}
+}

--- a/packages/michael/internal/handlers/cluster_test.go
+++ b/packages/michael/internal/handlers/cluster_test.go
@@ -45,7 +45,7 @@ func twoClusterServer() (*Server, *recordingStorage, *recordingStorage) {
 	srv := NewClusterServer(map[string]storage.Storage{
 		cluster.DefaultCode: def,
 		"spice":             spice,
-	}, cluster.DefaultCode, testPublicKey, nil)
+	}, cluster.DefaultCode, testPublicKey, testSealKeys, nil)
 	return srv, def, spice
 }
 
@@ -87,11 +87,12 @@ func TestClusterRoutingEmptyClaimUsesDefault(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodHead, "/"+testRepository+"/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, jwt.MapClaims{
-		"user":           testUser,
-		"repository":     testRepository,
-		"writeOnce":      false,
-		"storageCluster": "",
-		"exp":            jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         testRepository,
+		"writeOnce":          false,
+		"storageCluster":     "",
+		"storageCredentials": sealedFor(t, testRepository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	})))
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)
@@ -170,7 +171,7 @@ func TestClusterRoutingUnknownClusterCounted(t *testing.T) {
 		t.Fatalf("NewMetrics: %v", err)
 	}
 	srv := NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: &mockStorage{}},
-		cluster.DefaultCode, testPublicKey, m)
+		cluster.DefaultCode, testPublicKey, testSealKeys, m)
 
 	for range 2 {
 		rec := doRequest(t, srv, http.MethodHead, "/"+testRepository+"/config", nil, clusterAuth("sietch"), nil)
@@ -221,11 +222,12 @@ func TestClusterRoutingNonStringClaimRejected(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodHead, "/"+testRepository+"/config", nil)
 			req.Header.Set("Authorization", makeBasicAuth(makeJWT(t, jwt.MapClaims{
-				"user":           testUser,
-				"repository":     testRepository,
-				"writeOnce":      false,
-				"storageCluster": value,
-				"exp":            jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				"user":               testUser,
+				"repository":         testRepository,
+				"writeOnce":          false,
+				"storageCluster":     value,
+				"storageCredentials": sealedFor(t, testRepository),
+				"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 			})))
 			rec := httptest.NewRecorder()
 			srv.Handler().ServeHTTP(rec, req)

--- a/packages/michael/internal/handlers/server.go
+++ b/packages/michael/internal/handlers/server.go
@@ -26,9 +26,10 @@ type Server struct {
 	Clusters map[string]storage.Storage
 	// DefaultCluster is the code served to tokens carrying no storageCluster
 	// claim — every token minted before multi-cluster routing existed.
-	DefaultCluster string
-	JWTPublicKey   *ecdsa.PublicKey
-	Metrics        *metrics.Metrics
+	DefaultCluster  string
+	JWTPublicKey    *ecdsa.PublicKey
+	StorageSealKeys [][]byte
+	Metrics         *metrics.Metrics
 	// ResolveClient identifies the source network of a request, for the traffic
 	// metrics and the access log. Optional: nil leaves both unattributed, which
 	// is what the tests and any deployment without an ASN database get.
@@ -37,18 +38,25 @@ type Server struct {
 
 // NewServer builds a single-cluster server: everything is served from s under
 // the default cluster code.
-func NewServer(s storage.Storage, jwtPublicKey *ecdsa.PublicKey, m *metrics.Metrics) *Server {
-	return NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: s}, cluster.DefaultCode, jwtPublicKey, m)
+func NewServer(s storage.Storage, jwtPublicKey *ecdsa.PublicKey, sealKeys [][]byte, m *metrics.Metrics) *Server {
+	return NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: s}, cluster.DefaultCode, jwtPublicKey, sealKeys, m)
 }
 
 // NewClusterServer builds a server fronting several storage clusters, routing
 // each request by its token's storageCluster claim.
-func NewClusterServer(clusters map[string]storage.Storage, defaultCluster string, jwtPublicKey *ecdsa.PublicKey, m *metrics.Metrics) *Server {
+func NewClusterServer(
+	clusters map[string]storage.Storage,
+	defaultCluster string,
+	jwtPublicKey *ecdsa.PublicKey,
+	sealKeys [][]byte,
+	m *metrics.Metrics,
+) *Server {
 	return &Server{
-		Clusters:       clusters,
-		DefaultCluster: defaultCluster,
-		JWTPublicKey:   jwtPublicKey,
-		Metrics:        m,
+		Clusters:        clusters,
+		DefaultCluster:  defaultCluster,
+		JWTPublicKey:    jwtPublicKey,
+		StorageSealKeys: sealKeys,
+		Metrics:         m,
 	}
 }
 
@@ -134,7 +142,7 @@ func (s *Server) Handler() http.Handler {
 			}
 		}
 	}
-	verifier := auth.NewVerifier(s.JWTPublicKey, onLookup)
+	verifier := auth.NewVerifier(s.JWTPublicKey, s.StorageSealKeys, onLookup)
 
 	r.Route("/{path}", func(r chi.Router) {
 		r.Use(verifier.Middleware())

--- a/packages/michael/internal/handlers/server_bench_test.go
+++ b/packages/michael/internal/handlers/server_bench_test.go
@@ -52,7 +52,7 @@ func benchServer(b *testing.B, blob []byte, resolve func(*http.Request) geoip.Cl
 		},
 	}
 
-	srv := NewServer(store, testPublicKey, m)
+	srv := NewServer(store, testPublicKey, testSealKeys, m)
 	srv.ResolveClient = resolve
 	return srv
 }
@@ -63,10 +63,11 @@ func benchServer(b *testing.B, blob []byte, resolve func(*http.Request) geoip.Cl
 func benchRequest(b *testing.B) *http.Request {
 	b.Helper()
 	token := makeJWTForBench(b, jwt.MapClaims{
-		"user":       testUser,
-		"repository": testRepository,
-		"writeOnce":  false,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               testUser,
+		"repository":         testRepository,
+		"writeOnce":          false,
+		"storageCredentials": sealedFor(b, testRepository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	})
 	r := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/data/"+testBlobName, nil)
 	r.Header.Set("Authorization", makeBasicAuth(token))

--- a/packages/michael/internal/handlers/server_test.go
+++ b/packages/michael/internal/handlers/server_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"michael/internal/auth"
+	"michael/internal/credentials"
 	"michael/internal/geoip"
 	"michael/internal/metrics"
 	"michael/internal/storage"
@@ -34,6 +35,20 @@ const (
 	testUser       = "00000000-0000-0000-0000-000000000001"
 	testRepository = "00000000-0000-0000-0000-000000000002"
 )
+
+var testSealKeys = [][]byte{bytes.Repeat([]byte{0x2a}, 32)}
+
+func sealedFor(t testing.TB, repository string) string {
+	t.Helper()
+	sealed, err := credentials.Seal(testSealKeys[0], repository, credentials.Credentials{
+		AccessKeyID:     "AKIAREPO",
+		SecretAccessKey: "s3cret",
+	})
+	if err != nil {
+		t.Fatalf("failed to seal storage credentials: %v", err)
+	}
+	return sealed
+}
 
 func makeJWT(t *testing.T, claims jwt.MapClaims) string {
 	t.Helper()
@@ -129,7 +144,7 @@ func (m *mockStorage) DeleteObject(ctx context.Context, bucket, key string) erro
 
 // newTestServer creates a single-cluster Server with mock storage.
 func newTestServer(store *mockStorage) *Server {
-	return NewServer(store, testPublicKey, nil)
+	return NewServer(store, testPublicKey, testSealKeys, nil)
 }
 
 // doRequest creates and executes a request against the test server with a real JWT auth header.
@@ -139,10 +154,11 @@ func doRequest(t *testing.T, srv *Server, method, path string, body io.Reader, a
 
 	// Generate a real JWT for the auth middleware
 	claims := jwt.MapClaims{
-		"user":       a.User,
-		"repository": a.Repository,
-		"writeOnce":  a.WriteOnce,
-		"exp":        jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		"user":               a.User,
+		"repository":         a.Repository,
+		"writeOnce":          a.WriteOnce,
+		"storageCredentials": sealedFor(t, a.Repository),
+		"exp":                jwt.NewNumericDate(time.Now().Add(time.Hour)),
 	}
 	// Omitted rather than empty when unset, so the default path under test is
 	// the shape of a token minted before multi-cluster routing existed.
@@ -356,7 +372,7 @@ func TestUploadBodySurvivesTrafficAccounting(t *testing.T) {
 		},
 	}
 
-	srv := NewServer(store, testPublicKey, m)
+	srv := NewServer(store, testPublicKey, testSealKeys, m)
 	srv.ResolveClient = func(*http.Request) geoip.Client {
 		return geoip.Client{IP: "203.0.113.7", ASN: "AS64496", Org: "Example Transit"}
 	}

--- a/packages/michael/internal/metrics/metrics.go
+++ b/packages/michael/internal/metrics/metrics.go
@@ -62,6 +62,12 @@ type Metrics struct {
 	TrafficUploadedBytes   otelmetric.Int64Counter
 	TrafficDownloadedBytes otelmetric.Int64Counter
 	TrafficRequests        otelmetric.Int64Counter
+
+	// Per-credential S3 client cache. A collapsing hit rate means clients are
+	// being rebuilt per request, which costs the SDK's per-client state (never
+	// the connection pool, which every client shares).
+	CredentialCacheHits   otelmetric.Int64Counter
+	CredentialCacheMisses otelmetric.Int64Counter
 }
 
 // durationBuckets replaces the SDK default histogram boundaries, which are
@@ -181,6 +187,18 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating traffic_requests counter: %w", err)
 	}
 
+	credentialCacheHits, err := meter.Int64Counter("storage.credentials.cache.hits",
+		otelmetric.WithDescription("Storage requests served by an already-built per-credential S3 client"))
+	if err != nil {
+		return nil, fmt.Errorf("creating credential_cache_hits counter: %w", err)
+	}
+
+	credentialCacheMisses, err := meter.Int64Counter("storage.credentials.cache.misses",
+		otelmetric.WithDescription("Storage requests that had to build an S3 client for their credentials"))
+	if err != nil {
+		return nil, fmt.Errorf("creating credential_cache_misses counter: %w", err)
+	}
+
 	client, err := newClientMetrics(meter)
 	if err != nil {
 		return nil, err
@@ -204,6 +222,9 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		TrafficUploadedBytes:   trafficUploadedBytes,
 		TrafficDownloadedBytes: trafficDownloadedBytes,
 		TrafficRequests:        trafficRequests,
+
+		CredentialCacheHits:   credentialCacheHits,
+		CredentialCacheMisses: credentialCacheMisses,
 	}, nil
 }
 

--- a/packages/michael/internal/storage/clientcache.go
+++ b/packages/michael/internal/storage/clientcache.go
@@ -1,0 +1,64 @@
+package storage
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// Sized to span the repositories backing up concurrently: restic holds one
+// credential for a whole session, and an entry is only an options struct.
+const clientCacheSize = 1024
+
+// clientCache is a bounded LRU of S3 clients keyed by credential fingerprint.
+// Every client wraps the same *http.Client, so the connection pool is shared
+// and an eviction costs nothing but the SDK's per-client state.
+type clientCache struct {
+	mu      sync.Mutex
+	max     int
+	order   *list.List
+	entries map[[32]byte]*list.Element
+}
+
+type clientEntry struct {
+	key    [32]byte
+	client *s3.Client
+}
+
+func newClientCache(max int) *clientCache {
+	return &clientCache{
+		max:     max,
+		order:   list.New(),
+		entries: make(map[[32]byte]*list.Element, max),
+	}
+}
+
+func (c *clientCache) get(key [32]byte) (*s3.Client, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	el, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	c.order.MoveToFront(el)
+	return el.Value.(*clientEntry).client, true
+}
+
+func (c *clientCache) put(key [32]byte, client *s3.Client) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if el, ok := c.entries[key]; ok {
+		el.Value.(*clientEntry).client = client
+		c.order.MoveToFront(el)
+		return
+	}
+	c.entries[key] = c.order.PushFront(&clientEntry{key: key, client: client})
+	if c.order.Len() > c.max {
+		el := c.order.Back()
+		c.order.Remove(el)
+		delete(c.entries, el.Value.(*clientEntry).key)
+	}
+}

--- a/packages/michael/internal/storage/s3.go
+++ b/packages/michael/internal/storage/s3.go
@@ -15,10 +15,11 @@ import (
 	"github.com/rs/zerolog"
 
 	"michael/internal/config"
+	"michael/internal/credentials"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/aws/aws-sdk-go-v2/credentials"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
@@ -51,8 +52,17 @@ type Storage interface {
 	DeleteObject(ctx context.Context, bucket, key string) error
 }
 
+// ErrNoCredentials is fatal to the request by design: there is no fallback
+// credential to serve it with.
+var ErrNoCredentials = errors.New("no storage credentials on request")
+
+// S3Storage owns one endpoint's HTTP transport, and caches an SDK client per
+// credential pair on top of it.
 type S3Storage struct {
-	client *s3.Client
+	base        s3.Options
+	clients     *clientCache
+	probeClient *s3.Client
+	onLookup    func(hit bool)
 }
 
 func NewS3Storage(cfg config.Config) *S3Storage {
@@ -75,12 +85,13 @@ type S3Options struct {
 	TLSSkipVerify bool
 	// Wrap, when set, wraps the backend's transport (e.g. with per-backend
 	// client metrics).
-	Wrap func(http.RoundTripper) http.RoundTripper
+	Wrap               func(http.RoundTripper) http.RoundTripper
+	OnCredentialLookup func(hit bool)
 }
 
 // NewS3StorageForEndpoint builds an S3Storage bound to a specific endpoint,
-// reusing the credentials/region/path-style from cfg. The load-balancing pool
-// uses this to stamp out one client per backend gateway.
+// reusing the region/path-style from cfg. The load-balancing pool uses this to
+// stamp out one backend per gateway.
 func NewS3StorageForEndpoint(cfg config.Config, endpoint string) *S3Storage {
 	return NewS3StorageWithOptions(cfg, S3Options{
 		Endpoint:      endpoint,
@@ -90,27 +101,59 @@ func NewS3StorageForEndpoint(cfg config.Config, endpoint string) *S3Storage {
 
 // NewS3StorageWithOptions builds an S3Storage for the default storage cluster
 // with explicit per-backend options (host-pinned dialing and/or TLS
-// skip-verify) layered on the cfg credentials.
+// skip-verify).
 func NewS3StorageWithOptions(cfg config.Config, opts S3Options) *S3Storage {
 	return NewS3StorageForCluster(cfg.DefaultCluster(), opts)
 }
 
 // NewS3StorageForCluster builds an S3Storage against one storage cluster's
-// credentials, region, and path-style. Each cluster michael fronts has its own
-// object-user, so credentials cannot be shared across clusters.
+// region and path-style. Credentials are not part of it: they come from the
+// token on each request.
 func NewS3StorageForCluster(cc config.ClusterConfig, opts S3Options) *S3Storage {
-	s3opts := s3.Options{
-		Region: cc.S3Region,
-		Credentials: credentials.NewStaticCredentialsProvider(
-			cc.S3AccessKeyID,
-			cc.S3SecretAccessKey,
-			"",
-		),
+	base := s3.Options{
+		Region:       cc.S3Region,
 		BaseEndpoint: aws.String(opts.Endpoint),
 		UsePathStyle: cc.S3ForcePathStyle,
+		HTTPClient:   buildHTTPClient(opts),
 	}
-	s3opts.HTTPClient = buildHTTPClient(opts)
-	return &S3Storage{client: s3.New(s3opts)}
+
+	probeOptions := base
+	probeOptions.Credentials = aws.AnonymousCredentials{}
+
+	return &S3Storage{
+		base:        base,
+		clients:     newClientCache(clientCacheSize),
+		probeClient: s3.New(probeOptions),
+		onLookup:    opts.OnCredentialLookup,
+	}
+}
+
+// All clients share the backend's transport, so a new credential costs an
+// options struct, not a connection pool.
+func (s *S3Storage) client(ctx context.Context) (*s3.Client, error) {
+	creds, ok := credentials.FromContext(ctx)
+	if !ok {
+		return nil, ErrNoCredentials
+	}
+
+	key := creds.Fingerprint()
+	if client, ok := s.clients.get(key); ok {
+		s.lookup(true)
+		return client, nil
+	}
+	s.lookup(false)
+
+	options := s.base
+	options.Credentials = awscreds.NewStaticCredentialsProvider(creds.AccessKeyID, creds.SecretAccessKey, "")
+	client := s3.New(options)
+	s.clients.put(key, client)
+	return client, nil
+}
+
+func (s *S3Storage) lookup(hit bool) {
+	if s.onLookup != nil {
+		s.onLookup(hit)
+	}
 }
 
 // buildHTTPClient builds the HTTP client for one backend. Always custom (never
@@ -163,7 +206,7 @@ func buildHTTPClient(opts S3Options) *http.Client {
 func (s *S3Storage) Probe(ctx context.Context, bucket string) error {
 	// Single-shot: a probe must not be silently retried by the SDK, or a dead
 	// gateway would look slow-but-alive and add latency to every reconcile.
-	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+	_, err := s.probeClient.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}, func(o *s3.Options) {
 		o.RetryMaxAttempts = 1
@@ -175,7 +218,11 @@ func (s *S3Storage) Probe(ctx context.Context, bucket string) error {
 }
 
 func (s *S3Storage) CheckBucket(ctx context.Context, bucket string) (bool, error) {
-	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return false, err
+	}
+	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	})
 	if err != nil {
@@ -194,7 +241,11 @@ func (s *S3Storage) CheckBucket(ctx context.Context, bucket string) (bool, error
 }
 
 func (s *S3Storage) CreateBucket(ctx context.Context, bucket string) error {
-	_, err := s.client.CreateBucket(ctx, &s3.CreateBucketInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
 	if err != nil {
@@ -204,7 +255,11 @@ func (s *S3Storage) CreateBucket(ctx context.Context, bucket string) error {
 }
 
 func (s *S3Storage) HeadObject(ctx context.Context, bucket, key string) (int64, error) {
-	out, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return 0, err
+	}
+	out, err := client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
@@ -218,6 +273,11 @@ func (s *S3Storage) HeadObject(ctx context.Context, bucket, key string) (int64, 
 }
 
 func (s *S3Storage) GetObject(ctx context.Context, bucket, key, rangeHeader string) (*S3Object, error) {
+	client, err := s.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -226,7 +286,7 @@ func (s *S3Storage) GetObject(ctx context.Context, bucket, key, rangeHeader stri
 		input.Range = aws.String(rangeHeader)
 	}
 
-	out, err := s.client.GetObject(ctx, input)
+	out, err := client.GetObject(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +310,11 @@ func (s *S3Storage) GetObject(ctx context.Context, bucket, key, rangeHeader stri
 }
 
 func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.Reader, contentLength int64, writeOnce bool, sha256Hex string) error {
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+
 	var uploadBody io.Reader = body
 	var hasher *sha256Writer
 
@@ -277,7 +342,7 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 	// large fraction of PUTs. With retries off, a transient gateway error
 	// surfaces cleanly and restic retries the pack itself (its body IS
 	// seekable). See TestPutObject_NonSeekableBodyOn503_NoRewindRetry.
-	_, err := s.client.PutObject(ctx, input, s3.WithAPIOptions(
+	_, err = client.PutObject(ctx, input, s3.WithAPIOptions(
 		v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
 	), func(o *s3.Options) {
 		o.RetryMaxAttempts = 1
@@ -319,7 +384,12 @@ func (w *sha256Writer) Write(p []byte) (n int, err error) {
 // page (1000 keys each). Names are full object keys; callers strip what they
 // need. An fn error aborts the walk.
 func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error {
-	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+
+	paginator := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
 		Prefix: aws.String(prefix),
 	})
@@ -341,7 +411,11 @@ func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string, fn f
 }
 
 func (s *S3Storage) DeleteObject(ctx context.Context, bucket, key string) error {
-	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+	client, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})

--- a/packages/michael/internal/storage/s3_test.go
+++ b/packages/michael/internal/storage/s3_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"michael/internal/config"
+	"michael/internal/credentials"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
@@ -128,7 +129,7 @@ func TestListObjects_PaginatesAllPages(t *testing.T) {
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
 	var blobs []BlobInfo
-	err := s.ListObjects(context.Background(), "bucket", "data/", func(b BlobInfo) error {
+	err := s.ListObjects(testCtx(), "bucket", "data/", func(b BlobInfo) error {
 		blobs = append(blobs, b)
 		return nil
 	})
@@ -165,7 +166,7 @@ func TestListObjects_EmptyListing(t *testing.T) {
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
 	calls := 0
-	err := s.ListObjects(context.Background(), "bucket", "data/", func(BlobInfo) error {
+	err := s.ListObjects(testCtx(), "bucket", "data/", func(BlobInfo) error {
 		calls++
 		return nil
 	})
@@ -204,7 +205,7 @@ func TestPutObject_NonSeekableBodyOn503_NoRewindRetry(t *testing.T) {
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
 	body := readOnly{strings.NewReader("restic-pack-bytes")}
-	err := s.PutObject(context.Background(), "bucket", "data/deadbeef", body, int64(len("restic-pack-bytes")), true, "")
+	err := s.PutObject(testCtx(), "bucket", "data/deadbeef", body, int64(len("restic-pack-bytes")), true, "")
 
 	if err == nil {
 		t.Fatal("expected an error from the 503 gateway, got nil")
@@ -220,12 +221,18 @@ func TestPutObject_NonSeekableBodyOn503_NoRewindRetry(t *testing.T) {
 	}
 }
 
+// Only Probe works without credentials.
+func testCtx() context.Context {
+	return credentials.NewContext(context.Background(), credentials.Credentials{
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+	})
+}
+
 func probeConfig() config.Config {
 	return config.Config{
-		S3AccessKeyID:     "test",
-		S3SecretAccessKey: "test",
-		S3Region:          "us-east-1",
-		S3ForcePathStyle:  true,
+		S3Region:         "us-east-1",
+		S3ForcePathStyle: true,
 	}
 }
 
@@ -237,7 +244,7 @@ func TestProbe_HealthyOn404(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Errorf("Probe against 404 gateway: expected healthy, got %v", err)
 	}
 }
@@ -249,7 +256,7 @@ func TestProbe_HealthyOn200(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Errorf("Probe against 200 gateway: expected healthy, got %v", err)
 	}
 }
@@ -261,7 +268,7 @@ func TestProbe_UnhealthyOn503(t *testing.T) {
 	defer srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
-	if err := s.Probe(context.Background(), "probe-bucket"); err == nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err == nil {
 		t.Error("Probe against 503 gateway: expected unhealthy, got nil")
 	}
 }
@@ -273,7 +280,7 @@ func TestProbe_UnhealthyOnConnRefused(t *testing.T) {
 	srv.Close()
 
 	s := NewS3StorageForEndpoint(probeConfig(), url)
-	if err := s.Probe(context.Background(), "probe-bucket"); err == nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err == nil {
 		t.Error("Probe against down gateway: expected unhealthy, got nil")
 	}
 }
@@ -297,7 +304,7 @@ func TestNewS3StorageWithOptions_PinsDialAndPreservesHost(t *testing.T) {
 		Endpoint: "http://s3.signing-host.invalid",
 		DialAddr: dialAddr,
 	})
-	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := s.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Fatalf("Probe through pinned dial: %v", err)
 	}
 	if !hit {
@@ -321,7 +328,7 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 		Endpoint: "https://s3.signing-host.invalid",
 		DialAddr: dialAddr,
 	})
-	if err := noSkip.Probe(context.Background(), "probe-bucket"); err == nil {
+	if err := noSkip.Probe(testCtx(), "probe-bucket"); err == nil {
 		t.Error("expected TLS verification failure without skip-verify")
 	}
 
@@ -331,7 +338,7 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 		DialAddr:      dialAddr,
 		TLSSkipVerify: true,
 	})
-	if err := skip.Probe(context.Background(), "probe-bucket"); err != nil {
+	if err := skip.Probe(testCtx(), "probe-bucket"); err != nil {
 		t.Errorf("Probe with skip-verify against self-signed gateway: %v", err)
 	}
 }
@@ -350,3 +357,71 @@ type httpError struct {
 
 func (e *httpError) Error() string       { return "http error" }
 func (e *httpError) HTTPStatusCode() int { return e.statusCode }
+
+// The connection pool belongs to the transport, so it is shared regardless.
+func TestClientCachedPerCredential(t *testing.T) {
+	var hits, misses int
+	s := NewS3StorageForCluster(config.ClusterConfig{S3Region: "us-east-1", S3Endpoint: "http://s3.invalid"}, S3Options{
+		Endpoint: "http://s3.invalid",
+		OnCredentialLookup: func(hit bool) {
+			if hit {
+				hits++
+				return
+			}
+			misses++
+		},
+	})
+
+	repoA := credentials.NewContext(context.Background(), credentials.Credentials{AccessKeyID: "a", SecretAccessKey: "a"})
+	repoB := credentials.NewContext(context.Background(), credentials.Credentials{AccessKeyID: "b", SecretAccessKey: "b"})
+
+	first, err := s.client(repoA)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	again, err := s.client(repoA)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	other, err := s.client(repoB)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	if first != again {
+		t.Error("expected the same client for the same credentials")
+	}
+	if first == other {
+		t.Error("expected a distinct client for different credentials")
+	}
+	if misses != 2 || hits != 1 {
+		t.Errorf("expected 2 misses and 1 hit, got %d/%d", misses, hits)
+	}
+}
+
+func TestStorageRejectsRequestWithoutCredentials(t *testing.T) {
+	s := NewS3StorageForEndpoint(probeConfig(), "http://s3.invalid")
+
+	if _, err := s.CheckBucket(context.Background(), "bucket"); !errors.Is(err, ErrNoCredentials) {
+		t.Fatalf("expected ErrNoCredentials, got %v", err)
+	}
+}
+
+// Any HTTP response at all proves the gateway is serving, so an unsigned probe
+// is enough.
+func TestProbeSendsNoAuthorizationHeader(t *testing.T) {
+	var authorization string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
+	if err := s.Probe(context.Background(), "probe-bucket"); err != nil {
+		t.Errorf("Probe against a 403 gateway: expected healthy, got %v", err)
+	}
+	if authorization != "" {
+		t.Errorf("expected an unsigned probe, got Authorization %q", authorization)
+	}
+}

--- a/packages/michael/main.go
+++ b/packages/michael/main.go
@@ -86,7 +86,7 @@ func main() {
 		log.Info().Str("endpoint", cfg.OTLPMetricsEndpoint).Msg("OpenTelemetry metrics enabled")
 	}
 
-	stores, pools := buildClusters(cfg, tm)
+	stores, pools := buildClusters(cfg, tm, credentialLookup(m))
 
 	if len(pools) > 0 && meterProvider != nil {
 		providers := make(map[string]metrics.BackendStatsProvider, len(pools))
@@ -109,7 +109,7 @@ func main() {
 		log.Info().Str("path", cfg.ASNDatabasePath).Msg("ASN database loaded")
 	}
 
-	srv := handlers.NewClusterServer(stores, cfg.S3DefaultCluster, cfg.JWTPublicKey, m)
+	srv := handlers.NewClusterServer(stores, cfg.S3DefaultCluster, cfg.JWTPublicKey, cfg.StorageSealKeys, m)
 	srv.ResolveClient = func(r *http.Request) geoip.Client {
 		return asnDB.Resolve(r, cfg.ClientIPHeader)
 	}
@@ -169,11 +169,15 @@ func main() {
 // concretely so the caller can register their metrics and run their reconcile
 // loops). A single-cluster deployment yields exactly one entry, under
 // cfg.S3DefaultCluster.
-func buildClusters(cfg config.Config, tm *metrics.TransportMetrics) (map[string]storage.Storage, map[string]*storage.Pool) {
+func buildClusters(
+	cfg config.Config,
+	tm *metrics.TransportMetrics,
+	onCredentialLookup func(hit bool),
+) (map[string]storage.Storage, map[string]*storage.Pool) {
 	stores := make(map[string]storage.Storage, len(cfg.Clusters))
 	pools := make(map[string]*storage.Pool)
 	for _, cc := range cfg.Clusters {
-		store, pool := buildStorage(cc, tm)
+		store, pool := buildStorage(cc, tm, onCredentialLookup)
 		stores[cc.Code] = store
 		if pool != nil {
 			pools[cc.Code] = pool
@@ -187,17 +191,22 @@ func buildClusters(cfg config.Config, tm *metrics.TransportMetrics) (map[string]
 // configured it is a single S3 client (legacy behavior) and pool is nil. With
 // source=file or source=dns it is a load-balancing Pool, also returned
 // concretely so the caller can register its metrics and run its reconcile loop.
-func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storage.Storage, *storage.Pool) {
+func buildStorage(
+	cc config.ClusterConfig,
+	tm *metrics.TransportMetrics,
+	onCredentialLookup func(hit bool),
+) (storage.Storage, *storage.Pool) {
 	if cc.S3BackendSource == "" {
 		return storage.NewS3StorageForCluster(cc, storage.S3Options{
-			Endpoint:      cc.S3Endpoint,
-			TLSSkipVerify: cc.S3TLSSkipVerify,
-			Wrap:          transportWrap(tm, cc.Code, cc.S3Endpoint),
+			Endpoint:           cc.S3Endpoint,
+			TLSSkipVerify:      cc.S3TLSSkipVerify,
+			Wrap:               transportWrap(tm, cc.Code, cc.S3Endpoint),
+			OnCredentialLookup: onCredentialLookup,
 		}), nil
 	}
 
 	resolver := buildResolver(cc)
-	factory := backendFactory(cc, tm)
+	factory := backendFactory(cc, tm, onCredentialLookup)
 	pool, err := storage.NewPool(storage.PoolConfig{
 		EjectThreshold:    cc.S3EjectThreshold,
 		ProbeBucket:       cc.S3ProbeBucket,
@@ -215,13 +224,18 @@ func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storag
 // directly while still signing/Host-ing with the cluster endpoint (replacing the
 // HAProxy hop); otherwise the resolved endpoint is used as the S3 endpoint
 // as-is.
-func backendFactory(cc config.ClusterConfig, tm *metrics.TransportMetrics) storage.BackendFactory {
+func backendFactory(
+	cc config.ClusterConfig,
+	tm *metrics.TransportMetrics,
+	onCredentialLookup func(hit bool),
+) storage.BackendFactory {
 	if !cc.S3BackendPinHost {
 		return func(endpoint string) (storage.Storage, error) {
 			return storage.NewS3StorageForCluster(cc, storage.S3Options{
-				Endpoint:      endpoint,
-				TLSSkipVerify: cc.S3TLSSkipVerify,
-				Wrap:          transportWrap(tm, cc.Code, endpoint),
+				Endpoint:           endpoint,
+				TLSSkipVerify:      cc.S3TLSSkipVerify,
+				Wrap:               transportWrap(tm, cc.Code, endpoint),
+				OnCredentialLookup: onCredentialLookup,
 			}), nil
 		}
 	}
@@ -239,11 +253,27 @@ func backendFactory(cc config.ClusterConfig, tm *metrics.TransportMetrics) stora
 			dial = net.JoinHostPort(u.Hostname(), port)
 		}
 		return storage.NewS3StorageForCluster(cc, storage.S3Options{
-			Endpoint:      cc.S3Endpoint,
-			DialAddr:      dial,
-			TLSSkipVerify: cc.S3TLSSkipVerify,
-			Wrap:          transportWrap(tm, cc.Code, dial),
+			Endpoint:           cc.S3Endpoint,
+			DialAddr:           dial,
+			TLSSkipVerify:      cc.S3TLSSkipVerify,
+			Wrap:               transportWrap(tm, cc.Code, dial),
+			OnCredentialLookup: onCredentialLookup,
 		}), nil
+	}
+}
+
+// credentialLookup returns the per-credential client cache hook, or nil when
+// metrics are disabled.
+func credentialLookup(m *metrics.Metrics) func(hit bool) {
+	if m == nil {
+		return nil
+	}
+	return func(hit bool) {
+		if hit {
+			m.CredentialCacheHits.Add(context.Background(), 1)
+			return
+		}
+		m.CredentialCacheMisses.Add(context.Background(), 1)
 	}
 }
 


### PR DESCRIPTION
michael stops holding S3 credentials and opens the ones each token carries; a token without them is a 401.

- `main` <!-- branch-stack -->
  - \#433
    - \#437
      - \#438
        - \#439
          - \#440 :point\_left:
            - \#441
              - \#442
                - \#446
