### PR TITLE
docs: per-repository storage credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Zod-validated `env.ts`, JWT auth guards via `@AuthRoute()`, OTel from `@common/s
 |---|---|---|
 | `yucca-api` | NestJS | User-facing API. Owns auth (OIDC code + device flow, ES256 JWTs), repositories, **DB schema + migrations**. |
 | `yucca-admin-api` | NestJS | Admin API (user/session/repository management). Same DB + JWT validation. |
-| `michael` | Go | **Production** restic REST backend — S3 proxy with JWT verification, WORM enforcement, backend pooling. |
+| `michael` | Go | **Production** restic REST backend — S3 proxy with JWT verification, WORM enforcement, backend pooling. Holds **no S3 credentials**: each token carries its repository's own, sealed. |
 | `restic-api` | NestJS | Earlier TS implementation of the restic backend, kept as **reference**; not deployed. |
 | `yucca-metrics-worker` | NestJS | 5-min cron: RadosGW usage → meter tables → per-connection rollup (`connectionMetrics`, billing floor), OTel gauges. |
 | `redis` (valkey) | | Shared platform cache (ephemeral; keys `yucca:<service>:<purpose>:*`). Primary-region only. |
@@ -136,6 +136,28 @@ Full detail: `docs/connections.md`. The essentials:
   introspection (`GET /internal/restic-tokens/:jti`). Revoke flips the DB row + best-effort DELs
   the valkey key; introspection outage honors the grace window then **fails closed**. Long-lived
   tokens are revocable-only. yuctl: `tokens list/revoke`, `repos url --ttl`.
+
+### Per-repository storage credentials
+
+Full detail: `docs/storage-credentials.md`. The essentials:
+
+- Every repository owns an RGW user (`yucca-repo-<id>`, `max-buckets=1`), created by the APIs
+  through the RadosGW admin API with the ansible-provisioned `yucca-provisioner` credential
+  (`users=*`, Secret `yucca-provisioner-rgw`, chart `radosSecretName`). Bucket ops belong to a
+  separate `yucca-migrator` (`buckets=*`) that only the yuctl migration uses, read from 1Password
+  and never mounted into the cluster.
+- Its keys ride in the token as the `storageCredentials` claim: AES-256-GCM,
+  `base64url(version||nonce||ct||tag)`, **repository id as AAD**. Sealed by `@common/server`
+  `sealStorageCredentials`, opened by michael's `internal/credentials`; a cross-language fixture
+  test pins the format.
+- Two keys, both comma-separated lists (first seals, all open, so rotation is a two-step deploy):
+  `STORAGE_CREDENTIAL_KEY` (APIs only, at-rest column `repositories.storageSecretAccessKey`) and
+  `STORAGE_CREDENTIAL_SEAL_KEY` (APIs **+ michael**).
+- michael caches one S3 client per credential per backend and probes backends **unsigned**. A
+  token without credentials is a 401 — there is no fallback. Clusters without an
+  `rgw_admin_endpoint` (compose/MinIO) fall back to `STORAGE_STATIC_*`.
+- Pre-existing buckets: `yuctl repos migrate-storage-credentials` (BucketOwnerEnforced as the old
+  owner, admin-API link, then verify).
 
 ## Infrastructure architecture
 

--- a/docs/storage-credentials.md
+++ b/docs/storage-credentials.md
@@ -1,0 +1,140 @@
+# Per-repository storage credentials
+
+michael used to hold one RGW user per storage cluster — a credential that could
+read and write **every** repository's bucket, sitting in the one service exposed
+to the internet, whether or not anyone was backing up. It no longer holds any.
+
+Each repository has its **own** S3 user. Its keys are sealed into the restic
+token, so michael learns them only from a request that already proves the caller
+owns that repository, and only for as long as that token is in play.
+
+```
+yucca-api ──creates──> RGW user yucca-repo-<repository id>   (users+buckets admin)
+          ──seals────> storageCredentials claim in the restic token
+                            │
+restic ─────────────────────┴──> michael ──opens──> per-request S3 client
+                                              (L1 cache, keyed by credential)
+```
+
+## The seal
+
+The `storageCredentials` claim is written by `@common/server`
+`sealStorageCredentials` and read by michael's `internal/credentials`:
+
+```
+base64url(version[1] || nonce[12] || ciphertext || tag[16])
+```
+
+AES-256-GCM over `{"accessKeyId","secretAccessKey"}`, with the **repository id
+as additional authenticated data** — a blob lifted out of one repository's token
+does not open against another's, even though both were sealed with the same key.
+The format is pinned from both sides: `TestOpenTypeScriptFixture` opens a blob
+the TypeScript implementation actually emitted.
+
+Two keys, deliberately distinct:
+
+| Key | Held by | Seals |
+|---|---|---|
+| `STORAGE_CREDENTIAL_KEY` | yucca-api, yucca-admin-api | the RGW secret key at rest in `repositories.storageSecretAccessKey` |
+| `STORAGE_CREDENTIAL_SEAL_KEY` | the APIs **and michael** | the credentials inside a restic token |
+
+michael can therefore open a token but not a database row. Both accept a
+comma-separated list: the first key seals, every key opens, so a rotation is
+`add new key everywhere` → `move it to the front on the APIs` → `drop the old
+one`, with no flag day.
+
+## Provisioning
+
+`RepositoryService.create` provisions eagerly, so a storage cluster that cannot
+issue a user fails the create rather than the first backup. `createUrl`
+provisions lazily too, which is what heals a repository that predates this.
+
+The RGW user is `yucca-repo-<repository id>`, created through the RadosGW admin
+API with `max-buckets=1` — it owns exactly the one bucket backing its
+repository, so a leaked key cannot stand up storage of its own. Deleting a
+repository revokes its keys and leaves the bucket alone, matching the existing
+behaviour that deleting a repository never deletes data.
+
+A storage cluster with no `rgw_admin_endpoint` (the compose stack, which runs
+against MinIO) falls back to `STORAGE_STATIC_ACCESS_KEY_ID` /
+`STORAGE_STATIC_SECRET_ACCESS_KEY` for every repository. That exercises the
+whole sealing path in dev without isolating anything — it is a development
+fallback, not a deployment mode.
+
+## michael
+
+- The token's claim is required. There is no fallback credential, so a token
+  without one is a 401 rather than a request served with someone else's keys.
+- Credentials are opened once per token: the existing verified-token cache
+  already keys on the `Authorization` header, so a restic session decrypts once.
+- Each S3 **client** is cached per credential fingerprint per backend
+  (`storage.clientCache`, 1024 entries). Every client shares its backend's
+  `*http.Client`, so a new credential costs an options struct, never a
+  connection pool. `storage.credentials.cache.{hits,misses}` tracks it.
+- Backend health probes are **unsigned**. Any HTTP response — including the 403
+  an anonymous `HeadBucket` earns — proves the gateway is serving, and only
+  transport failures and 5xx mark a backend unhealthy, so probing needs no
+  credential at all.
+
+## Migrating existing repositories
+
+Buckets created before this change belong to the old cluster-wide user, and
+their objects carry that user's ACLs. `yuctl repos migrate-storage-credentials`
+does, per repository:
+
+1. `POST /repository/:id/storage-credentials` on the admin API — creates the
+   repository's RGW user and keys (idempotent).
+2. `PutBucketOwnershipControls` = `BucketOwnerEnforced`, signed as the **current**
+   owner. RGW then ignores per-object ACLs, so the objects the old owner wrote
+   follow the bucket instead of staying readable only by it.
+3. Admin-API `link` of the bucket to the new user.
+4. Re-read the bucket and fail loudly unless the owner actually changed.
+
+Ordering matters: enforce ownership *before* the link, or the new owner inherits
+a bucket full of objects it cannot read. `--dry-run` reports what would move;
+`--repository <id>` does one; a repository already on its own user is skipped.
+
+If an RGW rejects bucket ownership controls, the command says so and names the
+fallback (`radosgw-admin bucket chown` on a ceph host) rather than half-migrating.
+
+## Cutover
+
+This is a hard cutover — michael has no path back to a cluster-wide credential.
+Deploy the APIs and michael together, then run the migration. Tokens minted
+before it carry no credentials and are rejected; on the current 1-day token
+lifetime, clients re-mint within a day.
+
+## Deleting a repository
+
+Deleting a repository revokes its RGW user's keys and drops the row. It does
+**not** delete the bucket — that has never been this codebase's behaviour, and a
+WORM repository refuses deletion outright. What is left is a bucket owned by a
+keyless `yucca-repo-<id>` user with no row referring to it.
+
+Those strays are discoverable rather than automatic: `yuctl repos orphans` diffs
+RGW's buckets against the repository list and reports what it finds (the
+metrics-worker already logs the same buckets as `has no matching repository`),
+and `yuctl repos purge <id>` reclaims one behind `--yes`, refusing anything the
+database still knows about. Deleting a *user* is blocked while they own any
+repository, so the order is always repositories first.
+
+## The admin identities
+
+Two, deliberately split, both ansible-provisioned with TF-minted keys:
+
+| User | Caps | Held by |
+|---|---|---|
+| `yucca-provisioner` | `users=*` | the APIs, online, in `yucca-provisioner-rgw` |
+| `yucca-migrator` | `buckets=*` | operators only, read from 1Password by yuctl |
+
+The APIs only ever call `/admin/user`, so the credential that is online
+permanently has no bucket admin at all — it cannot list, stat, relink or delete
+a bucket. The one that can is used by a human running a one-shot migration and
+is never mounted into the cluster.
+
+**This is a reduction, not a wall.** `users=*` can mint a key for any RGW user,
+including a repository's own, and then read that bucket over the S3 data path.
+RGW admin caps have no finer grain than read/write/`*` per category, so no cap
+set both provisions users and forecloses that escalation. Removing it entirely
+would mean no online component may create storage identities — i.e. provisioning
+moves offline, or moves to short-lived STS credentials once RGW STS is enabled.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -149,10 +149,11 @@ persistence, secrets) are where a future prod cluster overlay diverges. Notably:
   in [`ansible/ceph`](../ansible/ceph) / [`tf/`](../tf)) — not this Rook cluster.
 - The Rook-Ceph dev cluster is single-node/single-replica and synthesizes a
   loopback block device (k3d has no spare disk). See
-  [`charts/platform/rook-ceph-cluster`](../charts/platform/rook-ceph-cluster). `michael`'s S3
-  credentials come from a full RGW user
-  ([`charts/platform/ceph-objectuser`](../charts/platform/ceph-objectuser)) whose Secret Rook
-  writes into the `yucca` namespace.
+  [`charts/platform/rook-ceph-cluster`](../charts/platform/rook-ceph-cluster). `michael` has
+  **no** S3 credentials: the APIs create one RGW user per repository (with the
+  `provisioner` object-user's admin caps,
+  [`charts/platform/ceph-objectuser`](../charts/platform/ceph-objectuser)) and seal its keys
+  into each restic token. See [`docs/storage-credentials.md`](../docs/storage-credentials.md).
 - The dev keypair/secrets committed in chart `secretData` are **well-known
   fixtures** (the same keypair lives in `.mise/tasks/*/env`); they must become
   `ExternalSecret`s backed by the org's 1Password (External Secrets Operator)


### PR DESCRIPTION
Documents the design, the two admin identities and what deleting a repository leaves behind.

- `main` <!-- branch-stack -->
  - \#433
    - \#437
      - \#438
        - \#439
          - \#440
            - \#441
              - \#442 :point\_left:
                - \#446
