### PR TITLE
feat(yucca-metrics-worker): report orphaned storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Zod-validated `env.ts`, JWT auth guards via `@AuthRoute()`, OTel from `@common/s
 | `yucca-admin-api` | NestJS | Admin API (user/session/repository management). Same DB + JWT validation. |
 | `michael` | Go | **Production** restic REST backend — S3 proxy with JWT verification, WORM enforcement, backend pooling. Holds **no S3 credentials**: each token carries its repository's own, sealed. |
 | `restic-api` | NestJS | Earlier TS implementation of the restic backend, kept as **reference**; not deployed. |
-| `yucca-metrics-worker` | NestJS | 5-min cron: RadosGW usage → meter tables → per-connection rollup (`connectionMetrics`, billing floor), OTel gauges. |
+| `yucca-metrics-worker` | NestJS | 5-min cron: RadosGW usage → meter tables → per-connection rollup (`connectionMetrics`, billing floor), OTel gauges incl. orphaned-bucket storage. |
 | `redis` (valkey) | | Shared platform cache (ephemeral; keys `yucca:<service>:<purpose>:*`). Primary-region only. |
 | `mock-oidc-provider` | Node | Dev/test OIDC IdP (code + device flow). |
 | `common` (`@common/server`) | TS lib | OTel init, pino repository, **feature-flag registry + connection-type registry**. |

--- a/docs/storage-credentials.md
+++ b/docs/storage-credentials.md
@@ -111,11 +111,11 @@ Deleting a repository revokes its RGW user's keys and drops the row. It does
 WORM repository refuses deletion outright. What is left is a bucket owned by a
 keyless `yucca-repo-<id>` user with no row referring to it.
 
-Those strays are discoverable rather than automatic: `yuctl repos orphans` diffs
-RGW's buckets against the repository list and reports what it finds (the
-metrics-worker already logs the same buckets as `has no matching repository`),
-and `yuctl repos purge <id>` reclaims one behind `--yes`, refusing anything the
-database still knows about. Deleting a *user* is blocked while they own any
+Those strays are discoverable rather than automatic. `yucca-metrics-worker`
+reports them every cycle as `rgw_orphaned_bucket_count` and `rgw_orphaned_bytes`,
+labelled by site and cluster and recorded even at zero so the series can be
+alerted on. `yuctl repos orphans` then names them, and `yuctl repos purge <id>`
+reclaims one behind `--yes`, refusing anything the database still knows about. Deleting a *user* is blocked while they own any
 repository, so the order is always repositories first.
 
 ## The admin identities

--- a/packages/yucca-metrics-worker/src/services/metrics.service.spec.ts
+++ b/packages/yucca-metrics-worker/src/services/metrics.service.spec.ts
@@ -15,8 +15,15 @@ describe(MetricsService.name, () => {
   const repositories = { getAll: jest.fn() };
   const sizeGauge = { record: jest.fn() };
   const objectGauge = { record: jest.fn() };
+  const orphanedCountGauge = { record: jest.fn() };
+  const orphanedBytesGauge = { record: jest.fn() };
+  const gauges: Record<string, { record: jest.Mock }> = {
+    rgw_repository_size_bytes: sizeGauge,
+    rgw_orphaned_bucket_count: orphanedCountGauge,
+    rgw_orphaned_bytes: orphanedBytesGauge,
+  };
   const metricService = {
-    getGauge: jest.fn((name: string) => (name === 'rgw_repository_size_bytes' ? sizeGauge : objectGauge)),
+    getGauge: jest.fn((name: string) => gauges[name] ?? objectGauge),
   };
 
   const connectionMetrics = {
@@ -99,5 +106,69 @@ describe(MetricsService.name, () => {
     expect(fleet.clusters).not.toHaveBeenCalled();
     expect(meter.record).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(expect.any(Error), 'Failed to list repositories; skipping sync');
+  });
+  it('reports buckets with no repository as orphaned storage', async () => {
+    repositories.getAll.mockResolvedValue([
+      { id: 'repository-1', userId: 'customer-1', siteCode: 'father', storageClusterCode: 'father-spice' },
+    ]);
+    const fleet = {
+      clusters: () => [
+        {
+          siteCode: 'father',
+          clusterCode: 'father-spice',
+          rgw: {
+            getBucketStats: () =>
+              bucketStats([
+                { bucket: 'repository-1', bytes: 100, objects: 10 },
+                { bucket: 'deleted-repository', bytes: 4096, objects: 7 },
+                { bucket: 'another-deleted-one', bytes: 512, objects: 1 },
+              ]),
+          },
+        },
+      ],
+    };
+
+    const service = new MetricsService(
+      logger as never,
+      fleet as never,
+      meter as never,
+      repositories as never,
+      connectionMetrics as never,
+      metricService as never,
+    );
+    await service.sync();
+
+    expect(orphanedCountGauge.record).toHaveBeenCalledWith(2, { site: 'father', cluster: 'father-spice' });
+    expect(orphanedBytesGauge.record).toHaveBeenCalledWith(4608, { site: 'father', cluster: 'father-spice' });
+    expect(meter.record).toHaveBeenCalledTimes(1);
+  });
+
+  // Absent series can't be alerted on, so a healthy cluster still reports zero.
+  it('reports zero when every bucket is claimed', async () => {
+    repositories.getAll.mockResolvedValue([
+      { id: 'repository-1', userId: 'customer-1', siteCode: 'father', storageClusterCode: 'father-spice' },
+    ]);
+    const fleet = {
+      clusters: () => [
+        {
+          siteCode: 'father',
+          clusterCode: 'father-spice',
+          rgw: { getBucketStats: () => bucketStats([{ bucket: 'repository-1', bytes: 100, objects: 10 }]) },
+        },
+      ],
+    };
+
+    const service = new MetricsService(
+      logger as never,
+      fleet as never,
+      meter as never,
+      repositories as never,
+      connectionMetrics as never,
+      metricService as never,
+    );
+    await service.sync();
+
+    expect(orphanedCountGauge.record).toHaveBeenCalledWith(0, { site: 'father', cluster: 'father-spice' });
+    expect(orphanedBytesGauge.record).toHaveBeenCalledWith(0, { site: 'father', cluster: 'father-spice' });
   });
 });

--- a/packages/yucca-metrics-worker/src/services/metrics.service.ts
+++ b/packages/yucca-metrics-worker/src/services/metrics.service.ts
@@ -14,6 +14,8 @@ export class MetricsService implements OnApplicationBootstrap {
   private readonly repositorySizeBytes: Gauge;
   private readonly repositoryObjectCount: Gauge;
   private readonly connectionBillableBytes: Gauge;
+  private readonly orphanedBucketCount: Gauge;
+  private readonly orphanedBytes: Gauge;
 
   constructor(
     private logger: LoggerRepository,
@@ -31,6 +33,12 @@ export class MetricsService implements OnApplicationBootstrap {
     });
     this.connectionBillableBytes = metricService.getGauge('connection_billable_bytes', {
       description: 'Billable bytes rolled up per connection (min-object-size floor applied)',
+    });
+    this.orphanedBucketCount = metricService.getGauge('rgw_orphaned_bucket_count', {
+      description: 'Buckets in RadosGW with no matching repository row',
+    });
+    this.orphanedBytes = metricService.getGauge('rgw_orphaned_bytes', {
+      description: 'Bytes held by buckets with no matching repository row',
     });
   }
 
@@ -64,11 +72,15 @@ export class MetricsService implements OnApplicationBootstrap {
 
       try {
         let count = 0;
+        let orphanedCount = 0;
+        let orphanedBytes = 0;
         for await (const { bucket: repositoryId, bytes, objects } of rgw.getBucketStats()) {
           count++;
 
           const repository = repositoryById.get(repositoryId);
           if (!repository) {
+            orphanedCount++;
+            orphanedBytes += bytes;
             this.logger.warn(
               `RGW bucket "${repositoryId}" (cluster ${clusterCode}) has no matching repository; skipping`,
             );
@@ -101,6 +113,11 @@ export class MetricsService implements OnApplicationBootstrap {
             cluster: clusterCode,
           });
         }
+
+        // Recorded even at zero, so an alert can watch the series rather than
+        // its absence.
+        this.orphanedBucketCount.record(orphanedCount, { site: siteCode, cluster: clusterCode });
+        this.orphanedBytes.record(orphanedBytes, { site: siteCode, cluster: clusterCode });
 
         this.logger.info(`Synced stats for ${count} buckets from cluster ${clusterCode}`);
       } catch (error) {


### PR DESCRIPTION
Buckets that outlive their repository row become a gauge instead of a log line, so the storage they hold can be alerted on.

- `main` <!-- branch-stack -->
  - \#433
    - \#437
      - \#438
        - \#439
          - \#440
            - \#441
              - \#442
                - \#446 :point\_left:
