### PR TITLE
fix(ceph): unblock spice scrub scheduling

### DIFF
--- a/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
+++ b/tf/deployment/prod/htz-fsn1/ceph/clusters.auto.tfvars
@@ -35,38 +35,39 @@ clusters = {
     # === Ceph config (-> group_vars/all/ceph-config.generated.yml) ===
     # Desired state for `ceph config set`, merged over the ceph_tuning defaults.
     #
-    # Deep scrub at 7d (the role default) is unachievable at this size: the
-    # 02:00-06:00 window cannot carry it, so PGs ran permanently overdue and
-    # scrubbed around the clock. 28d fits. Shallow scrub stays at 7d.
+    # Deep scrub at 28d, not the role's 7d. Shallow stays at 7d.
     #
-    # `global`, not `osd`: the active mgr emits PG_NOT_DEEP_SCRUBBED from its own
-    # copy, so an `osd` entry leaves the check on the 7-day default. It lived in
-    # `osd` until 2026-08-03 and warned at 12.25 days with nothing overdue.
+    # osd_deep_scrub_interval goes in `global`, not `osd`. The active mgr reads
+    # its own copy for PG_NOT_DEEP_SCRUBBED, so an `osd` entry leaves the health
+    # check on the 7-day default.
     #
-    # Since 19.2.0 a replica queues a scrub reservation instead of denying it.
-    # EC 16+4 needs 20 shard reservations at once against 4032 remote slots, so
-    # most PGs hold partial sets and wait forever. disable_reservation_queuing
-    # restores grant-or-fail; osd_max_scrubs only means anything once it does.
-    # UPSTREAM REMOVES THAT OPTION IN THE NEXT RELEASE -- re-check on any Ceph
-    # upgrade or the deadlock returns silently.
-    # https://www.mail-archive.com/ceph-users@ceph.io/msg28007.html
+    # Two settings gate scrub scheduling. Both must be open or scrubbing stops.
     #
-    # osd_scrub_cost and osd_deep_scrub_stride are provisional: measured gains
-    # were inside noise, under conditions that no longer apply. Drop them once
-    # the cluster is quiet enough to A/B properly. The custom mclock profile
-    # from the same incident is already gone: the cluster runs `balanced` (set
-    # live; the old model still said custom and would have re-imposed it on
-    # converge). balanced owns the scheduler reservations, so no _res overrides.
+    # 1. Window off (0/0 = all day), overriding the role's 02:00-06:00. Tentacle
+    # has no `overdue` urgency, so the window gates a scrub however overdue it
+    # is. Client load here is hour-of-day independent, so the window protects
+    # nothing.
+    #
+    # 2. osd_scrub_during_recovery. The role default (false) does not scale with
+    # EC width: a recovering OSD refuses scrub reservations, and a k16+m4 PG
+    # needs all 20 shards free, so any nontrivial rebalance stops scrubbing
+    # outright. Costs roughly 4x recovery throughput while scrubs run.
+    #
+    # osd_scrub_cost and osd_deep_scrub_stride are upstream defaults. They and
+    # osd_scrub_disable_reservation_queuing (removed) came from the squid scrub
+    # thread: https://www.mail-archive.com/ceph-users@ceph.io/msg28007.html
     ceph_config = {
       global = {
         osd_deep_scrub_interval = "2419200" # 28 days
       }
       osd = {
-        osd_scrub_disable_reservation_queuing = "true"
-        osd_max_scrubs                        = "6"
-        osd_scrub_cost                        = "50"      # provisional
-        osd_deep_scrub_stride                 = "2097152" # provisional, 2 MiB
-        osd_mclock_profile                    = "balanced"
+        osd_scrub_begin_hour      = "0" # 0/0 = no window
+        osd_scrub_end_hour        = "0"
+        osd_scrub_during_recovery = "true"
+        osd_max_scrubs            = "6"
+        osd_scrub_cost            = "52428800" # upstream default
+        osd_deep_scrub_stride     = "524288"   # upstream default, 512 KiB
+        osd_mclock_profile        = "high_recovery_ops"
       }
     }
     hosts = [


### PR DESCRIPTION
Spice scrubs on schedule again. Two settings gated scheduling and both had to open: the 02:00-06:00 window, and `osd_scrub_during_recovery`. With both closed the cluster reached 634 PGs past the 10.5d warn threshold and was doing zero scrubs; it is now at 1, and that PG is `remapped` so it cannot scrub until backfill finishes.

Tentacle has no `overdue` scrub urgency (`observes_allowed_hours()` is `urgency < operator_requested`, and `periodic_regular` is the floor), so the window gated a shallow scrub however overdue it was. Setting it to 0/0 took 118 PGs from zero to concurrently scrubbing within three minutes, at an hour where starts had been impossible. Client load on this cluster is bursty but hour-of-day independent, so the window was never quieter than any other hour.

`osd_scrub_during_recovery` is the one that does not scale with EC width, and it was the larger effect. A recovering OSD refuses scrub reservations, and at k16+m4 a PG needs all 20 shards free. With 39 recovering PGs touching 452 of 719 OSDs, the odds of any PG assembling a full set were about 2e-9 and scrubbing stopped entirely. At 3x replication the same footprint still leaves roughly 5% of PGs schedulable, which is why the role default is reasonable everywhere except here. The cost is real: scrub and recovery compete about 4 to 1, measured at 175 recovery ops/s with no scrubs against 41 with 118 running.

`osd_scrub_disable_reservation_queuing` is removed. It is stock `false`, upstream deletes the option in the next release, and its grant-or-fail behaviour is what compounded `not_before` through `delay_on_failure()` until targets parked at `2106-02-07` (utime max) and left the schedulable pool. `osd_scrub_cost` and `osd_deep_scrub_stride` return to upstream defaults, stated explicitly rather than left implied; both were workaround values from the same ceph-users thread and the comment already flagged them as provisional pending an A/B. `osd_mclock_profile` moves to `high_recovery_ops`, which is currently live.

Takes effect on a ceph converge (workflow_dispatch, `run_ceph_ansible=true`, spice), not on merge. All of these are already set on the running cluster, so this commit makes the live state declarative rather than changing it.

Removing `osd_scrub_disable_reservation_queuing` from the map does not clear it from the cluster: `ceph_config_prune` in the ceph_tuning role is an explicit four-entry allowlist and this key is not on it. The live entry currently reads `false`, which is the upstream default, so the leftover is cosmetic rather than behavioural. The cluster operator will clear it by hand.