### PR TITLE
docs: mark unmerged revocation work as in-flight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,6 @@ Zod-validated `env.ts`, JWT auth guards via `@AuthRoute()`, OTel from `@common/s
 | `michael` | Go | **Production** restic REST backend — S3 proxy with JWT verification, WORM enforcement, backend pooling. |
 | `restic-api` | NestJS | Earlier TS implementation of the restic backend, kept as **reference**; not deployed. |
 | `yucca-metrics-worker` | NestJS | 5-min cron: RadosGW usage → meter tables → per-connection rollup (`connectionMetrics`, billing floor), OTel gauges. |
-| `redis` (valkey) | | Shared platform cache (ephemeral; keys `yucca:<service>:<purpose>:*`). Primary-region only. |
 | `mock-oidc-provider` | Node | Dev/test OIDC IdP (code + device flow). |
 | `common` (`@common/server`) | TS lib | OTel init, pino repository, **feature-flag registry + connection-type registry**. |
 
@@ -131,11 +130,10 @@ Full detail: `docs/connections.md`. The essentials:
   (admin-owned, runtime).
 - **Billing**: `ConnectionTypeInfos` declares metering tiers and `minObjectSizeBytes` floor;
   metrics-worker computes `billableBytes = max(size, objects * floor)` per connection.
-- **Revocation** (revocable types only, default `restic`): postgres is truth; michael checks
-  L1 per-process cache → valkey verdict cache (`yucca:michael:verdict:<jti>`) → yucca-api
-  introspection (`GET /internal/restic-tokens/:jti`). Revoke flips the DB row + best-effort DELs
-  the valkey key; introspection outage honors the grace window then **fails closed**. Long-lived
-  tokens are revocable-only. yuctl: `tokens list/revoke`, `repos url --ttl`.
+- **Revocation** — **not on main yet**: the layered design in `docs/connections.md` (valkey
+  verdict cache, yucca-api introspection, yuctl `tokens`) is in flight on
+  `feat/conn-4-revocation`; no valkey/redis service, introspection endpoint, or `resticTokens`
+  table exists in the current tree.
 
 ## Infrastructure architecture
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -18,6 +18,14 @@ Connection→Repository is 1:N (a restic connection is reused across repositorie
 a repository belongs to exactly one connection. `POST /connections/:id/adopt`
 re-parents a repository that still sits on the user's **default** connection.
 
+> **Status.** The connection model, feature flags, billing rollup, and the web
+> Connections page are on `main`. Everything marked *(in flight)* below —
+> revocation (valkey verdict cache, introspection, `resticTokens`), long-lived
+> tokens, and the one-call self-serve restic flow — is unmerged work on
+> `feat/conn-4-revocation` / `feat/conn-5-restic`. On `main`, minting a restic
+> URL (`POST /repository/:id/restic`) issues a session-lifetime JWT with no
+> revocation surface.
+
 ## Types (a code registry)
 
 The set of connection types and their behavior is **code**, not data, only
@@ -25,7 +33,7 @@ per-user/instance state is data. The descriptor lives in
 `packages/common/src/connections.ts` (`ConnectionTypeInfos`), exported from
 `@common/server`. Adding a type is a one-object change there.
 
-| Type | Metering tiers | Reports activity | Min object size | Revocable | Self-serve flag |
+| Type | Metering tiers | Reports activity | Min object size | Revocable *(in flight)* | Self-serve flag |
 |---|---|---|---|---|---|
 | `immich` | storage, transfer, activity | yes | 0 | no | none (always on) |
 | `restic` | storage, transfer | no | 1 MiB | yes | `connection-restic` |
@@ -65,7 +73,7 @@ cases. Exact per-object billing (S3 `ListObjects`) is a documented future option
 
 *(This produces billable-bytes only. Pricing/plan/quota is a separate later layer.)*
 
-## Revocation: postgres truth, layered caches, bounded grace
+## Revocation: postgres truth, layered caches, bounded grace *(in flight — `feat/conn-4-revocation`)*
 
 restic tokens are long-lived, so their liveness is checked against the **source
 of truth, postgres** (`resticTokens`), fronted by yucca-api's internal
@@ -111,24 +119,29 @@ michael request ──> L1 (per-process, fresh 60s / grace 30min)
 
 michael enforces validity only where `TOKEN_INTROSPECTION_URL` is set (primary
 regions, secondaries have no local yucca-api and run with checking off). The
-valkey is the **generic shared platform cache** (`charts/apps/redis`, ephemeral
-by design, keys namespaced `yucca:<service>:<purpose>:*`); the verdict cache is
-its first tenant, with michael rate limiting a likely second.
+valkey is the **generic shared platform cache** (`charts/apps/redis`, introduced
+by the same branch; ephemeral by design, keys namespaced
+`yucca:<service>:<purpose>:*`); the verdict cache is its first tenant, with
+michael rate limiting a likely second.
 
 ## Self-serve restic
 
-A user with the `connection-restic` flag can stand up a restic backup in one call:
+On `main` today: `POST /repository/:id/restic` mints a rest: URL for an existing
+repository with the session-JWT lifetime (`JWT_EXPIRES_IN`), no options.
+
+The full flow *(in flight — `feat/conn-5-restic`)* lets a user with the
+`connection-restic` flag stand up a restic backup in one call:
 
 - **`POST /connections/restic`**, get-or-create the user's restic connection,
   create a repository under it, mint a **long-lived** rest: URL, and return
   `{ connection, repository, url, jti, expiresAt }`. Idempotent on the connection
   (reused across repositories). Gated on `connection-restic` (403 without).
-- **`POST /repository/:id/restic`**, mint a URL for an existing repository.
-  Optional `expiresIn` and `label`. **Long-lived tokens are revocable-only**: for
-  restic repositories the default is `RESTIC_JWT_EXPIRES_IN` (90d), capped at
-  `RESTIC_JWT_MAX_EXPIRES_IN` (365d); for non-revocable types (immich, michael
-  never validity-checks them) the token keeps the short session-JWT lifetime
-  (`JWT_EXPIRES_IN`, 1d) and a custom `expiresIn` is rejected.
+- **`POST /repository/:id/restic`** grows optional `expiresIn` and `label`.
+  **Long-lived tokens are revocable-only**: for restic repositories the default
+  is `RESTIC_JWT_EXPIRES_IN` (90d), capped at `RESTIC_JWT_MAX_EXPIRES_IN` (365d);
+  for non-revocable types (immich, michael never validity-checks them) the token
+  keeps the short session-JWT lifetime (`JWT_EXPIRES_IN`, 1d) and a custom
+  `expiresIn` is rejected.
 - **`GET /repository/:id/restic-tokens`**, list a repository's minted tokens
   (owner-scoped).
 - **`DELETE /restic-tokens/:jti`**, revoke your own token (owner-scoped; unknown
@@ -150,22 +163,23 @@ lists each connection with its type and usage rollup. It's a thin SvelteKit rout
 `+page.ts` loads `listConnections` + `getRepositories` via the generated client, and
 `+page.svelte` renders it with `@immich/ui`.
 
-**Restic self-serve is invisible without the flag.** The "New restic backup" button and
-all restic actions render only when `data.user.features['connection-restic']` is true,
-absent from the DOM otherwise, not merely disabled. The create flow (`CreateResticModal`)
-calls `POST /connections/restic` and opens a result modal (`ResticResultModal`) showing the
-`rest:` URL, a `restic -r … init` snippet (copy buttons), and a repository-password
-reminder. Per-repository access keys are listed/revoked/re-minted in `ManageTokensModal`.
+**Restic self-serve is invisible without the flag** *(in flight — `feat/conn-restic-web`)*.
+The "New restic backup" button and all restic actions render only when
+`data.user.features['connection-restic']` is true, absent from the DOM otherwise, not merely
+disabled. The create flow (`CreateResticModal`) calls `POST /connections/restic` and opens a
+result modal (`ResticResultModal`) showing the `rest:` URL, a `restic -r … init` snippet
+(copy buttons), and a repository-password reminder. Per-repository access keys are
+listed/revoked/re-minted in `ManageTokensModal`.
 
 ## Where things live
 
 | Concern | Location |
 |---|---|
 | Type descriptor + billing floor | `packages/common/src/connections.ts` |
-| Schema (`connections`, `connectionMetrics`, `resticTokens`) | `packages/yucca-api/src/schema/` |
+| Schema (`connections`, `connectionMetrics`; `resticTokens` *in flight*) | `packages/yucca-api/src/schema/` |
 | Connection + self-serve restic API | `packages/yucca-api/src/{controllers,services}/` |
-| Web Connections page + restic modals | `packages/web/src/routes/dashboard/connections/`, `packages/web/src/lib/components/connections/` |
+| Web Connections page (restic modals *in flight*) | `packages/web/src/routes/dashboard/connections/`, `packages/web/src/lib/components/connections/` |
 | Billing rollup | `packages/yucca-metrics-worker/` |
-| Validity check (michael: L1/L2/introspection) | `packages/michael/internal/revocation/` |
-| Introspection endpoint | `packages/yucca-api/src/controllers/introspection.controller.ts` |
+| Validity check *(in flight)* | `packages/michael/internal/revocation/` |
+| Introspection endpoint *(in flight)* | `packages/yucca-api/src/controllers/introspection.controller.ts` |
 | Admin provisioning | `packages/yucca-admin-api/`, `packages/yuctl/` |


### PR DESCRIPTION
`docs/connections.md` and `CLAUDE.md` described the token-revocation system, the shared valkey cache and the one-call self-serve restic flow in the present tense. None of it is on `main`.

Verified against the tree: there is no `charts/apps/redis`, no valkey/redis reference anywhere in `packages/`, `kubernetes/` or `charts/`, no introspection endpoint, no `resticTokens` table, no `REVOCATION_*`/`VERDICT_*` env vars and no yuctl `tokens` command. That work lives on `feat/conn-4-revocation` / `feat/conn-5-restic`.

What is real on main and left untouched: the connection model (`connectionId` NOT NULL), the feature-flag registry, and the billing floor in `packages/common/src/connections.ts`.

Changes:

- Drop the `redis` (valkey) row from the service table in CLAUDE.md.
- Add a status callout to `connections.md` separating shipped from in-flight.
- Tag the revocation section, the Revocable column, the restic web modals and the affected "Where things live" rows as *(in flight)*.
- State what `POST /repository/:id/restic` actually does on main today (session-lifetime JWT, no options).

Docs only, no code.

- `main` <!-- branch-stack -->
  - \#451 :point\_left:
