### PR TITLE
feat(yuctl): migrate, list orphans and purge repository storage

### DIFF
--- a/packages/yuctl/README.md
+++ b/packages/yuctl/README.md
@@ -41,6 +41,7 @@ packages/yuctl/
     context/                  # ~/.config/yuctl/context.json {partition,region,ceph_cluster}
     k8s/                      # talosctl upgrade wrapper
     ceph/                     # RGW/dashboard health probe
+    rgw/                      # RadosGW admin ops + bucket-ownership calls
     adminapi/                 # CLI loopback login + Bearer admin-api client
 ```
 
@@ -60,6 +61,10 @@ yuctl
 ├── users
 │   ├── list                        list users in the partition's PRIMARY region
 │   └── view-dashboard              open the grafana per-user drill-down (--id or --email)
+├── repos
+│   ├── migrate-storage-credentials  give each repository its own RGW user and hand its bucket over
+│   ├── orphans                      list repository buckets no repository row claims
+│   └── purge <id>                   delete an orphaned bucket, its objects and its RGW user (--yes)
 ├── config                          scoped config overrides (served to clients via /api/meta)
 │   ├── list                        list every settings scope (global / site:* / cluster:*)
 │   ├── get                         print one scope's overrides (--site / --cluster)
@@ -89,6 +94,31 @@ yuctl
 
 Global flags: `--log-level` (trace|debug|info|warn|error), `--log-format`
 (pretty|json).
+
+## Storage-credential migration
+
+`repos migrate-storage-credentials` is the one-time cutover behind
+[`docs/storage-credentials.md`](../../docs/storage-credentials.md): every
+repository gets its own RGW user, and its bucket is handed over to it, so
+michael can stop holding a cluster-wide S3 credential.
+
+```sh
+yuctl ceph select spice
+yuctl repos migrate-storage-credentials --dry-run   # report what would move
+yuctl repos migrate-storage-credentials
+```
+
+Deleting a repository has never deleted its data, so buckets outlive their rows.
+`orphans` lists the strays (bucket, owner, objects, bytes) by diffing RGW against
+the repository list; `purge` reclaims one, refusing anything still in the
+database and requiring `--yes`. Nothing reclaims automatically.
+
+It talks to the admin API (provisioning) and to the RGW directly, using the
+selected ceph cluster's `s3_migrator_cred_refs` (bucket admin) and
+`s3_owner_cred_refs` (the current bucket owner, which has to sign the
+ownership-controls call) from discovery. Neither is the credential the APIs
+hold online — that one has no bucket admin at all. Idempotent, and it re-reads each bucket
+afterwards rather than trusting the link.
 
 ## State-reading approach
 

--- a/packages/yuctl/internal/adminapi/repos.go
+++ b/packages/yuctl/internal/adminapi/repos.go
@@ -135,3 +135,20 @@ func (c *Client) ListRepositories(ctx context.Context, userID string, limit int)
 	}
 	return all, nil
 }
+
+// StorageCredentials carries no secret: it never leaves the API.
+type StorageCredentials struct {
+	StorageUserID      string `json:"storageUserId"`
+	StorageClusterCode string `json:"storageClusterCode"`
+	AccessKeyID        string `json:"accessKeyId"`
+}
+
+// rotate issues a fresh key pair, invalidating the credentials any
+// already-minted token carries.
+func (c *Client) ProvisionStorageCredentials(ctx context.Context, id string, rotate bool) (*StorageCredentials, error) {
+	var out StorageCredentials
+	if err := c.postJSON(ctx, "/api/repository/"+id+"/storage-credentials", map[string]any{"rotate": rotate}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/packages/yuctl/internal/cli/repos.go
+++ b/packages/yuctl/internal/cli/repos.go
@@ -1,0 +1,427 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"yuctl/internal/adminapi"
+	"yuctl/internal/op"
+	"yuctl/internal/rgw"
+	"yuctl/internal/state"
+)
+
+func newReposCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repos",
+		Short: "Repository administration via yucca-admin-api",
+	}
+	cmd.AddCommand(newReposMigrateStorageCredentialsCmd(), newReposOrphansCmd(), newReposPurgeCmd())
+	return cmd
+}
+
+func newReposMigrateStorageCredentialsCmd() *cobra.Command {
+	flags := &adminFlags{}
+	var (
+		dryRun      bool
+		rotate      bool
+		repoID      string
+		rgwEndpoint string
+		region      string
+	)
+
+	c := &cobra.Command{
+		Use:   "migrate-storage-credentials",
+		Short: "Give each repository its own RGW user and hand its bucket over",
+		Long: "Provisions every repository's own S3 user through admin-api, marks its bucket\n" +
+			"BucketOwnerEnforced (signed as the current owner, so existing objects follow the\n" +
+			"bucket), then links the bucket to the new user. Idempotent: a repository that is\n" +
+			"already migrated is reported and skipped.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			client, _, err := flags.allowlistClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			cluster, err := selectedCephCluster(ctx)
+			if err != nil {
+				return err
+			}
+			endpoint := rgwEndpoint
+			if endpoint == "" {
+				endpoint = cluster.RGWS3Endpoint
+			}
+			if endpoint == "" {
+				return fmt.Errorf("no rgw_s3_endpoint in discovery for the selected ceph cluster; pass --rgw-endpoint")
+			}
+
+			admin, err := resolveCredentials(ctx, cluster.S3MigratorCredRefs, "s3_migrator_cred_refs")
+			if err != nil {
+				return err
+			}
+			owner, err := resolveCredentials(ctx, cluster.S3OwnerCredRefs, "s3_owner_cred_refs")
+			if err != nil {
+				return err
+			}
+
+			repositories, err := listMigrationTargets(ctx, client, repoID)
+			if err != nil {
+				return err
+			}
+
+			rgwAdmin := rgw.NewAdminClient(endpoint, region, admin, flags.insecure)
+			out := cmd.OutOrStdout()
+			var migrated, skipped, failed int
+
+			for _, repository := range repositories {
+				status, err := migrateOne(ctx, migration{
+					client:   client,
+					rgw:      rgwAdmin,
+					endpoint: endpoint,
+					region:   region,
+					owner:    owner,
+					insecure: flags.insecure,
+					dryRun:   dryRun,
+					rotate:   rotate,
+				}, repository)
+				switch {
+				case err != nil:
+					failed++
+					fmt.Fprintf(out, "%s  FAILED  %s\n", repository.ID, err)
+				case status == statusSkipped:
+					skipped++
+					fmt.Fprintf(out, "%s  ok      already owned by its repository user\n", repository.ID)
+				default:
+					migrated++
+					fmt.Fprintf(out, "%s  %s\n", repository.ID, status)
+				}
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "\n%d migrated, %d already done, %d failed (of %d)\n",
+				migrated, skipped, failed, len(repositories))
+			if failed > 0 {
+				return fmt.Errorf("%d repositories could not be migrated", failed)
+			}
+			return nil
+		},
+	}
+
+	flags.register(c)
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "report what would change without provisioning or linking anything")
+	c.Flags().BoolVar(&rotate, "rotate", false, "issue fresh keys even for repositories that already have some")
+	c.Flags().StringVar(&repoID, "repository", "", "migrate a single repository by id")
+	registerRGWFlags(c, &rgwEndpoint, &region)
+	return c
+}
+
+type migrationStatus string
+
+const (
+	statusSkipped   migrationStatus = "skipped"
+	statusMigrated  migrationStatus = "migrated"
+	statusWouldMove migrationStatus = "would migrate"
+)
+
+type migration struct {
+	client   *adminapi.Client
+	rgw      *rgw.AdminClient
+	endpoint string
+	region   string
+	owner    rgw.Credentials
+	insecure bool
+	dryRun   bool
+	rotate   bool
+}
+
+// Ownership is enforced before the link, or the new owner inherits a bucket
+// full of objects it cannot read.
+func migrateOne(ctx context.Context, m migration, repository adminapi.Repository) (migrationStatus, error) {
+	bucket, err := m.rgw.GetBucket(ctx, repository.ID)
+	if err != nil {
+		return "", fmt.Errorf("read bucket: %w", err)
+	}
+
+	credentials, err := m.provision(ctx, repository.ID)
+	if err != nil {
+		return "", err
+	}
+
+	if bucket.Owner == credentials.StorageUserID && !m.rotate {
+		return statusSkipped, nil
+	}
+	if m.dryRun {
+		return statusWouldMove, nil
+	}
+
+	if bucket.Owner != credentials.StorageUserID {
+		if err := rgw.EnforceBucketOwner(ctx, m.endpoint, m.region, m.owner, repository.ID, m.insecure); err != nil {
+			return "", err
+		}
+		if err := m.rgw.LinkBucket(ctx, repository.ID, bucket.ID, credentials.StorageUserID); err != nil {
+			return "", fmt.Errorf("link bucket to %s: %w", credentials.StorageUserID, err)
+		}
+
+		// A silently no-op link would leave the repository unreadable with its
+		// new credentials.
+		after, err := m.rgw.GetBucket(ctx, repository.ID)
+		if err != nil {
+			return "", fmt.Errorf("verify bucket owner: %w", err)
+		}
+		if after.Owner != credentials.StorageUserID {
+			return "", fmt.Errorf("bucket owner is still %q after link, expected %q", after.Owner, credentials.StorageUserID)
+		}
+	}
+
+	return statusMigrated, nil
+}
+
+// Mirrors storageUserId() in the APIs: a dry run must not provision anything,
+// so it is the one path that derives the name instead of being told it.
+const storageUserPrefix = "yucca-repo-"
+
+func (m migration) provision(ctx context.Context, id string) (*adminapi.StorageCredentials, error) {
+	if m.dryRun {
+		return &adminapi.StorageCredentials{StorageUserID: storageUserPrefix + id}, nil
+	}
+	credentials, err := m.client.ProvisionStorageCredentials(ctx, id, m.rotate)
+	if err != nil {
+		return nil, fmt.Errorf("provision storage credentials: %w", err)
+	}
+	return credentials, nil
+}
+
+func listMigrationTargets(ctx context.Context, client *adminapi.Client, repoID string) ([]adminapi.Repository, error) {
+	if repoID != "" {
+		return []adminapi.Repository{{ID: repoID}}, nil
+	}
+	return client.ListRepositories(ctx, "", 0)
+}
+
+func selectedCephCluster(ctx context.Context) (state.CephCluster, error) {
+	c, err := requireContext()
+	if err != nil {
+		return state.CephCluster{}, err
+	}
+	if c.CephCluster == "" {
+		return state.CephCluster{}, fmt.Errorf("no ceph cluster selected; run `yuctl ceph select <name>` first")
+	}
+	topo, err := resolveTopology(ctx)
+	if err != nil {
+		return state.CephCluster{}, err
+	}
+	clusters := topo.CephClusters(c.Partition, c.Region)
+	cluster, ok := clusters[c.CephCluster]
+	if !ok {
+		return state.CephCluster{}, fmt.Errorf("ceph cluster %q no longer present in %s@%s", c.CephCluster, c.Partition, c.Region)
+	}
+	return cluster, nil
+}
+
+// resolveCredentials reads an {access_key, secret_key} pair of op:// references
+// out of a discovery payload.
+func resolveCredentials(ctx context.Context, refs map[string]string, field string) (rgw.Credentials, error) {
+	access, secret := refs["access_key"], refs["secret_key"]
+	if access == "" || secret == "" {
+		return rgw.Credentials{}, fmt.Errorf("ceph discovery has no %s.{access_key,secret_key}", field)
+	}
+	accessKey, err := op.Read(ctx, access)
+	if err != nil {
+		return rgw.Credentials{}, fmt.Errorf("resolve %s.access_key: %w", field, err)
+	}
+	secretKey, err := op.Read(ctx, secret)
+	if err != nil {
+		return rgw.Credentials{}, fmt.Errorf("resolve %s.secret_key: %w", field, err)
+	}
+	return rgw.Credentials{
+		AccessKeyID:     strings.TrimSpace(accessKey),
+		SecretAccessKey: strings.TrimSpace(secretKey),
+	}, nil
+}
+
+// A bucket whose name is a repository id but which no repository row claims:
+// deleting a repository has never deleted its data, so these accumulate and are
+// otherwise only visible as a metrics-worker log line.
+type orphan struct {
+	bucket  rgw.Bucket
+	userUID string
+}
+
+func findOrphans(ctx context.Context, client *adminapi.Client, admin *rgw.AdminClient) ([]orphan, error) {
+	repositories, err := client.ListRepositories(ctx, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	live := make(map[string]struct{}, len(repositories))
+	for _, r := range repositories {
+		live[r.ID] = struct{}{}
+	}
+
+	buckets, err := admin.ListBuckets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list buckets: %w", err)
+	}
+
+	var out []orphan
+	for _, b := range buckets {
+		if _, ok := live[b.Bucket]; ok {
+			continue
+		}
+		if !strings.HasPrefix(b.Owner, storageUserPrefix) {
+			continue
+		}
+		out = append(out, orphan{bucket: b, userUID: b.Owner})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].bucket.Bucket < out[j].bucket.Bucket })
+	return out, nil
+}
+
+func newReposOrphansCmd() *cobra.Command {
+	flags := &adminFlags{}
+	var rgwEndpoint, region string
+
+	c := &cobra.Command{
+		Use:   "orphans",
+		Short: "List repository buckets that no repository row claims",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			client, _, err := flags.allowlistClient(cmd)
+			if err != nil {
+				return err
+			}
+			admin, endpoint, err := migratorClient(ctx, rgwEndpoint, region, flags.insecure)
+			if err != nil {
+				return err
+			}
+			_ = endpoint
+
+			orphans, err := findOrphans(ctx, client, admin)
+			if err != nil {
+				return err
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+			fmt.Fprintln(w, "BUCKET\tOWNER\tOBJECTS\tBYTES")
+			var bytes int64
+			for _, o := range orphans {
+				fmt.Fprintf(w, "%s\t%s\t%d\t%d\n", o.bucket.Bucket, o.userUID, o.bucket.Objects(), o.bucket.Bytes())
+				bytes += o.bucket.Bytes()
+			}
+			w.Flush()
+			fmt.Fprintf(cmd.ErrOrStderr(), "\n%d orphaned bucket(s), %d bytes. Reclaim one with `yuctl repos purge <id>`.\n",
+				len(orphans), bytes)
+			return nil
+		},
+	}
+	flags.register(c)
+	registerRGWFlags(c, &rgwEndpoint, &region)
+	return c
+}
+
+func newReposPurgeCmd() *cobra.Command {
+	flags := &adminFlags{}
+	var rgwEndpoint, region string
+	var yes bool
+
+	c := &cobra.Command{
+		Use:   "purge <repository-id>",
+		Short: "Delete an orphaned repository bucket, its objects and its RGW user",
+		Long: "Destroys data. Refuses unless the repository is genuinely gone from the\n" +
+			"database and its bucket is owned by the matching " + storageUserPrefix + "* user.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			id := args[0]
+
+			client, _, err := flags.allowlistClient(cmd)
+			if err != nil {
+				return err
+			}
+			admin, endpoint, err := migratorClient(ctx, rgwEndpoint, region, flags.insecure)
+			if err != nil {
+				return err
+			}
+
+			orphans, err := findOrphans(ctx, client, admin)
+			if err != nil {
+				return err
+			}
+			var target *orphan
+			for i := range orphans {
+				if orphans[i].bucket.Bucket == id {
+					target = &orphans[i]
+					break
+				}
+			}
+			if target == nil {
+				return fmt.Errorf("%s is not an orphaned bucket; `yuctl repos orphans` lists what can be purged", id)
+			}
+
+			if !yes {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"About to DELETE bucket %s (%d objects, %d bytes) and user %s. Re-run with --yes.\n",
+					id, target.bucket.Objects(), target.bucket.Bytes(), target.userUID)
+				return fmt.Errorf("refusing to purge without --yes")
+			}
+
+			if err := admin.RemoveBucket(ctx, id, true); err != nil {
+				return fmt.Errorf("remove bucket: %w", err)
+			}
+			// The user is a separate credential's job: the migrator is bucket-only.
+			provisioner, err := provisionerClient(ctx, endpoint, region, flags.insecure)
+			if err != nil {
+				return err
+			}
+			if err := provisioner.RemoveUser(ctx, target.userUID); err != nil {
+				return fmt.Errorf("remove user %s: %w", target.userUID, err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "%s  purged (bucket, objects and %s)\n", id, target.userUID)
+			return nil
+		},
+	}
+	flags.register(c)
+	registerRGWFlags(c, &rgwEndpoint, &region)
+	c.Flags().BoolVar(&yes, "yes", false, "confirm the deletion")
+	return c
+}
+
+func registerRGWFlags(c *cobra.Command, endpoint, region *string) {
+	c.Flags().StringVar(endpoint, "rgw-endpoint", "", "RGW S3 endpoint (default: the selected ceph cluster's rgw_s3_endpoint)")
+	c.Flags().StringVar(region, "region", "us-east-1", "S3 region to sign with")
+}
+
+func migratorClient(ctx context.Context, rgwEndpoint, region string, insecure bool) (*rgw.AdminClient, string, error) {
+	cluster, err := selectedCephCluster(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	endpoint := rgwEndpoint
+	if endpoint == "" {
+		endpoint = cluster.RGWS3Endpoint
+	}
+	if endpoint == "" {
+		return nil, "", fmt.Errorf("no rgw_s3_endpoint in discovery for the selected ceph cluster; pass --rgw-endpoint")
+	}
+	creds, err := resolveCredentials(ctx, cluster.S3MigratorCredRefs, "s3_migrator_cred_refs")
+	if err != nil {
+		return nil, "", err
+	}
+	return rgw.NewAdminClient(endpoint, region, creds, insecure), endpoint, nil
+}
+
+func provisionerClient(ctx context.Context, endpoint, region string, insecure bool) (*rgw.AdminClient, error) {
+	cluster, err := selectedCephCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+	creds, err := resolveCredentials(ctx, cluster.S3ProvisionerCredRefs, "s3_provisioner_cred_refs")
+	if err != nil {
+		return nil, err
+	}
+	return rgw.NewAdminClient(endpoint, region, creds, insecure), nil
+}

--- a/packages/yuctl/internal/cli/root.go
+++ b/packages/yuctl/internal/cli/root.go
@@ -49,6 +49,7 @@ func NewRootCmd() *cobra.Command {
 		newCephCmd(),
 		newInfraCmd(),
 		newUsersCmd(),
+		newReposCmd(),
 		newConfigCmd(),
 		newFeaturesCmd(),
 		newToolsCmd(),

--- a/packages/yuctl/internal/cli/root_test.go
+++ b/packages/yuctl/internal/cli/root_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Building the tree panics on a duplicate flag registration, which breaks every
+// yuctl invocation rather than the one subcommand at fault.
+func TestNewRootCmdBuildsEveryCommand(t *testing.T) {
+	var count int
+	var visit func(*cobra.Command)
+	visit = func(c *cobra.Command) {
+		count++
+		c.InitDefaultHelpFlag()
+		for _, sub := range c.Commands() {
+			visit(sub)
+		}
+	}
+	visit(NewRootCmd())
+
+	if count < 10 {
+		t.Fatalf("walked only %d commands; the tree did not build", count)
+	}
+}

--- a/packages/yuctl/internal/rgw/rgw.go
+++ b/packages/yuctl/internal/rgw/rgw.go
@@ -1,0 +1,214 @@
+// Package rgw drives the RadosGW admin ops API and the bucket-ownership S3
+// calls behind `yuctl repos migrate-storage-credentials`.
+package rgw
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// Credentials is one S3 identity.
+type Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+}
+
+// emptyPayloadHash is the SigV4 hash of an empty body; every admin ops call
+// here sends one.
+var emptyPayloadHash = func() string {
+	sum := sha256.Sum256(nil)
+	return hex.EncodeToString(sum[:])
+}()
+
+// AdminClient calls the RadosGW admin ops API with a users+buckets admin
+// credential.
+type AdminClient struct {
+	endpoint string
+	region   string
+	creds    aws.Credentials
+	http     *http.Client
+}
+
+func NewAdminClient(endpoint, region string, creds Credentials, insecureTLS bool) *AdminClient {
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if insecureTLS {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		hc.Transport = tr
+	}
+	return &AdminClient{
+		endpoint: strings.TrimRight(endpoint, "/"),
+		region:   region,
+		creds: aws.Credentials{
+			AccessKeyID:     creds.AccessKeyID,
+			SecretAccessKey: creds.SecretAccessKey,
+		},
+		http: hc,
+	}
+}
+
+// Bucket is the slice of the admin API's bucket stats yuctl acts on.
+type Bucket struct {
+	Bucket string `json:"bucket"`
+	ID     string `json:"id"`
+	Owner  string `json:"owner"`
+	Usage  struct {
+		Main struct {
+			NumObjects int64 `json:"num_objects"`
+			SizeActual int64 `json:"size_actual"`
+		} `json:"rgw.main"`
+	} `json:"usage"`
+}
+
+func (b Bucket) Objects() int64 { return b.Usage.Main.NumObjects }
+func (b Bucket) Bytes() int64   { return b.Usage.Main.SizeActual }
+
+// ListBuckets reads every bucket with its owner and usage, which is how the
+// orphan report tells a stranded repository bucket from a live one.
+func (c *AdminClient) ListBuckets(ctx context.Context) ([]Bucket, error) {
+	var out []Bucket
+	if err := c.do(ctx, http.MethodGet, "/admin/bucket", url.Values{
+		"stats":  {"true"},
+		"format": {"json"},
+	}, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// RemoveBucket deletes a bucket and, with purgeObjects, everything in it.
+func (c *AdminClient) RemoveBucket(ctx context.Context, bucket string, purgeObjects bool) error {
+	return c.do(ctx, http.MethodDelete, "/admin/bucket", url.Values{
+		"bucket":        {bucket},
+		"purge-objects": {strconv.FormatBool(purgeObjects)},
+		"format":        {"json"},
+	}, nil)
+}
+
+// RemoveUser needs a users-capable credential, so purge resolves the
+// provisioner separately from the bucket-only migrator.
+func (c *AdminClient) RemoveUser(ctx context.Context, uid string) error {
+	err := c.do(ctx, http.MethodDelete, "/admin/user", url.Values{
+		"uid":        {uid},
+		"purge-data": {"false"},
+		"format":     {"json"},
+	}, nil)
+	if err != nil && strings.Contains(err.Error(), "NoSuchUser") {
+		return nil
+	}
+	return err
+}
+
+// GetBucket reads one bucket's stats, which is how the migration learns its
+// current owner and its bucket id.
+func (c *AdminClient) GetBucket(ctx context.Context, bucket string) (*Bucket, error) {
+	var out Bucket
+	if err := c.do(ctx, http.MethodGet, "/admin/bucket", url.Values{
+		"bucket": {bucket},
+		"stats":  {"true"},
+		"format": {"json"},
+	}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// LinkBucket moves a bucket to another owner. The bucket id is passed alongside
+// the name because RGW resolves an unqualified name against the *caller's*
+// tenant, which is not the owner here.
+func (c *AdminClient) LinkBucket(ctx context.Context, bucket, bucketID, uid string) error {
+	return c.do(ctx, http.MethodPut, "/admin/bucket", url.Values{
+		"bucket":    {bucket},
+		"bucket-id": {bucketID},
+		"uid":       {uid},
+		"format":    {"json"},
+	}, nil)
+}
+
+func (c *AdminClient) do(ctx context.Context, method, path string, query url.Values, out any) error {
+	u := c.endpoint + path + "?" + query.Encode()
+	req, err := http.NewRequestWithContext(ctx, method, u, nil)
+	if err != nil {
+		return err
+	}
+	if err := v4.NewSigner().SignHTTP(ctx, c.creds, req, emptyPayloadHash, "s3", c.region, time.Now().UTC()); err != nil {
+		return fmt.Errorf("sign %s %s: %w", method, path, err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out != nil {
+		if err := json.Unmarshal(body, out); err != nil {
+			return fmt.Errorf("parse %s %s response: %w", method, path, err)
+		}
+	}
+	return nil
+}
+
+// EnforceBucketOwner sets ObjectOwnership to BucketOwnerEnforced, which makes
+// RGW ignore per-object ACLs so the bucket's owner controls every object in it.
+// It must be signed by the CURRENT owner, and must run before the bucket is
+// linked to its new one: without it, objects written by the old owner stay
+// readable only by the old owner.
+func EnforceBucketOwner(ctx context.Context, endpoint, region string, creds Credentials, bucket string, insecureTLS bool) error {
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if insecureTLS {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		hc.Transport = tr
+	}
+
+	client := s3.New(s3.Options{
+		Region:       region,
+		BaseEndpoint: aws.String(endpoint),
+		UsePathStyle: true,
+		HTTPClient:   hc,
+		Credentials: awscreds.NewStaticCredentialsProvider(
+			creds.AccessKeyID,
+			creds.SecretAccessKey,
+			"",
+		),
+	})
+
+	_, err := client.PutBucketOwnershipControls(ctx, &s3.PutBucketOwnershipControlsInput{
+		Bucket: aws.String(bucket),
+		OwnershipControls: &types.OwnershipControls{
+			Rules: []types.OwnershipControlsRule{
+				{ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf(
+			"set BucketOwnerEnforced on %s: %w "+
+				"(if this RGW does not support bucket ownership controls, chown the bucket on a ceph host instead: "+
+				"`radosgw-admin bucket chown --bucket=%s --uid=<uid>`)",
+			bucket, err, bucket,
+		)
+	}
+	return nil
+}

--- a/packages/yuctl/internal/state/contract.go
+++ b/packages/yuctl/internal/state/contract.go
@@ -54,13 +54,18 @@ type Kubernetes struct {
 // CephCluster is one entry of the ceph payload's ceph_clusters map. A region may
 // have one-or-more, keyed by friendly name (e.g. "sietch").
 type CephCluster struct {
-	ClusterName      string            `json:"cluster_name"`
-	FQDN             string            `json:"fqdn"`
-	RGWS3Endpoint    string            `json:"rgw_s3_endpoint"`
-	HealthCredRef    string            `json:"health_cred_ref"`    // op:// reference
-	S3AdminCredRefs  map[string]string `json:"s3_admin_cred_refs"` // op:// references
-	SecretItemTitles map[string]string `json:"secret_item_titles"` // purpose → 1P item title
-	BootstrapHost    string            `json:"bootstrap_host"`
+	ClusterName     string            `json:"cluster_name"`
+	FQDN            string            `json:"fqdn"`
+	RGWS3Endpoint   string            `json:"rgw_s3_endpoint"`
+	HealthCredRef   string            `json:"health_cred_ref"`    // op:// reference
+	S3AdminCredRefs map[string]string `json:"s3_admin_cred_refs"` // op:// references
+	// Full users+buckets RGW admin, and the S3 user owning pre-migration
+	// buckets. Both are maps of {access_key, secret_key} to op:// references.
+	S3ProvisionerCredRefs map[string]string `json:"s3_provisioner_cred_refs"`
+	S3MigratorCredRefs    map[string]string `json:"s3_migrator_cred_refs"`
+	S3OwnerCredRefs       map[string]string `json:"s3_owner_cred_refs"`
+	SecretItemTitles      map[string]string `json:"secret_item_titles"` // purpose → 1P item title
+	BootstrapHost         string            `json:"bootstrap_host"`
 }
 
 // DNS is the dns stack payload.

--- a/tf/.env
+++ b/tf/.env
@@ -53,6 +53,8 @@ export TF_VAR_yucca_rgw_secret_access_key="op://yucca_tf_staging/SIETCH_CEPH_S3_
 # Secret (secrets.tf). NOT from CI — the cluster pulls nothing from CI.
 export TF_VAR_sietch_metrics_worker_access_key="op://yucca_tf_staging/SIETCH_METRICS_WORKER_ACCESS_KEY/password"
 export TF_VAR_sietch_metrics_worker_secret_key="op://yucca_tf_staging/SIETCH_METRICS_WORKER_SECRET_KEY/password"
+export TF_VAR_sietch_provisioner_access_key="op://yucca_tf_staging/SIETCH_PROVISIONER_ACCESS_KEY/password"
+export TF_VAR_sietch_provisioner_secret_key="op://yucca_tf_staging/SIETCH_PROVISIONER_SECRET_KEY/password"
 
 # vmagent + collector → o11y staging vmauth bearer token.
 export TF_VAR_vmauth_remote_write_password="op://shared_tf_staging/VICTORIAMETRICS_VMAUTH_PASSWORD/password"

--- a/tf/.env.prod
+++ b/tf/.env.prod
@@ -70,6 +70,8 @@ export TF_VAR_yucca_rgw_secret_access_key="op://yucca_tf_prod/SPICE_CEPH_S3_SVC_
 # yucca-metrics-worker → spice RGW admin API.
 export TF_VAR_spice_metrics_worker_access_key="op://yucca_tf_prod/SPICE_METRICS_WORKER_ACCESS_KEY/password"
 export TF_VAR_spice_metrics_worker_secret_key="op://yucca_tf_prod/SPICE_METRICS_WORKER_SECRET_KEY/password"
+export TF_VAR_spice_provisioner_access_key="op://yucca_tf_prod/SPICE_PROVISIONER_ACCESS_KEY/password"
+export TF_VAR_spice_provisioner_secret_key="op://yucca_tf_prod/SPICE_PROVISIONER_SECRET_KEY/password"
 
 # vmagent/logs remote-write bearer for o11y prod vmauth.
 export TF_VAR_vmauth_remote_write_password="op://shared_tf_prod/O11Y_VICTORIAMETRICS_VMAUTH_PASSWORD/password"

--- a/tf/deployment/prod/htz-fsn1/talos/secrets.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/secrets.tf
@@ -128,6 +128,44 @@ resource "kubernetes_namespace_v1" "observability" {
   }
 }
 
+# Per-repository storage credentials. STORAGE_CREDENTIAL_KEY encrypts the RGW
+# secret keys at rest in postgres; STORAGE_CREDENTIAL_SEAL_KEY is shared with
+# michael and seals them into each restic token. Both are 32-byte AES-256 keys.
+# prevent_destroy: losing the at-rest key orphans every repository's stored
+# credential, and losing the seal key invalidates every token in flight.
+resource "random_bytes" "yucca_storage_credential_key" {
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "random_bytes" "yucca_storage_seal_key" {
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "onepassword_item" "yucca_storage_keys" {
+  vault    = data.onepassword_vault.prod.uuid
+  title    = "YUCCA_STORAGE_CREDENTIAL_KEYS"
+  category = "password"
+
+  password = random_bytes.yucca_storage_credential_key.base64
+
+  section {
+    label = "keys"
+    field {
+      label = "seal_key"
+      type  = "STRING"
+      value = random_bytes.yucca_storage_seal_key.base64
+    }
+  }
+}
+
 # yucca-api: signs JWTs with the generated private key + its OIDC client creds
 # (prod Zitadel, CUSTOMER_ZITADEL_OAUTH_*_YUCCA_WEB / _YUCCA_ORCHESTRATOR).
 resource "kubernetes_secret_v1" "yucca_api" {
@@ -140,6 +178,10 @@ resource "kubernetes_secret_v1" "yucca_api" {
     OIDC_CLIENT_ID        = var.yucca_oidc_client_id
     OIDC_CLIENT_SECRET    = var.yucca_oidc_client_secret
     OIDC_DEVICE_CLIENT_ID = var.yucca_oidc_device_client_id
+    # Per-repository storage credentials: sealed at rest with the first key,
+    # sealed into restic tokens with the second (michael holds only the second).
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key.base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key.base64
   }
 
   lifecycle {
@@ -165,6 +207,10 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
     # bench): deliberately the yucca_jwt SIGNING key — michael only accepts
     # tokens from that keypair. Admin session JWTs stay on yucca_admin_jwt.
     RESTIC_JWT_PRIVATE_KEY = tls_private_key.yucca_jwt.private_key_pem_pkcs8
+    # Same storage-credential keys as yucca-api: admin-created repositories and
+    # admin-minted restic URLs go through the identical provisioning path.
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key.base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key.base64
   }
 
   lifecycle {
@@ -175,17 +221,16 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
   }
 }
 
-# michael: verifies yucca-api's JWTs + the spice RGW svc-yucca-restic S3 keys
-# (out-of-band contract items, seeded into the RGW by the ceph ansible).
+# michael: verifies yucca-api's JWTs and opens the per-repository S3 credentials
+# they carry. It holds no S3 keys of its own.
 resource "kubernetes_secret_v1" "yucca_michael" {
   metadata {
     name      = "yucca-michael"
     namespace = kubernetes_namespace_v1.yucca.metadata[0].name
   }
   data = {
-    JWT_PUBLIC_KEY       = tls_private_key.yucca_jwt.public_key_pem
-    S3_ACCESS_KEY_ID     = var.yucca_rgw_access_key_id
-    S3_SECRET_ACCESS_KEY = var.yucca_rgw_secret_access_key
+    JWT_PUBLIC_KEY              = tls_private_key.yucca_jwt.public_key_pem
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key.base64
   }
 
   lifecycle {
@@ -213,6 +258,27 @@ resource "kubernetes_secret_v1" "yucca_metrics_rgw" {
     precondition {
       condition     = length(var.spice_metrics_worker_access_key) > 0 && length(var.spice_metrics_worker_secret_key) > 0
       error_message = "spice metrics-worker RGW keys are empty — run applies through tf/op-run.sh with OP_ENV_FILE=tf/.env.prod."
+    }
+  }
+}
+
+# yucca-api / yucca-admin-api: the RGW user with users+buckets admin caps, used
+# to create one S3 user per repository. Keys are AccessKey/SecretKey to match
+# the charts' radosSecretName lookup, as with yucca-metrics-rgw.
+resource "kubernetes_secret_v1" "yucca_provisioner_rgw" {
+  metadata {
+    name      = "yucca-provisioner-rgw"
+    namespace = kubernetes_namespace_v1.yucca.metadata[0].name
+  }
+  data = {
+    AccessKey = var.spice_provisioner_access_key
+    SecretKey = var.spice_provisioner_secret_key
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.spice_provisioner_access_key) > 0 && length(var.spice_provisioner_secret_key) > 0
+      error_message = "spice provisioner RGW keys are empty — run applies through tf/op-run.sh."
     }
   }
 }

--- a/tf/deployment/prod/htz-fsn1/talos/variables.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/variables.tf
@@ -220,3 +220,16 @@ variable "vmauth_remote_write_password" {
   sensitive   = true
   default     = ""
 }
+
+variable "spice_provisioner_access_key" {
+  description = "Spice RGW admin access key for the yucca APIs (creates one S3 user per repository)."
+  type        = string
+  default     = ""
+}
+
+variable "spice_provisioner_secret_key" {
+  description = "Spice RGW admin secret key for the yucca APIs."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/tf/deployment/prod/htz-fsn1/talos/versions.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/versions.tf
@@ -22,6 +22,11 @@ terraform {
       source  = "1Password/onepassword"
       version = "~> 2.1"
     }
+    # Storage-credential key generation (secrets.tf).
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
     # App JWT keypair generation (secrets.tf).
     tls = {
       source  = "hashicorp/tls"

--- a/tf/deployment/staging/austin/talos/secrets.tf
+++ b/tf/deployment/staging/austin/talos/secrets.tf
@@ -149,6 +149,47 @@ resource "kubernetes_namespace_v1" "netbird" {
 
 # ─── App Secrets (namespace: yucca) ─────────────────────────────────────
 
+# Per-repository storage credentials. STORAGE_CREDENTIAL_KEY encrypts the RGW
+# secret keys at rest in postgres; STORAGE_CREDENTIAL_SEAL_KEY is shared with
+# michael and seals them into each restic token. Both are 32-byte AES-256 keys.
+# prevent_destroy: losing the at-rest key orphans every repository's stored
+# credential, and losing the seal key invalidates every token in flight.
+resource "random_bytes" "yucca_storage_credential_key" {
+  count  = local.provision_secrets ? 1 : 0
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "random_bytes" "yucca_storage_seal_key" {
+  count  = local.provision_secrets ? 1 : 0
+  length = 32
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "onepassword_item" "yucca_storage_keys" {
+  count    = local.provision_secrets ? 1 : 0
+  vault    = data.onepassword_vault.staging.uuid
+  title    = "YUCCA_STORAGE_CREDENTIAL_KEYS"
+  category = "password"
+
+  password = random_bytes.yucca_storage_credential_key[0].base64
+
+  section {
+    label = "keys"
+    field {
+      label = "seal_key"
+      type  = "STRING"
+      value = random_bytes.yucca_storage_seal_key[0].base64
+    }
+  }
+}
+
 # yucca-api: signs JWTs with the generated private key + its OIDC client creds.
 resource "kubernetes_secret_v1" "yucca_api" {
   count = local.provision_secrets ? 1 : 0
@@ -161,6 +202,10 @@ resource "kubernetes_secret_v1" "yucca_api" {
     OIDC_CLIENT_ID        = var.yucca_oidc_client_id
     OIDC_CLIENT_SECRET    = var.yucca_oidc_client_secret
     OIDC_DEVICE_CLIENT_ID = var.yucca_oidc_device_client_id
+    # Per-repository storage credentials: sealed at rest with the first key,
+    # sealed into restic tokens with the second (michael holds only the second).
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key[0].base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key[0].base64
   }
 }
 
@@ -179,6 +224,10 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
     # bench): deliberately the yucca_jwt SIGNING key — michael only accepts
     # tokens from that keypair. Admin session JWTs stay on yucca_admin_jwt.
     RESTIC_JWT_PRIVATE_KEY = tls_private_key.yucca_jwt[0].private_key_pem_pkcs8
+    # Same storage-credential keys as yucca-api: admin-created repositories and
+    # admin-minted restic URLs go through the identical provisioning path.
+    STORAGE_CREDENTIAL_KEY      = random_bytes.yucca_storage_credential_key[0].base64
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key[0].base64
   }
 
   lifecycle {
@@ -198,9 +247,8 @@ resource "kubernetes_secret_v1" "yucca_michael" {
     namespace = kubernetes_namespace_v1.yucca[0].metadata[0].name
   }
   data = {
-    JWT_PUBLIC_KEY       = tls_private_key.yucca_jwt[0].public_key_pem
-    S3_ACCESS_KEY_ID     = var.yucca_rgw_access_key_id
-    S3_SECRET_ACCESS_KEY = var.yucca_rgw_secret_access_key
+    JWT_PUBLIC_KEY              = tls_private_key.yucca_jwt[0].public_key_pem
+    STORAGE_CREDENTIAL_SEAL_KEY = random_bytes.yucca_storage_seal_key[0].base64
   }
 }
 
@@ -217,6 +265,28 @@ resource "kubernetes_secret_v1" "yucca_metrics_rgw" {
   data = {
     AccessKey = var.sietch_metrics_worker_access_key
     SecretKey = var.sietch_metrics_worker_secret_key
+  }
+}
+
+# yucca-api / yucca-admin-api: the RGW user with users+buckets admin caps, used
+# to create one S3 user per repository. Keys are AccessKey/SecretKey to match
+# the charts' radosSecretName lookup, as with yucca-metrics-rgw.
+resource "kubernetes_secret_v1" "yucca_provisioner_rgw" {
+  count = local.provision_secrets ? 1 : 0
+  metadata {
+    name      = "yucca-provisioner-rgw"
+    namespace = kubernetes_namespace_v1.yucca[0].metadata[0].name
+  }
+  data = {
+    AccessKey = var.sietch_provisioner_access_key
+    SecretKey = var.sietch_provisioner_secret_key
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.sietch_provisioner_access_key) > 0 && length(var.sietch_provisioner_secret_key) > 0
+      error_message = "sietch provisioner RGW keys are empty — run applies through tf/op-run.sh."
+    }
   }
 }
 

--- a/tf/deployment/staging/austin/talos/variables.tf
+++ b/tf/deployment/staging/austin/talos/variables.tf
@@ -210,3 +210,16 @@ variable "clusters" {
     config_patches = optional(list(string), [])
   }))
 }
+
+variable "sietch_provisioner_access_key" {
+  description = "Sietch RGW admin access key for the yucca APIs (creates one S3 user per repository)."
+  type        = string
+  default     = ""
+}
+
+variable "sietch_provisioner_secret_key" {
+  description = "Sietch RGW admin secret key for the yucca APIs."
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
Hands existing buckets to their repository's user, and makes stranded buckets discoverable and explicitly purgeable.

- `main` <!-- branch-stack -->
  - \#433
    - \#437
      - \#438
        - \#439
          - \#440
            - \#441 :point\_left:
              - \#442
                - \#446
