### PR TITLE
chore(claude): scope the zero-comment rule to code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,12 @@ The only permitted comment captures something the code *cannot* express — a wh
 a gotcha a reader would otherwise miss. These are rare. When in doubt, do not comment.
 **Before finishing any edit, re-read your diff and delete every comment that fails this bar.**
 
+This rule is about code. Infra config (`tf/`, `ansible/`, `kubernetes/`) has no equivalent
+remedy: the keys belong to Ceph, Terraform and Ansible, so there is no better name to pick and
+no smaller function to extract. The bar is the same and restating a value is still banned, but
+a comment recording why a value deviates from its default, or what breaks when it changes, is
+usually the only place that can live.
+
 ## What this is
 
 Yucca is a multi-tenant **backup service**: OIDC-authenticated users get S3-backed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ This rule is about code. Infra config (`tf/`, `ansible/`, `kubernetes/`) has no 
 remedy: the keys belong to Ceph, Terraform and Ansible, so there is no better name to pick and
 no smaller function to extract. The bar is the same and restating a value is still banned, but
 a comment recording why a value deviates from its default, or what breaks when it changes, is
-usually the only place that can live.
+usually the only place that knowledge can live.
 
 ## What this is
 


### PR DESCRIPTION
The zero-comment rule now says explicitly that it governs code, and that infra config is judged by the same bar with a different starting point.

The rule's remedy is "make the code self-explanatory instead: better names, smaller functions". Neither is available under `tf/`, `ansible/` or `kubernetes/`, where the keys belong to Ceph, Terraform and Ansible and there is no function to extract. Restating a value stays banned there, but a comment recording why a value deviates from its default, or what breaks when it changes, is usually the only place that knowledge can live.

This scopes rather than weakens: the code rule keeps its wording and its force, and the paragraph sits directly under it so it cannot be read alone.

- `main` <!-- branch-stack -->
  - \#449 :point\_left:
