### PR TITLE
chore(ansible): trim narration from comments

### DIFF
--- a/ansible/ceph/.mise.toml
+++ b/ansible/ceph/.mise.toml
@@ -2,14 +2,12 @@
 python = "3.12"
 
 [env]
-# Project-local virtualenv for all Python tooling
 VIRTUAL_ENV = "{{config_root}}/.venv"
 PATH = "{{config_root}}/.venv/bin:{{env.PATH}}"
-# Note: CEPH_ENV is intentionally NOT declared here. mise's [env] block
-# overrides shell-exported values, which silently sends operators to the
-# wrong cluster. Operators must export CEPH_ENV once per shell session:
+# CEPH_ENV deliberately NOT declared here: mise [env] overrides shell exports,
+# silently sending operators to the wrong cluster. Export it per shell session:
 #   export CEPH_ENV=inventories/staging-austin/sietch/inventory.ini
-# Inventory files are TF-generated — `mise run tf:apply` (from yucca root) if missing.
+# Inventories are TF-generated (`mise run tf:apply` from yucca root if missing).
 
 [tasks.setup]
 description = "Bootstrap development environment"
@@ -130,7 +128,6 @@ description = "Full deploy: baseline → tune → deploy → tune ceph → harde
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-# Rotate ansible.log before a full deploy
 if [ -f ansible.log ] && [ "$(wc -c < ansible.log)" -gt 1048576 ]; then
   mv ansible.log "ansible.$(date +%Y%m%dT%H%M%S).log"
   echo "Rotated ansible.log (>1MB)"
@@ -148,9 +145,9 @@ description = "Destroy Ceph cluster (requires confirmation)"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-CEPH_ENV_DIR=$(dirname "$CEPH_ENV")              # e.g., inventories/staging-austin/sietch
-REGION_SLUG=$(basename "$(dirname "$CEPH_ENV_DIR")")  # e.g., staging-austin (<partition>-<region>)
-DOMAIN="${REGION_SLUG/-/.}.int.futo.cloud"        # e.g., staging.austin.int.futo.cloud
+CEPH_ENV_DIR=$(dirname "$CEPH_ENV")
+REGION_SLUG=$(basename "$(dirname "$CEPH_ENV_DIR")")
+DOMAIN="${REGION_SLUG/-/.}.int.futo.cloud"
 DESTROY_INV="$CEPH_ENV_DIR/inventory-destroy.ini"
 echo "Usage: scripts/ansible-play.sh destroy-ceph.yml \\"
 echo "  -e yes_destroy_ceph=true -e destroy_target_domain=$DOMAIN"

--- a/ansible/ceph/add-node.yml
+++ b/ansible/ceph/add-node.yml
@@ -1,34 +1,22 @@
 ---
-# Manual, rescue-first "add a node" path: install + chroot + verify on a node the
-# operator has ALREADY put into the Hetzner rescue system by hand. This is the
-# default way to (re)image a spice node -- the Robot API (register keys / arm
-# rescue / hw reset) is deliberately OUT of the loop (reprovision_use_robot=false).
+# Manual, rescue-first "add a node": install + chroot + verify on a node the
+# operator ALREADY put into Hetzner rescue by hand (reprovision_use_robot=false).
+# Default way to (re)image a spice node. WHY manual: the Robot rescue/reset step
+# is both the unreliable part (arms rescue but never boots it) and the highest
+# blast radius (errant /reset on a LIVE node); with it out of the loop nothing
+# here can flip a running node -- wait_rescue hard-refuses any node not in the
+# rescue ramdisk. Remote "nuke a dead node" = reprovision.yml (Robot path).
 #
-# WHY manual: the Robot rescue/reset step is the unreliable part (nodes that arm
-# rescue but never boot it) AND the highest blast radius (an errant /reset on a
-# LIVE spice node once the cluster is in production). Taking it out means nothing
-# Ansible does here can flip a running node into rescue: installimage exists only
-# in the rescue ramdisk, so wait_rescue hard-refuses any node a human did not
-# deliberately rescue. The install/chroot/verify automation -- the reliable part --
-# still runs untouched.
+# OPERATOR PRECONDITION (Robot portal, per node): enable Linux rescue authorizing
+# the spice-ansible-iac + break-glass keys, hardware reset, wait for rescue on
+# the WAN IP, then run promptly (wait_rescue rejects rescue uptime >
+# reprovision_rescue_max_uptime; raise with -e if needed).
 #
-# For the rare remote "nuke a dead node" case, use reprovision.yml (Robot path).
-#
-# OPERATOR PRECONDITION (do this in the Hetzner Robot portal, per node):
-#   1. Enable the Linux rescue system, authorizing the spice-ansible-iac key
-#      (and operator break-glass keys). 2. Trigger a hardware reset. 3. Wait until
-#      the node is reachable in rescue over its WAN IP. THEN run this play.
-#   Run it promptly after rescue boots (wait_rescue rejects a stale rescue whose
-#   uptime exceeds reprovision_rescue_max_uptime; raise it with -e if needed).
-#
-# No secrets and no Robot creds are needed -- run with plain ansible-playbook:
-#   Canary (one node, full wipe + verify):
-#     ansible-playbook -i inventories/prod-htz-fsn1/spice/inventory.ini add-node.yml \
-#       -e confirm_wipe=true --limit spice-ceph-philip
-#   Fan-out (only nodes you have already rescued; low serial, canary-gated):
-#     ansible-playbook -i inventories/prod-htz-fsn1/spice/inventory.ini add-node.yml \
-#       -e confirm_wipe=true -e allow_fanout=true -e reprovision_serial=2 \
-#       --limit 'rescue:!spice-ceph-philip'
+# No secrets/Robot creds; plain ansible-playbook:
+#   Canary:   ansible-playbook -i inventories/prod-htz-fsn1/spice/inventory.ini add-node.yml \
+#               -e confirm_wipe=true --limit spice-ceph-philip
+#   Fan-out:  ... -e confirm_wipe=true -e allow_fanout=true -e reprovision_serial=2 \
+#               --limit 'rescue:!spice-ceph-philip'
 #
 # ALWAYS DESTRUCTIVE to the NVMe OS disks (installimage). Requires confirm_wipe=true.
 

--- a/ansible/ceph/ansible.cfg
+++ b/ansible/ceph/ansible.cfg
@@ -3,14 +3,12 @@
 # which injects secrets (from secrets.yml.tpl via op inject) as --extra-vars.
 log_path = ansible.log
 
-# Performance
 forks = 20
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = .ansible_facts_cache
 fact_caching_timeout = 3600
 
-# Output
 stdout_callback = default
 result_format = yaml
 callbacks_enabled = ansible.posix.timer, ansible.posix.profile_tasks
@@ -20,7 +18,6 @@ deprecation_warnings = False
 retry_files_enabled = False
 display_skipped_hosts = False
 
-# Security
 host_key_checking = False
 timeout = 30
 

--- a/ansible/ceph/backup-ceph.yml
+++ b/ansible/ceph/backup-ceph.yml
@@ -1,24 +1,10 @@
 ---
-# backup-ceph.yml - install (and enable) SCHEDULED Ceph cluster-state backups.
-#
-# The deep review flagged that config/topology backups were manual, unscheduled,
-# and controller-local only. This play installs an on-node capture script plus a
-# systemd timer on the bootstrap node so recoverable cluster state (fsid, config
-# dump, monmap/osdmap/crushmap, osd tree, orch ls/host ls, RGW realm/zonegroup/
-# zone) is snapshot to a timestamped tarball daily under a root-only local dir,
-# pruned by retention, and ready to ship offsite once an operator wires a target.
-#
-# Deliberate/manual: run it to install the timer; the timer then runs unattended.
-# It complements (does not replace):
-#   - mise run capture  (post-deploy-capture.yml) -- secrets -> 1Password
-#   - mise run backup    (backup-config.yml)       -- one-shot controller-local export
-#
-# Usage:
-#   scripts/ansible-play.sh backup-ceph.yml
-#   mise run backup-timer
-#
-# Opt a cluster out with `ceph_backup_enabled: false` in its group_vars.
-# Set an offsite target with `ceph_backup_offsite_dest` (empty by default).
+# Install SCHEDULED Ceph cluster-state backups: on-node capture script + systemd
+# timer on the bootstrap node, daily timestamped tarball (fsid, config dump,
+# mon/osd/crush maps, osd tree, orch ls, RGW realm/zonegroup/zone) in a root-only
+# dir, retention-pruned; offsite via ceph_backup_offsite_dest (empty default).
+# Complements mise run capture (secrets -> 1P) and mise run backup (one-shot
+# controller export). Opt out per cluster: ceph_backup_enabled: false.
 
 - name: Install scheduled Ceph cluster-state backups
   hosts: ceph_bootstrap

--- a/ansible/ceph/backup-config.yml
+++ b/ansible/ceph/backup-config.yml
@@ -1,12 +1,6 @@
 ---
-# Export Ceph cluster configuration for disaster recovery.
-# Captures: ceph.conf, admin keyring, CRUSH map, RGW realm config,
-# monitor map, and OSD map to the controller's backups/ directory.
-#
-# Usage:
-#   scripts/ansible-play.sh backup-config.yml
-#
-# Outputs: backups/<timestamp>/ on the controller (gitignored)
+# Captures ceph.conf, admin keyring, CRUSH map, RGW realm config, monitor map and
+# OSD map to backups/<timestamp>/ on the controller (gitignored).
 # Restore: see docs/runbooks/recovery.md
 
 - name: Backup Ceph cluster configuration

--- a/ansible/ceph/baseline.yml
+++ b/ansible/ceph/baseline.yml
@@ -1,25 +1,16 @@
 ---
-# Post-boot OS baseline — ops user, packages, /etc/hosts, services.
-# Run after provisioning, before ceph_deploy.
-# Fully convergeable — re-running fixes any drift in user config,
-# packages, or host entries.
+# Run after provisioning, before ceph_deploy. Re-running fixes drift in user
+# config, packages or host entries.
 #
-# Usage:
-#   scripts/ansible-play.sh baseline.yml
-#
-# Tags:
-#   --tags users       ops user only
-#   --tags packages    podman + diagnostics only
-#   --tags system      /etc/hosts + services only
+#   scripts/ansible-play.sh baseline.yml [--tags users|packages|system]
 
 - name: OS baseline configuration
   hosts: ceph_nodes
   become: true
   gather_facts: false
-  # Blast-radius control: converge in small batches (serial) and halt the whole
-  # roll if any node in a batch fails (max_fail_percentage:0) or the batch
-  # degrades the cluster (the ceph-health gate). deploy-ceph stays big-bang (its
-  # bootstrap needs all nodes at once); this governs the day-2 converge plays.
+  # Blast-radius control: small serial batches, halt on any node failure or
+  # cluster degradation (health gate). deploy-ceph stays big-bang (bootstrap
+  # needs all nodes); this governs the day-2 converge plays.
   serial: "{{ ceph_converge_serial | default('10%') }}"
   max_fail_percentage: 0
 

--- a/ansible/ceph/bench.yml
+++ b/ansible/ceph/bench.yml
@@ -1,9 +1,6 @@
 ---
-# S3 benchmark — runs in parallel on all Ceph nodes against local RGW.
-#
-# Default: 1000 objects x 16 MiB x 3 nodes = ~48 GiB PUT workload
-#
-# Usage:
+# Runs in parallel on all Ceph nodes against local RGW.
+# Default: 1000 objects x 16 MiB x 3 nodes = ~48 GiB PUT workload.
 #   scripts/ansible-play.sh bench.yml                              # default PUT
 #   scripts/ansible-play.sh bench.yml -e s3bench_ops=get           # GET (after PUT)
 #   scripts/ansible-play.sh bench.yml -e s3bench_ops=mixed         # 70/20/10 mix

--- a/ansible/ceph/deploy-ceph.yml
+++ b/ansible/ceph/deploy-ceph.yml
@@ -1,17 +1,8 @@
 ---
-# Deploy Ceph Tentacle cluster (cluster chosen via CEPH_ENV)
-#
-# Prerequisites:
-#   1. All nodes provisioned and running Debian 12 with bond0 networking
-#   2. SSH access via inventory.ini credentials (rendered by tofu apply)
-#   3. Storage partitioned with Ceph block.db LVs and SSD OSD partitions
-#
-# Usage:
-#   scripts/ansible-play.sh deploy-ceph.yml
-#
-# To run a specific phase only:
-#   scripts/ansible-play.sh deploy-ceph.yml --tags bootstrap
-#   scripts/ansible-play.sh deploy-ceph.yml --tags osds
+# Cluster is chosen via CEPH_ENV. Prerequisites: nodes provisioned on Debian 12
+# with bond0 up, inventory.ini SSH credentials rendered by tofu apply, storage
+# partitioned with block.db LVs + SSD OSD partitions.
+#   scripts/ansible-play.sh deploy-ceph.yml [--tags bootstrap|osds|...]
 
 - name: Deploy Ceph Tentacle cluster
   hosts: ceph_nodes
@@ -19,13 +10,10 @@
   gather_facts: true
 
   pre_tasks:
-    # Fail fast if the inventory was not rendered from TF. The ceph_deploy role
-    # gates every phase on the ceph_bootstrap/ceph_mon/ceph_join groups and indexes
-    # groups['ceph_bootstrap'][0]; against a hand-written stopgap inventory that
-    # lacks them the role would error mid-run or, worse, fall through to placing a
-    # MON on every host. render-inventories.sh emits these groups from TF state
-    # (bootstrap = exactly one host, mon = an odd quorum including the bootstrap
-    # node) - refuse to deploy against anything else.
+    # Fail fast on a non-TF-rendered inventory: without the ceph_bootstrap/mon/
+    # join groups the role errors mid-run or, worse, places a MON on every host.
+    # render-inventories.sh emits them from TF state (bootstrap = exactly one
+    # host, mon = odd quorum including bootstrap).
     - name: Assert the TF-rendered placement groups are present and sane  # noqa: run-once[task]
       ansible.builtin.assert:
         that:
@@ -44,11 +32,9 @@
           join={{ groups['ceph_join'] | default([]) | length }}.
       run_once: true
 
-    # Per host: the address the mon/OSD/RGW bind (ceph_service_ip) must be live on
-    # a local interface before bootstrap. For spice this is the fabric IP on
-    # bond0.120; a node whose VLAN sub-interface did not come back after a reboot
-    # would otherwise fail deep inside cephadm bootstrap/join. gather_facts is on,
-    # so ansible_all_ipv4_addresses is populated.
+    # ceph_service_ip must be live locally before bootstrap: a VLAN sub-interface
+    # that didn't come back after reboot would otherwise fail deep inside cephadm
+    # bootstrap/join.
     - name: Assert the Ceph service IP is live on this node (fabric/bond up)
       ansible.builtin.assert:
         that:

--- a/ansible/ceph/destroy-ceph.yml
+++ b/ansible/ceph/destroy-ceph.yml
@@ -1,21 +1,13 @@
 ---
-# Destroy Ceph Tentacle cluster — COMPLETE TEARDOWN
+# COMPLETE TEARDOWN: removes ALL pools, OSDs, daemons and cluster state; all data
+# on Ceph-managed devices is permanently lost.
 #
-# This removes ALL pools, OSDs, daemons, and cluster state.
-# All data on Ceph-managed devices will be permanently lost.
+# Guardrails: yes_destroy_ceph=true, destroy_target_domain matching
+# cluster_domain, and a manual confirmation pause before the destructive steps.
 #
-# Guardrails:
-#   1. Must pass yes_destroy_ceph=true or it refuses to run
-#   2. Must pass destroy_target_domain matching cluster_domain
-#   3. Pauses for manual confirmation before destructive steps
-#
-# Usage:
 #   scripts/ansible-play.sh destroy-ceph.yml \
-#     -e "yes_destroy_ceph=true destroy_target_domain=staging.austin.int.futo.cloud"
-#
-# To run a specific phase only:
-#   scripts/ansible-play.sh destroy-ceph.yml -e "yes_destroy_ceph=true destroy_target_domain=staging.austin.int.futo.cloud" --tags purge
-#   scripts/ansible-play.sh destroy-ceph.yml -e "yes_destroy_ceph=true destroy_target_domain=staging.austin.int.futo.cloud" --tags cleanup
+#     -e "yes_destroy_ceph=true destroy_target_domain=staging.austin.int.futo.cloud" \
+#     [--tags purge|cleanup]
 
 - name: Destroy Ceph Tentacle cluster
   hosts: ceph_nodes

--- a/ansible/ceph/drift.yml
+++ b/ansible/ceph/drift.yml
@@ -1,14 +1,8 @@
 ---
-# Drift detection: compares expected Ansible state against live cluster.
-# Read-only. No changes. Reports mismatches.
-#
-# Each role owns its own checks in roles/<role>/tasks/drift.yml and appends to
-# the drift_results accumulator; this play sequences them and renders the
-# report. Adding a tunable means touching one role directory, not two files.
-#
-# Usage:
-#   scripts/ansible-play.sh drift.yml
-#   mise run drift
+# Drift detection: expected Ansible state vs live cluster. Read-only.
+# Each role owns its checks in roles/<role>/tasks/drift.yml, appending to the
+# drift_results accumulator; this play sequences them and renders the report.
+# Usage: scripts/ansible-play.sh drift.yml  |  mise run drift
 
 - name: Drift detection
   hosts: ceph_nodes
@@ -19,18 +13,11 @@
     drift_results: []
 
   tasks:
-    # --- Per-role checks ---
-    #
-    # include_role, NOT vars_files. vars_files loads a role's defaults at
-    # precedence 14, above inventory group_vars (4) and host_vars (9), so every
-    # check compared the live host against the role default and a cluster that
-    # legitimately overrode a value would be reported as drifting. include_role
-    # loads defaults at precedence 2, where normal layering applies.
-    #
-    # Order is deliberate: it reproduces the report sequence this play emitted
-    # when the checks were inline, so the two can be diffed. security before
-    # baseline, and ceph_tuning after the cluster-state block below, for the
-    # same reason. Reorder freely once that comparison is no longer useful.
+    # include_role, NOT vars_files: vars_files loads role defaults at precedence
+    # 14 (above group_vars 4 / host_vars 9), so legitimate cluster overrides
+    # would report as drift; include_role loads them at 2 (#373).
+    # Order reproduces the old inline report sequence (ceph_tuning after the
+    # cluster-state block); reorder freely once diffing them stops mattering.
 
     - name: OS tuning checks
       ansible.builtin.include_role:
@@ -52,10 +39,7 @@
         name: baseline
         tasks_from: drift
 
-    # --- Cluster state (bootstrap only) ---
-    #
-    # These assert live cluster shape rather than a declared config value, so
-    # they read no role defaults and stay at play level.
+    # Live cluster shape, not declared config: no role defaults, stays at play level.
 
     - name: Check OSD status
       ansible.builtin.shell: |
@@ -99,10 +83,8 @@
       when: inventory_hostname in groups['ceph_bootstrap']
       changed_when: false
 
-    # Expect the declared quorum, not one MON per node. ceph_mon holds the hosts
-    # whose `roles` include "mon": every node on a small cluster, a pinned subset
-    # on a large one (spice runs 5 across 48). Comparing against ceph_nodes read
-    # as permanent drift on any cluster that pins its quorum.
+    # Expect the declared quorum (ceph_mon group), not one MON per node: spice
+    # runs 5 across 48, so comparing against ceph_nodes reads as permanent drift (#374).
     - name: Record MON drift
       ansible.builtin.set_fact:
         drift_results: >-
@@ -169,7 +151,6 @@
         name: ceph_tuning
         tasks_from: drift
 
-    # --- Report ---
 
     - name: Build drift report
       ansible.builtin.set_fact:

--- a/ansible/ceph/harden.yml
+++ b/ansible/ceph/harden.yml
@@ -1,28 +1,19 @@
 ---
-# Security hardening for Ceph nodes.
-# Deploys the nftables firewall + the full sshd hardening drop-in.
-# Runs AFTER deploy-ceph.yml - cephadm needs unrestricted access during deploy.
-# NB: the security-critical sshd lockdown (root key-only, no password auth, locked
-# root password) is applied EARLY in the baseline role, not here, so a node is
-# never left root-password-open on the WAN during the deploy campaign; this stage
-# adds the firewall and the remaining sshd hardening on top.
-#
-# WARNING: This locks down inbound traffic. Ensure ceph_firewall_trusted_networks
-# includes all subnets that need to reach Ceph services. SSH (port 22) stays open
-# from any source (ceph_firewall_ssh_any_source) to prevent lockout.
-#
-# Usage:
-#   scripts/ansible-play.sh harden.yml
+# nftables firewall + full sshd hardening drop-in. Runs AFTER deploy-ceph.yml
+# (cephadm needs unrestricted access during deploy). The security-critical sshd
+# lockdown itself lands EARLY in baseline so a node is never root-password-open
+# on the WAN mid-campaign; this adds the firewall + the rest.
+# WARNING: locks down inbound -- ceph_firewall_trusted_networks must cover every
+# subnet that reaches Ceph; SSH stays any-source (ceph_firewall_ssh_any_source)
+# to prevent lockout.
 
 - name: Security hardening for Ceph nodes
   hosts: ceph_nodes
   become: true
   gather_facts: false
-  # Blast-radius control (see baseline.yml): batch the roll + halt on any node
-  # failure or cluster degradation. Especially important here - a bad nftables
-  # ruleset that fences the fabric shows up as an unreachable batch (halts on
-  # max_fail_percentage) or a degraded cluster at the post-batch health gate,
-  # before it reaches the rest of the fleet.
+  # Blast-radius control (see baseline.yml). Critical here: a bad nftables
+  # ruleset that fences the fabric halts as an unreachable batch or a degraded
+  # cluster at the post-batch health gate, before reaching the fleet.
   serial: "{{ ceph_converge_serial | default('10%') }}"
   max_fail_percentage: 0
 

--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -1,86 +1,50 @@
 ---
-# Cluster-wide Ansible config for spice (prod / htz-fsn1, 48x SX295).
-# Committed. Hand-maintained. Adapted from the painbox (SX295/Hetzner) precedent
-# with the network reshaped onto the bonded-25G fabric VLANs.
-#
-# The cluster is deployed and serving production traffic. Every value here lands
-# on 48 live nodes, so converge one node at a time (--limit) and watch cluster
-# health between batches unless you have a specific reason not to.
+# spice (prod / htz-fsn1, 48x SX295). Hand-maintained; adapted from painbox precedent.
+# LIVE PROD: converge one node at a time (--limit), watch cluster health between batches.
 
-# === Naming ===
 cluster_name: spice
 cluster_role: ceph
 cluster_domain: prod.fsn1.htz.futo.cloud
 
-# === Network ===
-# Ceph public/cluster traffic runs on the bonded 25G fabric VLANs (NetBox
-# FSN1-C1-PUBLIC / FSN1-C1-PRIVATE). Per-host IPs are 10.40.20.<host_index> /
-# 10.40.22.<host_index> (host_index from spice-hosts.yaml; gateway .1 = leaf IRB).
-# A third fabric VLAN, FSN1-C1-HOST-MGMT (124, 10.40.24.0/24), is the in-band
-# host-management path: the leaf trunks it to every server bond and the fabric
-# advertises 10.40.24.0/24 into the NetBird overlay, so hosts answer on the
-# overlay as well as on their WAN address.
-# The DEFAULT ROUTE stays on the 1G WAN (Hetzner gateway); the fabric never
-# carries it. Ansible reaches nodes over their WAN address.
+# Ceph traffic rides the bonded-25G fabric VLANs (NetBox FSN1-C1-PUBLIC/-PRIVATE);
+# per-host IPs 10.40.20/22.<host_index>, gateway .1 = leaf IRB. VLAN 124 (10.40.24.0/24)
+# is in-band host-mgmt, advertised into the NetBird overlay. Default route stays on the
+# 1G WAN; ansible connects over WAN.
 public_network: 10.40.20.0/23     # VLAN 120 (Ceph Public)
 cluster_network: 10.40.22.0/23    # VLAN 122 (Ceph Private)
-# Per-host Ceph BIND address on the fabric public VLAN. Derived from host_index the
-# same way as networkd_bond_vlans below (a per-host host_var, so it resolves per
-# host at play time). Lives INSIDE public_network -- unlike bond_ip, the 1G WAN
-# address used only for the ansible/SSH connection (ansible_host). (No
-# ceph_cluster_ip var: OSD replication binds to the cluster_network CIDR, which
-# cephadm resolves to each node's bond0.122 address on its own.)
-ceph_public_ip: "10.40.20.{{ host_index }}"    # bond0.120, inside public_network
-# The address Ceph point-services advertise + bind on (mon --mon-ip, cephadm
-# host-add, dashboard monitoring URLs) = the fabric public IP. Ceph never touches
-# the WAN. A group_var, NOT a role default, because join/rgw/monitoring read it via
-# hostvars[<host>], which does not expose role defaults; here it resolves per host
-# to 10.40.20.<host_index>. sietch is flat with no ceph_public_ip, so there it
-# falls back to bond_ip (already inside its public_network).
+# Fabric bind address, inside public_network (bond_ip = WAN, SSH only). No ceph_cluster_ip:
+# OSD replication binds the cluster_network CIDR, cephadm resolves bond0.122 itself.
+ceph_public_ip: "10.40.20.{{ host_index }}"    # bond0.120
+# Advertise/bind address for mon --mon-ip, cephadm host-add, dashboard URLs. Must be a
+# group_var (join/rgw/monitoring read it via hostvars[], which skips role defaults);
+# sietch has no ceph_public_ip and falls back to bond_ip.
 ceph_service_ip: "{{ ceph_public_ip | default(bond_ip) }}"
-# Fabric-only bind opt-in: cephadm restricts the RGW + monitoring daemon binds to
-# these CIDR(s) so nothing Ceph listens on the 1G WAN (mon/mgr/OSD already bind
-# public_network/cluster_network). The role default is empty (flat clusters bind
-# every interface, unchanged); spice pins the fabric public network.
+# Restrict RGW + monitoring binds to the fabric so nothing Ceph listens on the WAN
+# (mon/mgr/OSD already bind public/cluster_network). Role default empty = bind all (flat clusters).
 ceph_bind_networks:
   - "{{ public_network }}"
 
-# Alert delivery. Without a receiver the ~89 Prometheus rules fire into
-# alertmanager's null route and nothing reaches an operator. The URL is a Zulip
-# incoming webhook whose alertmanager integration accepts the standard webhook
-# payload; it carries an API key, so it lives in 1Password and arrives through
-# secrets.yml.tpl rather than being written here.
-#
-# The URL carries `desc=description`, set on the 1Password item. Zulip's
-# alertmanager integration renders one field per alert and defaults it to
-# `alertname`. Without the parameter every alert arrives as a bare identifier,
-# with no host and no value. `description` is the only field that names a host.
+# Zulip incoming webhook (API key -> 1P via secrets.yml.tpl); without a receiver the ~89
+# rules fire into alertmanager's null route. URL must carry `desc=description` (set on the
+# 1P item) or Zulip renders each alert as a bare alertname with no host/value.
 ceph_alertmanager_webhook_urls:
   - "{{ vault_alertmanager_webhook_url }}"
-# Without this the URL above is inert. Someone repaired the route tree by hand on
-# the live cluster and the repair was tracked nowhere until 2026-07-31, so a
-# reprovision would have come up with alert delivery silently dead.
+# Route tree was hand-repaired on the live cluster, untracked until 2026-07-31; without
+# this a reprovision comes up with alert delivery silently dead.
 ceph_alertmanager_fix_route_tree: true
 # Companion to `desc=description`: without it CephPGsUnclean, CephPGsInactive
 # and CephPoolGrowthWarning render as `ec:16+4`.
 ceph_prometheus_drop_description_label: true
 # Bond of the two 25G NICs, LACP to match the leaf ae<k> aggregate (cluster-fabric).
 bond_mode: "802.3ad"
-# COEXISTENCE: keep the 1G WAN (oob_nic) on ifupdown exactly as installimage set
-# it (static IP + default route), and let networkd manage ONLY the bond + VLANs.
-# The WAN is never migrated, so a networkd error can't cost us the reachability
-# link (the painbox failure). networkd's commit leaves networking.service enabled
-# and an Unmanaged=yes guard fences oob_nic off. This stays false -- the WAN keeps
-# the default route.
+# Keep the 1G WAN (oob_nic) on ifupdown as installimage set it; networkd manages ONLY
+# bond+VLANs (Unmanaged=yes fences oob_nic). A networkd error must not cost the
+# reachability link (the painbox failure). Stays false.
 networkd_replace_ifupdown: false
-# Enable the networkd role (defaults false, so it is a no-op unless set). spice's
-# 25G fabric bond + VLANs are networkd-managed, so a reprovisioned node must bring
-# them up from the repo alone; committed here so the live state is reproducible
-# (previously supplied ad-hoc via -e). Safe: networkd_replace_ifupdown:false fences
-# the 1G WAN. Roll one node at a time on any live reconverge.
+# Role default is false; committed so a reprovisioned node brings up the fabric from the
+# repo alone (was ad-hoc -e). Roll one node at a time on any live reconverge.
 networkd_enabled: true
-# The two Intel E800 (ice) 25G ports, verified uniform across all 48 SX295 nodes
-# (PCI 0000:c1:00.0 / .1). Consumed by the networkd role as the bond0 members.
+# Two Intel E800 (ice) 25G ports, uniform across all 48 SX295 (PCI 0000:c1:00.0/.1).
 bond_interfaces:
   - enp193s0f0
   - enp193s0f1
@@ -90,32 +54,23 @@ fabric_public_vlan: 120
 fabric_private_vlan: 122
 fabric_mgmt_vlan: 124
 dns_server: 185.12.64.1            # Hetzner recursive (reachable via WAN default route)
-# Time sync: Hetzner's own NTP (low-latency from FSN1, consistent across all 48).
-# Ceph mon quorum is skew-sensitive; pin the source rather than the distro pool.
+# Mon quorum is skew-sensitive: pin Hetzner NTP (low-latency from FSN1), not the distro pool.
 chrony_ntp_servers:
   - ntp1.hetzner.de
   - ntp2.hetzner.de
   - ntp3.hetzner.de
 
-# Tagged VLAN sub-interfaces on the 25G LACP bond (consumed by the networkd role).
-# Addresses derive from host_index; masks match each network (public/private /23,
-# host-mgmt /24). No Gateway here -- the default route stays on the 1G WAN.
-# Jumbo (MTU 9000) is enabled on VLAN 122 (Ceph PRIVATE / OSD replication) ONLY.
-# That is a closed, homogeneous, all-under-our-control path where jumbo's packet/
-# interrupt savings on replication+recovery actually pay off. VLAN 120 (Ceph public,
-# where RGW faces heterogeneous 1500 S3 clients + the ~1400 NetBird overlay) and
-# VLAN 124 (mgmt) stay at 1500: jumbo on a client-facing path is a partial-blackhole
-# risk (small ops fine, large PUT/GET hang) for near-zero gain. The bond ceiling and
-# both 25G members auto-raise to the max child MTU so the jumbo VLAN is not capped.
-# PAIRED REQUIREMENT: the leaf server-LAG + the VLAN 122 IRB must be >= 9000 on the
-# QFX side before the cluster network passes jumbo; validate with a bidirectional
-# `ping -M do -s 8972` matrix on 10.40.22.0/23 + green ceph health before relying on it.
+# VLANs on the LACP bond; addresses derive from host_index, no Gateway (default route
+# stays on WAN). Jumbo (9000) on VLAN 122 (OSD replication, closed L2) ONLY -- VLANs
+# 120/124 face 1500 clients/overlay where jumbo risks partial blackholes (large PUT/GET
+# hang). Bond + members auto-raise to max child MTU. PAIRED REQUIREMENT: QFX leaf
+# server-LAG + VLAN 122 IRB must be >= 9000 first; validate with a bidirectional
+# `ping -M do -s 8972` matrix on 10.40.22.0/23 + green ceph health.
 networkd_bond_vlans:
   - id: "{{ fabric_public_vlan }}"     # 120 - Ceph public  (10.40.20.0/23)
     address: "10.40.20.{{ host_index }}/23"
-    # Return route to the kube workers (michael S3 clients): the spine holds a
-    # second IRB on this VLAN (10.40.21.254, fabric stack public_routing) and
-    # routes kube<->cls1-public. The leaf keeps the .1 host gateway.
+    # Return route to kube workers (michael S3 clients) via the spine's second IRB on
+    # this VLAN (10.40.21.254, fabric stack public_routing); leaf keeps the .1 gateway.
     routes:
       - { to: "10.40.10.0/24", via: "10.40.21.254" }
   - id: "{{ fabric_private_vlan }}"    # 122 - Ceph private (10.40.22.0/23)
@@ -124,40 +79,33 @@ networkd_bond_vlans:
   - id: "{{ fabric_mgmt_vlan }}"       # 124 - Host mgmt    (10.40.24.0/24)
     address: "10.40.24.{{ host_index }}/24"
 
-# Cluster-specific packages, merged with baseline_diag_packages. Spice hardware:
-# Intel E800 (ice) 25G NICs on an LACP fabric; direct-attach SATA HDDs + NVMe (no
-# SAS expander / Mellanox, so none of sietch's mstflint/ledmon/sg3-utils here).
+# Merged with baseline_diag_packages. No SAS expander / Mellanox on spice, so none of
+# sietch's mstflint/ledmon/sg3-utils.
 baseline_extra_packages:
-  - lldpd                 # LLDP neighbor/switch discovery on the 25G fabric
-  - ethtool               # NIC/bond link, driver, and 25G speed inspection
-  - tcpdump               # packet capture for fabric/network debugging
-  # Intel E810 (ice) DDP package (intel/ice/ddp/ice.pkg). WITHOUT it the NIC boots
-  # into Safe Mode, whose crippled classifier drops LACP/LLDP control frames -> the
-  # 25G bond never aggregates. The minimal Debian image omits it; baseline installs
-  # it and (nic-firmware.yml) reboots once to load the DDP. Needs the non-free-firmware
-  # apt component (present in the Hetzner Debian base).
+  - lldpd
+  - ethtool
+  - tcpdump
+  # Intel E810 (ice) DDP package. Without it the NIC boots into Safe Mode, which drops
+  # LACP/LLDP control frames -> the 25G bond never aggregates. Minimal Debian omits it;
+  # nic-firmware.yml reboots once to load the DDP. Needs the non-free-firmware apt component.
   - firmware-misc-nonfree
 timezone: UTC
 
-# === Ceph ===
 ceph_release: tentacle
 ceph_repo_url: "https://download.ceph.com/debian-{{ ceph_release }}/"
 ceph_repo_key_url: "https://download.ceph.com/keys/release.asc"
 
-# === OS / Auth ===
 # installimage boots root; the post-install script authorizes the cluster
 # ansible-iac key for root, and ansible connects as root (matches painbox).
 admin_user: root
 provision_iac_ssh_key_path: "~/.ssh/id_ed25519_spice"
 
-# ops gets passwordless sudo (matches sietch; the ops password remains for
-# console login but no longer gates root).
+# The ops password remains for console login but no longer gates root (matches sietch).
 baseline_ops_sudo: "NOPASSWD:ALL"
 
-# 1P vault for cluster secret lookups.
 cluster_secrets_vault: yucca_tf_prod
 
-# === Secret aliases (op inject -> vault_* at play time) ===
+# op inject renders vault_* at play time.
 ops_password: "{{ vault_ops_password }}"
 ceph_dashboard_user: admin
 ceph_dashboard_password: "{{ vault_ceph_dashboard_password }}"
@@ -166,95 +114,54 @@ ceph_grafana_admin_password: "{{ vault_grafana_admin_password }}"
 ceph_rgw_s3_user_access_key: "{{ vault_s3_restic_access_key }}"
 ceph_rgw_s3_user_secret_key: "{{ vault_s3_restic_secret_key }}"
 
-# === Reprovision (installimage; reprovision_hetzner role) ===
-# Most knobs live in roles/reprovision_hetzner/defaults; override the operator-
-# facing ones here. These were verified against the fleet during the build-out;
-# re-inspect before trusting them on a different batch of hardware:
+# Verified against this fleet; re-inspect before trusting on different hardware:
 #   mise run reprovision -- --limit <host> -e confirm_wipe=true -e reprovision_mode=inspect
 reprovision_boot_mode: bios          # SX295 painbox precedent = BIOS (verified)
 reprovision_expect_nvme: 2
 reprovision_expect_sata: 14
 # reprovision_image: override only if an inspect run shows a different image path/name.
 
-# === Storage (SX295: 2x NVMe RAID-1 OS + 14x SATA HDD per node) ===
-# block.db LVs carved from the NVMe RAID-1 vg0 at converge by ceph_deploy's
-# lvm-setup (NVMe-RAID branch): 14x 128G db-slots + one ssd-osd LV from the vg0
-# remainder minus reserve. HDDs become OSDs with block.db on those LVs.
-# Consumed ONLY by ceph_destroy's partition-6 SSD-OSD wipe (sietch's dual-SSD
-# shape). spice is NVMe-RAID: the ssd-osd is a vg0 LV removed by the generic VG/PV
-# cleanup, and the NVMe carries no partition 6, so this pattern is a deliberate
-# no-match here (the SSD-partition wipe finds nothing). cleanup.yml references it
-# unconditionally, so it must stay defined; the value is a don't-care on spice.
+# SX295 storage: 2x NVMe RAID-1 OS + 14x SATA HDD per node.
+# ceph_deploy lvm-setup (NVMe-RAID branch) carves vg0: 14x 128G db-slots + one ssd-osd LV
+# from the remainder minus reserve; HDDs become OSDs with block.db on those LVs.
+# Consumed ONLY by ceph_destroy's partition-6 SSD-OSD wipe (sietch dual-SSD shape).
+# Deliberate no-match on spice (ssd-osd is a vg0 LV, no partition 6), but cleanup.yml
+# references it unconditionally so it must stay defined.
 ssd_model_pattern: "__no_ssd_osd_partitions_on_nvme_raid__"
 ceph_db_vg: vg0                   # single NVMe-RAID VG created by installimage
 ceph_db_lv_size: "128G"
 ceph_db_lvs_per_node: 14
 ceph_ssd_osd_lv: ssd-osd          # NVMe-backed OSD LV (fast replicated pool)
-ceph_ssd_osd_reserve_gib: 512     # vg0 free left unallocated for headroom/expansion
+ceph_ssd_osd_reserve_gib: 512     # vg0 free left unallocated for headroom
 
-# Keep the OSD specs registered but inert. cephadm reconciles every MANAGED spec
-# on every serve-loop pass, and each pass costs a ceph-volume lvm list + raw list
-# per host; at spice's size that pinned one full loop iteration at ~35 minutes
-# (measured 2026-07-28: nine consecutive intervals, 33m57s to 35m43s), so every
-# orchestrator action -- an OSD drain, a daemon restart -- inherited up to 35
-# minutes of latency before cephadm even looked at it. Unmanaged specs are
-# skipped, and upstream sanctions this for drivegroups ("use the unmanaged
-# parameter" to disable automatic creation on available devices).
-#
-# The specs stay complete and applied, so they remain the record of intent; they
-# just do not act on their own. Creating OSDs from them is gated behind
-# ceph_osd_allow_spec_provisioning (osds.yml), which is for INITIAL provisioning
-# only. Rebuilding a replaced disk goes through ceph-volume by hand -- see
-# docs/runbooks/replace-disk.md. Ceph tracker #68436: re-managing a spec after a
-# disk swap can recreate the OSD without its block.db, which on spice silently
-# colocates block.db on the 22TB HDD instead of the vg0 db-slot LV.
+# Keep OSD specs registered but unmanaged: cephadm reconciles every MANAGED spec each
+# serve-loop pass (ceph-volume lvm list + raw list per host), which pinned the loop at
+# ~35 min at spice's size (measured 2026-07-28) and delayed every orchestrator action by
+# up to that. Unmanaged specs are skipped (upstream-sanctioned for drivegroups). Specs
+# stay applied as the record of intent; creating OSDs from them is gated behind
+# ceph_osd_allow_spec_provisioning (osds.yml, INITIAL provisioning only). Rebuild a
+# replaced disk via ceph-volume by hand -- docs/runbooks/replace-disk.md. Ceph tracker
+# #68436: re-managing a spec after a disk swap can recreate the OSD without its block.db
+# (silently colocated on the 22TB HDD).
 ceph_osd_spec_unmanaged: true
 
-# Collapsing the per-host specs into one per host TYPE is the shape upstream
-# expects, and spice is the obvious candidate: 47 of 48 nodes share a by-path
-# map, so it would render 3 documents instead of 96. It stays OFF here anyway,
-# because the collapse cannot be retrofitted onto a cluster that is already
-# built.
-#
-# An OSD's owning service is not a property of the spec, it is written into the
-# OSD's LVM tags at creation time from CEPH_VOLUME_OSDSPEC_AFFINITY
-# (`ceph.osdspec_affinity=spice-ceph-<host>-<class>`, on the data and db LVs
-# alike). Applying the collapsed specs would not move the 720 existing daemons
-# onto them, and `ceph orch ls` fabricates a service for any daemon whose spec
-# is missing (cephadm describe_service: "new unmanaged service"), so removing
-# the old 96 would only make them reappear synthesized. The end state is 99
-# entries instead of 96, no daemon changed, nothing gained -- the serve-loop
-# cost this was meant to address is already gone via ceph_osd_spec_unmanaged,
-# which cephadm honours regardless of how many specs exist.
-#
-# Re-attributing for real means retagging ~1440 LVs across 48 live hosts, or
-# destroying and rebuilding 720 OSDs. Neither is worth a cosmetic win. Turn
-# this on for a NEW cluster, where the OSDs are tagged with the collapsed names
-# from the start; leave it off for one that already has per-host specs deployed.
+# Per-TYPE spec collapse: NEW clusters only; cannot be retrofitted. Owning service is
+# baked into LVM tags at creation (ceph.osdspec_affinity=spice-ceph-<host>-<class>), so
+# collapsed specs would not adopt the 720 existing daemons and `ceph orch ls` would
+# re-synthesize the removed per-host specs (net: 99 entries, nothing moved). Real
+# re-attribution = retagging ~1440 LVs or rebuilding 720 OSDs; serve-loop cost is
+# already solved by ceph_osd_spec_unmanaged.
 ceph_osd_spec_group_by_layout: false
 
-# OSD device map (by-path, consumed by ceph_deploy/osd-spec.yml.j2, NVMe-RAID shape:
-# no sas_path_prefix -> data path is /dev/disk/by-path/<path_phy>, db is /dev/<db>).
-# The 14x 22TB SATA HDDs sit on 3 AHCI controllers; the by-path layout is IDENTICAL
-# across 47 of the 48 nodes (verified 2026-07-10), so it lives here as a group_var
-# instead of 48 host_vars. Exception: spice-ceph-miguel has one disk on
-# 46:00.0-ata-4 (not 87:00.0-ata-4) and overrides ceph_hdd_osds in its host_vars.
-# db-slotN and ssd-osd LVs are carved from vg0 at deploy by lvm-setup.
-#
-# The {path_phy, db} grouping below is PRESENTATIONAL, not a binding. A cephadm
-# OSD spec has no per-disk block.db syntax: osd-spec.yml.j2 loops this list twice
-# and emits data_devices.paths and db_devices.paths as two independent arrays,
-# so ceph-volume pairs them in whatever order it happens to process. On spice it
-# walked the two lists in opposite directions, and every disk ended up on slot
-# 13-N rather than slot N (verified on alyssa, 2026-07-27). That is harmless:
-# all 14 slots are identical 128G LVs on the same vg0 mirror, so only their
-# count and size matter, not which HDD gets which.
-#
-# Do NOT read a row below as "this disk uses this slot" when diagnosing. Resolve
-# the real pairing with `cephadm ceph-volume lvm list`. To pin a pairing (e.g.
-# rebuilding one replaced disk), create the OSD explicitly rather than via the
-# spec: ceph-volume lvm create --data <by-path> --block.db <vg/db-slot>.
-# See docs/runbooks/replace-disk.md.
+# OSD device map (by-path, ceph_deploy/osd-spec.yml.j2, NVMe-RAID shape). Layout is
+# IDENTICAL across 47/48 nodes (verified 2026-07-10); exception spice-ceph-miguel (one
+# disk on 46:00.0-ata-4, overrides ceph_hdd_osds in host_vars).
+# The {path_phy, db} pairing below is PRESENTATIONAL: the spec emits data/db paths as two
+# independent arrays and ceph-volume pairs them in its own order (reversed on spice --
+# slot 13-N; verified on alyssa 2026-07-27). Harmless: all 14 slots are identical 128G
+# vg0 LVs. Do NOT read a row as "this disk uses this slot"; resolve real pairings with
+# `cephadm ceph-volume lvm list`, pin one with `ceph-volume lvm create --data <by-path>
+# --block.db <vg/db-slot>`. See docs/runbooks/replace-disk.md.
 ceph_hdd_osds:
   - { path_phy: pci-0000:45:00.0-ata-1, db: vg0/db-slot0 }
   - { path_phy: pci-0000:45:00.0-ata-2, db: vg0/db-slot1 }
@@ -273,22 +180,15 @@ ceph_hdd_osds:
 ceph_ssd_osds:
   - { lv: vg0/ssd-osd }
 
-# === Ceph config overrides ===
-#
-# Moved. Terraform renders `ceph_config_cluster` and `ceph_config_host` into
-# group_vars/all/ceph-config.generated.yml from clusters.auto.tfvars; edit it
-# there, then scripts/render-inventories.sh prod htz-fsn1.
-#
-# Do NOT reintroduce either key here: group_vars merges per key, last file
-# wins, and vars.yml sorts after the generated file.
+# Ceph config overrides moved: TF renders ceph_config_cluster/_host into group_vars/all/ceph-config.generated.yml
+# from clusters.auto.tfvars; edit there + scripts/render-inventories.sh prod htz-fsn1.
+# Do NOT reintroduce either key here (group_vars merge per key, last file wins,
+# vars.yml sorts after the generated file).
 
-# === RGW ===
-# EC 16+4, HOST failure domain -- capacity-max profile (80% usable, m=4) for the
-# beta behind michael. Host domain trades rack-loss protection for capacity: a
-# destroyed rack means data loss, accepted because the beta is wipeable and the
-# API tier is already single-rack. Rationale + alternatives in Brain Box
-# spice-ec-profile-analysis.md. Hold m=4 (host domain is the only durability
-# left); do not widen past k+m=20.
+# EC 16+4, HOST failure domain: capacity-max (80% usable). Rack loss = data loss,
+# accepted (beta wipeable, API tier single-rack); rationale in Brain Box
+# spice-ec-profile-analysis.md. Hold m=4 (host domain is the only durability left);
+# do not widen past k+m=20.
 ceph_rgw_realm: spice
 ceph_rgw_zonegroup: eu-central-1
 ceph_rgw_zonegroup_api_name: eu-central-1
@@ -298,12 +198,9 @@ ceph_rgw_ec_k: 16
 ceph_rgw_ec_m: 4
 ceph_rgw_ec_failure_domain: host
 ceph_rgw_ec_device_class: hdd
-# Start the bulk EC data pool near its autoscaler target. The role default (128)
-# is sized for ~36 OSDs; spice has 672 HDD OSDs on a 20-chunk pool. pg_num 4096
-# => ~122 PG-shards/OSD ( pg_num * (k+m) / osds ), inside the recommended 100-250
-# per OSD for large BlueStore clusters (default target 100, docs recommend 200;
-# >500 hurts). 2048 would be only ~61/OSD (too low); 4096 is the right power of 2.
-# Starting low would PG-split during the first fill.
+# Role default 128 is sized for ~36 OSDs; spice has 672 HDD OSDs on a 20-chunk pool.
+# 4096 => ~122 PG-shards/OSD (pg_num*(k+m)/osds), inside the 100-250 sweet spot; 2048
+# would be ~61 (too low). Starting low would PG-split during the first fill.
 ceph_pg_init_data: 4096
 ceph_rgw_data_pool: "{{ ceph_rgw_zone }}.rgw.buckets.data"
 ceph_rgw_index_pool: "{{ ceph_rgw_zone }}.rgw.buckets.index"
@@ -311,22 +208,14 @@ ceph_rgw_extra_pool: "{{ ceph_rgw_zone }}.rgw.buckets.non-ec"
 ceph_rgw_dns_name: s3.{{ cluster_domain }}
 ceph_rgw_replicated_size: 3
 ceph_rgw_replicated_min_size: 2
-# Bootstrap default for any pool that does not pin its own size (footgun guard:
-# an ad-hoc or future pool on a prod cluster should not land at single-replica
-# 2/1). Applied via cluster-spec.yml.j2 at cephadm bootstrap; role default is
-# 2/1 so sietch is unchanged. Named RGW pools still pin their own size above.
+# Footgun guard: pools that don't pin a size must not land at 2/1 on prod. Applied via
+# cluster-spec.yml.j2 at bootstrap; role default stays 2/1 so sietch is unchanged.
 ceph_osd_pool_default_size: 3
 ceph_osd_pool_default_min_size: 2
-# --- Device-class CRUSH pool placement ---
-# crush-rules.yml creates replicated_ssd/replicated_hdd but binds nothing; every
-# replicated pool otherwise falls to the default class-agnostic rule, so the
-# omap-heavy bucket index lands on HDD (~98.5% of weight) while the 48-OSD NVMe
-# ssd-osd tier sits idle. Pin the latency-sensitive index/metadata/mgr pools to
-# the SSD tier; keep the bulk non-EC pool on HDD. The EC data pool is pinned to
-# hdd via ceph_rgw_ec_device_class (the EC profile), not here. OSD device classes
-# are forced at creation in osd-spec.yml.j2 (ssd-osd -> ssd, HDD -> hdd), and
-# verify.yml asserts every intended pool carries its rule and the ssd class has
-# live OSDs.
+# crush-rules.yml creates replicated_ssd/hdd but binds nothing; without these pins the
+# omap-heavy index lands on HDD (~98.5% of weight) while the 48-OSD NVMe tier idles.
+# EC data pool is pinned to hdd via the EC profile, not here. Device classes are forced
+# at OSD creation (osd-spec.yml.j2); verify.yml asserts rules + live ssd OSDs.
 ceph_rgw_ssd_crush_rule: replicated_ssd
 ceph_rgw_hdd_crush_rule: replicated_hdd
 ceph_rgw_ssd_pools:
@@ -340,13 +229,10 @@ ceph_rgw_hdd_pools:
   - "{{ ceph_rgw_extra_pool }}"
 ceph_rgw_count_per_host: 1
 ceph_rgw_port: 443
-# RGW/beast terminates TLS on 443 with a 10-year self-signed cert: rgw.yml
-# generates /etc/ceph/rgw-ssl.{crt,key} and cephadm distributes it to every RGW
-# daemon via the service spec. Clients reach RGW over the fabric / NetBird, so the
-# cert SANs cover the s3.<domain> name (+ wildcard for virtual-hosted buckets) and
-# each node's fabric IP (ceph_service_ip). Self-signed: clients trust-on-first-use
-# or pin the CA. Falkenstein/Saxony/DE matches the FSN1 site (cosmetic for a
-# self-signed cert; only the CN + SANs are validated).
+# beast terminates TLS on 443 with a 10-year self-signed cert: rgw.yml generates
+# /etc/ceph/rgw-ssl.{crt,key}, cephadm distributes it via the service spec. SANs cover
+# s3.<domain> (+ wildcard for virtual-hosted buckets) and each node's fabric IP.
+# Clients trust-on-first-use or pin the CA; subject locality is cosmetic.
 ceph_rgw_ssl: true
 ceph_rgw_ssl_cert_days: 3650   # 10 years
 ceph_rgw_ssl_cert_subject_c: DE
@@ -355,87 +241,58 @@ ceph_rgw_ssl_cert_subject_l: Falkenstein
 ceph_rgw_ssl_cert_subject_o: FUTO
 ceph_rgw_ssl_cert_email: yucca@futo.org
 ceph_rgw_scheme: "{{ 'https' if ceph_rgw_ssl else 'http' }}"
-# --- RGW ingress: health-checked S3 VIP (haproxy + keepalived, TLS terminate) ---
-# A cephadm ingress service puts a keepalived floating VIP with haproxy health
-# checks in front of the 48 RGW daemons, in TLS TERMINATION mode (haproxy
-# `mode http`: haproxy terminates the client TLS on the VIP with the reused RGW
-# self-signed cert, then re-encrypts to each beast backend). Without it a dead RGW
-# node blackholes ~1/48 of S3 connections; with it the node is health-checked out
-# of the VIP. The VIP sits on the fabric public network (10.40.20.0/23, bond0.120);
-# NetBird already advertises 10.40.20.0/23 into the overlay, so the VIP is
-# reachable, and DNS points s3.<domain> at it (that DNS cutover is a separate TF
-# apply that MUST follow the ingress being live, not precede it). The VIP is added
-# to the RGW cert SAN (rgw.yml) so a client hitting it validates; virtual-hosted
-# buckets keep working because mode http forwards the Host header to the wildcard
-# cert. Terminate (not L4 passthrough) because passthrough needs a post-20.2.2
-# cephadm field (use_tcp_mode_over_rgw) absent on the pinned 20.2.2.
-#
-# Preconditions are satisfied here: ceph_bind_networks non-empty (VIP:443 vs beast
-# per-node-IP:443 are distinct sockets) and ceph_rgw_ssl true (cert exists).
+# keepalived VIP + haproxy health checks in front of the 48 RGWs; without it a dead node
+# blackholes ~1/48 of S3 connections. TLS TERMINATION mode (haproxy `mode http`,
+# reused RGW cert, re-encrypt to beast) -- L4 passthrough needs use_tcp_mode_over_rgw,
+# absent on pinned cephadm 20.2.2. VIP lives on 10.40.20.0/23 (NetBird already
+# advertises it); the s3.<domain> DNS cutover is a separate TF apply that MUST follow
+# the ingress being live. VIP is in the RGW cert SAN (rgw.yml); virtual-hosted buckets
+# keep working (Host header forwarded to wildcard cert). Preconditions satisfied:
+# ceph_bind_networks non-empty (VIP:443 vs per-node beast :443 distinct) + ceph_rgw_ssl.
 ceph_rgw_ingress_enabled: true
 ceph_rgw_ingress_vip: "10.40.20.250"
 ceph_rgw_ingress_vip_prefix: 23   # matches public_network 10.40.20.0/23
 ceph_rgw_s3_user_uid: svc-yucca-restic
 ceph_rgw_s3_user_display_name: "yucca/restic service account"
-# Metrics-worker RGW admin user (read-only): the yucca-metrics-worker service
-# reads bucket usage from RadosGW. Keys are TF-minted (SPICE_METRICS_WORKER_*)
-# and injected via secrets.yml.tpl as vault_metrics_worker_*; rgw.yml (Step 14.5)
-# creates the user with these caps. Without this block the RGW phase fails with
-# AnsibleUndefinedVariable. Mirror of the sietch definition.
+# Read-only RGW admin user for yucca-metrics-worker bucket-usage reads. Keys are
+# TF-minted (SPICE_METRICS_WORKER_*) via secrets.yml.tpl; rgw.yml (Step 14.5) creates
+# the user. Without this block the RGW phase fails AnsibleUndefinedVariable. Mirrors sietch.
 ceph_rgw_metrics_user_uid: metrics-worker
 ceph_rgw_metrics_user_display_name: "yucca/metrics-worker RGW admin (read-only)"
 ceph_rgw_metrics_user_access_key: "{{ vault_metrics_worker_access_key }}"
 ceph_rgw_metrics_user_secret_key: "{{ vault_metrics_worker_secret_key }}"
 ceph_rgw_metrics_user_caps: "buckets=read;usage=read;metadata=read;users=read"
 
-# === Monitoring Stack ===
 ceph_prometheus_port: 9095
 ceph_grafana_port: 3000
 ceph_alertmanager_port: 9093
-# ceph_grafana_admin_user/password are defined once in the Secret aliases block above.
 
-# === Security / firewall ===
-# Spice is fabric-only: every Ceph daemon binds the 25G fabric (mon/mgr/OSD via
-# public_network/cluster_network; RGW + monitoring via ceph_bind_networks) and
-# never listens on the 1G WAN. RGW is therefore scoped to the trusted networks
-# rather than left world-open (ceph_firewall_rgw_any_source defaults true for
-# flat/dev clusters; spice pins it closed).
+# Fabric-only cluster: nothing Ceph listens on the WAN, so scope RGW to trusted
+# networks (default true is for flat/dev clusters).
 ceph_firewall_rgw_any_source: false
-# The private replication VLAN is a closed L2 (cluster nodes only): accept it
-# wholesale so established OSD flows survive firewall (re)activation instead
-# of dying on the drop policy (see the security role defaults for the full
-# rationale; 2026-07-20 incident).
-# wt0 is the NetBird overlay: NetBird's own policy engine (default-deny,
-# group-scoped, enforced in its own nftables table) is the access-control
-# plane for mesh traffic, so this firewall must not second-guess it per port.
-# In particular netbird-ssh DNATs overlay :22 to :22022 on the netbird
-# address, which a dport allow-list here would silently drop post-DNAT. Inert on
-# a node with no wt0, which is how it shipped ahead of the peer rollout; all 48
-# are enrolled now.
+# bond0.122: closed L2, accepted wholesale so established OSD flows survive firewall
+# (re)activation instead of dying on the drop policy (2026-07-20 incident; full
+# rationale in security role defaults).
+# wt0: NetBird's own default-deny policy engine is the access-control plane for mesh
+# traffic -- a per-port allow-list here would silently drop netbird-ssh post-DNAT
+# (overlay :22 -> :22022). Inert on nodes without wt0; all 48 enrolled now.
 ceph_firewall_trusted_ifaces:
   - bond0.122
   - wt0
 
-# === NetBird ===
-# Spice nodes are NetBird endpoint peers (group yucca-prod-htz-fsn1-ceph):
-# operator + CI SSH arrives over the overlay, governed by NetBird policies.
+# Endpoint peers (group yucca-prod-htz-fsn1-ceph); operator + CI SSH over the overlay.
 # Fresh enrollment: `mise run netbird` (canary --limit spice-ceph-philip first);
-# converge of enrolled nodes is key-free. See roles/netbird.
+# enrolled-node converge is key-free. See roles/netbird.
 ceph_netbird_enabled: true
-# Human SSH is SSO/policy-gated via NetBird's own server (overlay :22 -> :22022,
-# wt0-scoped so cephadm/ansible key SSH on fabric+WAN are untouched). Root off:
-# operators `netbird ssh ops@<node>` and sudo. `mise run netbird` sets the
-# per-peer management flag via the API.
+# SSO/policy-gated human SSH via NetBird's server (overlay :22 -> :22022, wt0-scoped;
+# cephadm/ansible key SSH on fabric+WAN untouched). Root off: `netbird ssh ops@<node>`
+# + sudo. `mise run netbird` sets the per-peer flag via the API.
 ceph_netbird_ssh_server: true
 
-# === Host logs ===
-# Fluent Bit ships journald to o11y's VictoriaLogs over the overlay, tagged
-# cluster/site/env to match the metrics. Needs the ceph-to-o11y-gateway NetBird
-# policy for the route. See roles/fluentbit and logging.yml.
-#
-# OFF until the canary proves the path end to end. Nothing has shipped a log
-# through it yet, and site.yml carries logging.yml, so flipping this on lands
-# fluent-bit on all 48 nodes at the next converge. Canary first:
+# Fluent Bit ships journald to o11y VictoriaLogs over the overlay (needs the
+# ceph-to-o11y-gateway NetBird policy). See roles/fluentbit and logging.yml.
+# OFF until the canary proves the path end to end -- site.yml carries logging.yml, so
+# flipping this lands fluent-bit on all 48 at the next converge. Canary:
 #   mise run logs -- --limit spice-ceph-adelia -e ceph_fluentbit_enabled=true
-# then flip this to true in its own change.
+# then flip in its own change.
 ceph_fluentbit_enabled: false

--- a/ansible/ceph/inventories/staging-austin/sietch/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/staging-austin/sietch/group_vars/all/vars.yml
@@ -1,17 +1,13 @@
 ---
-# === Naming ===
 cluster_name: sietch
 cluster_role: ceph
 
-# === Network ===
 cluster_domain: staging.austin.int.futo.cloud
 public_network: 10.10.10.0/24
 cluster_network: 10.10.10.0/24
-# The address Ceph point-services advertise + bind on (mon --mon-ip, cephadm
-# host-add, dashboard monitoring URLs). Flat cluster: no ceph_public_ip, so this
-# resolves to bond_ip (10.10.10.9x) - identical to the pre-fabric behavior. A
-# group_var, NOT a role default, because it is read via hostvars[<host>] which
-# does not expose role defaults.
+# Advertise/bind address (mon --mon-ip, cephadm host-add, dashboard URLs). Flat
+# cluster: resolves to bond_ip. Must be a group_var -- hostvars[] does not expose
+# role defaults.
 ceph_service_ip: "{{ ceph_public_ip | default(bond_ip) }}"
 gateway: 10.10.10.1
 dns_server: 10.10.10.1
@@ -21,12 +17,10 @@ bond_interfaces:
   - eno2np1
 networkd_enabled: true
 
-# === Ceph ===
 ceph_release: tentacle
 ceph_repo_url: "https://download.ceph.com/debian-{{ ceph_release }}/"
 ceph_repo_key_url: "https://download.ceph.com/keys/release.asc"
 
-# === OS Provisioning ===
 admin_user: ansible-iac
 timezone: UTC
 
@@ -34,44 +28,34 @@ timezone: UTC
 # which requires the ops password).
 baseline_ops_sudo: "NOPASSWD:ALL"
 
-# Cluster-specific packages, merged with the baseline role's universal
-# baseline_diag_packages. These match sietch's hardware: Mellanox ConnectX 25G
-# NICs (eno1np0/eno2np1) and SAS-expander drive enclosures. A different cluster
-# declares its own set (or none).
+# Merged with baseline_diag_packages; matches sietch hardware (Mellanox ConnectX
+# 25G, SAS-expander enclosures).
 baseline_extra_packages:
-  - lldpd       # LLDP neighbor/switch discovery on the 25G fabric
-  - mstflint    # Mellanox ConnectX firmware query/update
-  - tcpdump     # packet capture for network debugging
-  - ledmon      # SAS enclosure drive-fault LEDs (ledctl)
-  - sg3-utils   # SCSI enclosure management (sg_ses)
+  - lldpd
+  - mstflint    # Mellanox ConnectX firmware
+  - tcpdump
+  - ledmon      # drive-fault LEDs (ledctl)
+  - sg3-utils   # SCSI enclosure (sg_ses)
 
-# Deploy keypair path on the controller. Both {path} and {path}.pub must
-# exist before running provision.yml (the preflight play in provision.yml
-# enforces this). ansible-iac's authorized_keys on every node is populated
-# by a file lookup at provision time — rotating the key on the controller
-# automatically propagates on the next re-provision.
+# Deploy keypair on the controller; {path} and {path}.pub must both exist
+# (provision.yml preflight enforces). authorized_keys comes from a file lookup at
+# provision time, so a controller-side rotation propagates on next re-provision.
 provision_iac_ssh_key_path: "~/.ssh/id_ed25519_sietch"
 
-# 1P vault for cluster secret lookups (e.g., rotate-ssh-key.yml reads pubkey from here).
 cluster_secrets_vault: yucca_tf_staging
 
-# Secret aliases — vault_* vars populated by scripts/ansible-play.sh via op inject
-#
-# Note: the deploy public key is NOT a secret — it's public data and lives
-# at {{ provision_iac_ssh_key_path }}.pub on the controller. Reading it via
-# file lookup avoids drift between vault and disk.
+# vault_* populated by scripts/ansible-play.sh via op inject.
+# The deploy PUBLIC key is not a secret: read from {{ provision_iac_ssh_key_path }}.pub
+# on disk to avoid vault/disk drift.
 ops_password: "{{ vault_ops_password }}"
 ceph_dashboard_user: admin
 ceph_dashboard_password: "{{ vault_ceph_dashboard_password }}"
 
-# S3 svc-user (yucca-restic consumer) — TF+1P-predetermined keys passed to
-# `radosgw-admin user create --access-key=... --secret-key=...` so the Yucca
-# app can be pre-configured with matching credentials. Rotation path documented
-# in docs/runbooks/rotate-secrets.md.
+# S3 svc-user (yucca-restic): TF+1P-predetermined keys passed to radosgw-admin
+# user create. Rotation: docs/runbooks/rotate-secrets.md.
 ceph_rgw_s3_user_access_key: "{{ vault_s3_restic_access_key }}"
 ceph_rgw_s3_user_secret_key: "{{ vault_s3_restic_secret_key }}"
 
-# === Storage ===
 ssd_model_pattern: "Micron_5100"
 
 os_partitions:
@@ -84,7 +68,6 @@ os_partitions:
 ceph_db_lv_size: "240G"
 ceph_db_lvs_per_ssd: 6
 
-# === RGW (Object Gateway) ===
 ceph_rgw_realm: sietch
 ceph_rgw_zonegroup: us-east-1
 ceph_rgw_zonegroup_api_name: us-east-1
@@ -103,25 +86,19 @@ ceph_rgw_port: 443
 ceph_rgw_s3_user_uid: svc-yucca-restic
 ceph_rgw_s3_user_display_name: "yucca/restic service account"
 
-# Metrics-worker RGW admin (read-only). Keys TF-minted in 1P
-# (SIETCH_METRICS_WORKER_{ACCESS,SECRET}_KEY); the metrics worker scrapes RGW
-# usage/bucket/user stats via the admin ops API. Read-only admin caps only.
+# Metrics-worker keys are TF-minted in 1P (SIETCH_METRICS_WORKER_{ACCESS,SECRET}_KEY).
 ceph_rgw_metrics_user_uid: metrics-worker
 ceph_rgw_metrics_user_display_name: "yucca/metrics-worker RGW admin (read-only)"
 ceph_rgw_metrics_user_access_key: "{{ vault_metrics_worker_access_key }}"
 ceph_rgw_metrics_user_secret_key: "{{ vault_metrics_worker_secret_key }}"
 ceph_rgw_metrics_user_caps: "buckets=read;usage=read;metadata=read;users=read"
 
-# --- RGW DNS + TLS ---
-# Virtual-hosted S3 support: setting rgw_dns_name tells RGW to strip this
-# suffix from the Host header and treat the remainder as the bucket name.
-# Requires matching DNS: both s3.<domain> and *.s3.<domain> should resolve
-# to the cluster nodes (round-robin A, or VIP/LB in prod).
+# Virtual-hosted S3: RGW strips this suffix from Host to get the bucket name.
+# Requires s3.<domain> AND *.s3.<domain> resolving to the cluster nodes.
 ceph_rgw_dns_name: s3.staging.austin.int.futo.cloud
 
-# Self-signed wildcard cert handed to cephadm via service spec.
-# cephadm distributes to all RGW daemons. To rotate, delete
-# /etc/ceph/rgw-ssl.{crt,key} on the bootstrap node and re-run the role.
+# Self-signed wildcard cert distributed by cephadm via the service spec. Rotate:
+# delete /etc/ceph/rgw-ssl.{crt,key} on the bootstrap node, re-run the role.
 ceph_rgw_ssl: true
 ceph_rgw_ssl_cert_days: 3650  # 10 years
 ceph_rgw_ssl_cert_subject_c: US
@@ -130,10 +107,8 @@ ceph_rgw_ssl_cert_subject_l: Austin
 ceph_rgw_ssl_cert_subject_o: FUTO
 ceph_rgw_ssl_cert_email: yucca@futo.org
 
-# Computed: scheme used for endpoints, debug output, and zonegroup/zone URLs
 ceph_rgw_scheme: "{{ 'https' if ceph_rgw_ssl else 'http' }}"
 
-# === Monitoring Stack ===
 ceph_prometheus_port: 9095
 ceph_grafana_port: 3000
 ceph_alertmanager_port: 9093

--- a/ansible/ceph/inventories/staging-austin/sietch/host_vars/example.yml
+++ b/ansible/ceph/inventories/staging-austin/sietch/host_vars/example.yml
@@ -3,12 +3,10 @@
 # The <name> segment is either operator-declared in clusters.auto.tfvars
 # or TF-auto-picked from wordlist.txt — see docs/naming.md.
 # Filename MUST match inventory_hostname for Ansible auto-load.
-# Values are node-specific — hardware paths differ per chassis.
 hostname_short: sietch-ceph-EXAMPLE
 bond_ip: 10.0.0.1
 
-# SAS expander base path (unique per chassis)
-# Find with: ls /dev/disk/by-path/ | grep sas
+# Unique per chassis; find with: ls /dev/disk/by-path/ | grep sas
 sas_path_prefix: "pci-0000:02:00.0-sas-exp0x500056b3XXXXXXXX"
 
 # SSD PHY positions in the SAS topology
@@ -19,8 +17,7 @@ ssd2_phy: 13
 ceph_db_vg1: ceph-db-ssd1
 ceph_db_vg2: ceph-db-ssd2
 
-# HDD OSD mappings: SAS PHY slot -> block.db LV
-# 6 HDDs per SSD, each gets a dedicated 240G block.db LV
+# 6 HDDs per SSD, each with a dedicated 240G block.db LV.
 ceph_hdd_osds:
   - path_phy: phy0
     db: ceph-db-ssd1/db-slot0

--- a/ansible/ceph/inventories/staging-austin/sietch/host_vars/sietch-ceph-laurel.yml
+++ b/ansible/ceph/inventories/staging-austin/sietch/host_vars/sietch-ceph-laurel.yml
@@ -21,7 +21,6 @@ ceph_db_vg2: ceph-db-rear13   # VG on SSD2 (phy13) partition 5
 ceph_ssd_vg1: ceph-ssd-rear12  # VG on SSD1 (phy12) partition 6 -- SSD OSD data
 ceph_ssd_vg2: ceph-ssd-rear13  # VG on SSD2 (phy13) partition 6 -- SSD OSD data
 
-# HDD OSD mappings: PHY slot -> block.db LV
 # PHY 0-5 -> SSD1 (ceph-db-rear12/db-slot0..5)
 # PHY 6-11 -> SSD2 (ceph-db-rear13/db-slot6..11)
 # by-path is slot-stable: replacing a drive in the same bay keeps the same path

--- a/ansible/ceph/logging.yml
+++ b/ansible/ceph/logging.yml
@@ -1,28 +1,19 @@
 ---
-# Ship each ceph node's journald to o11y's VictoriaLogs over the NetBird overlay.
-# journald is the whole source: cephadm daemons write there via libsystemd
-# (log_to_journald true, log_to_file false), and so does the mon cluster channel.
-#
-# Needs the node enrolled in NetBird and the ceph-to-o11y-gateway policy applied;
-# without the policy there is no route to the gateway VIP.
-#
-# Runs LAST in site.yml, after harden.yml: log shipping is not on the Ceph
-# critical path, so it must never stand between a node and convergence, and
-# running it last means it is exercised against the final nftables ruleset.
-#
+# Ship journald (the whole source: cephadm daemons + mon cluster channel) to
+# o11y VictoriaLogs over the NetBird overlay. Needs enrollment + the
+# ceph-to-o11y-gateway policy (no policy = no route to the gateway VIP).
+# Runs LAST in site.yml, after harden.yml: not on the Ceph critical path, and
+# last means it is exercised against the final nftables ruleset.
 #   Canary:   mise run logs -- --limit spice-ceph-adelia
 #   Fleet:    mise run logs
 - name: Host log shipping
   hosts: ceph_nodes
   become: true
   serial: "{{ fluentbit_serial | default('25%') }}"
-  # No blast-radius control here, unlike baseline.yml: a node that will not ship
-  # logs cannot degrade the cluster. Isolated failures ride along and the rest of
-  # the fleet still converges.
-  # Ansible evaluates this per batch. At the 25% default, 12 nodes on spice, it
-  # rides out 2 failures and halts at 3. One dead node is a node problem. A third
-  # of a batch is the gateway, the policy, or the package.
-  # A wholly failed batch halts regardless, and failed hosts still fail the run.
+  # Looser than baseline.yml: a node that won't ship logs can't degrade the
+  # cluster. Per batch (12 nodes on spice at 25%): rides out 2 failures, halts at
+  # 3 -- one dead node is a node problem, a third of a batch is the gateway/
+  # policy/package. Failed hosts still fail the run.
   max_fail_percentage: 20
   tasks:
     - name: Ship journald via the fluentbit role

--- a/ansible/ceph/migrate-networkd.yml
+++ b/ansible/ceph/migrate-networkd.yml
@@ -1,29 +1,11 @@
 ---
-# Migrate ifupdown -> systemd-networkd on sietch Ceph nodes.
-#
-# Live migration — no reboot, no Ceph disruption:
-#   1. Deploys networkd configs
-#   2. Starts networkd (adopts existing bond0)
-#   3. Verifies bond0 IP, members, gateway
-#   4. Commits: disables ifupdown, enables networkd for boot
-#
-# If verification fails, the play stops before committing.
-# networkd can be stopped and ifupdown still owns next boot.
-#
-# Safety:
-#   - serial: 1 -- one node at a time
-#   - /etc/network/interfaces preserved on disk
-#   - Rollback: /usr/local/sbin/rollback-networkd.sh
-#   - iDRAC at 10.10.11.9{0,1,2} for emergency recovery
-#
-# Usage (samara first):
+# Migrate ifupdown -> systemd-networkd, live (no reboot, no Ceph disruption):
+# deploy configs -> start networkd (adopts bond0) -> verify IP/members/gateway ->
+# commit (disable ifupdown for boot). A failed verify stops BEFORE commit;
+# ifupdown still owns next boot. Safety: serial 1, /etc/network/interfaces kept
+# on disk, rollback-networkd.sh, iDRAC at 10.10.11.9{0,1,2} for recovery.
+# Usage (canary samara first, then 'ceph_nodes:!sietch-ceph-samara'; --check --diff dry-runs):
 #   scripts/ansible-play.sh migrate-networkd.yml --limit sietch-ceph-samara
-#
-# Usage (remaining nodes):
-#   scripts/ansible-play.sh migrate-networkd.yml --limit 'ceph_nodes:!sietch-ceph-samara'
-#
-# Dry run:
-#   scripts/ansible-play.sh migrate-networkd.yml --limit sietch-ceph-samara --check --diff
 
 - name: Migrate to systemd-networkd
   hosts: ceph_nodes
@@ -33,9 +15,8 @@
   max_fail_percentage: 0   # any node fails (e.g. WAN drops -> unreachable) -> halt
 
   pre_tasks:
-    # Ceph-health gate applies only to a live cluster. Pre-Ceph clusters (spice
-    # bringup: coexistence activation before any cephadm deploy) have no
-    # ceph_bootstrap group and no ceph binary, so skip it automatically.
+    # Health gate only for live clusters; pre-Ceph bringup (no ceph_bootstrap
+    # group / no ceph binary) skips it automatically.
     - name: Preflight -- check Ceph health
       ansible.builtin.command: ceph health --format json
       register: ceph_health_pre

--- a/ansible/ceph/post-deploy-capture.yml
+++ b/ansible/ceph/post-deploy-capture.yml
@@ -1,23 +1,10 @@
 ---
-# post-deploy-capture.yml — snapshot bootstrap-side secrets into 1Password.
-#
-# Captures:
-#   /etc/ceph/rgw-ssl.crt         -> <CLUSTER>_CEPH_RGW_TLS_CERT
-#   /etc/ceph/rgw-ssl.key         -> <CLUSTER>_CEPH_RGW_TLS_KEY
+# Snapshot bootstrap-side secrets into 1Password (idempotent create/update):
+#   /etc/ceph/rgw-ssl.{crt,key} -> <CLUSTER>_CEPH_RGW_TLS_{CERT,KEY}
 #   /etc/ceph/ceph.client.admin.keyring -> <CLUSTER>_CEPH_CLIENT_ADMIN_KEYRING
-#
-# Idempotent: creates item if missing, updates if content drifted.
-#
-# Belt-and-suspenders only. The cluster continues to run from on-node
-# copies; the 1P copies exist for disaster recovery (e.g., laurel dies +
-# filesystem loss + you want to restore the RGW cert to a new bootstrap
-# node without re-trusting it in every S3 client).
-#
-# Usage:
-#   scripts/ansible-play.sh post-deploy-capture.yml
-#
-# Requires: superuser SA read access from controller (already required by
-# mise run tf:* tasks), op CLI on controller, 1P session live.
+# DR belt-and-suspenders only (restore the RGW cert to a new bootstrap node
+# without re-trusting every S3 client); the cluster runs from on-node copies.
+# Requires superuser SA read access + op CLI + live 1P session on the controller.
 
 - name: Capture bootstrap-side secrets to 1Password
   hosts: ceph_bootstrap

--- a/ansible/ceph/provision.yml
+++ b/ansible/ceph/provision.yml
@@ -1,34 +1,12 @@
 ---
-# Provision sietch-ceph nodes from the Debian 12 live image.
-#
-# Fresh-install workflow (no cloning):
-#   1. Boot all target nodes to Debian 12 live image (user/live credentials)
-#   2. Ensure the live image is reachable on its reserved IP (= bond_ip)
-#   3. CEPH_ENV=inventories/<cluster>/inventory-provision.ini \
-#        scripts/ansible-play.sh provision.yml -e confirm_wipe=true
-#
-# Flags:
-#   confirm_wipe=true                    required — destroys all data on SSDs
-#   provision_create_iac_keypair=true    opt-in: preflight auto-generates
-#                                        the ansible-iac deploy keypair if
-#                                        it doesn't already exist on disk
-#   provision_skip_reboot=true           opt-in: skip the final reboot and
-#                                        the post-reboot verification play
-#                                        (canary inspection of the chroot)
-#   --limit <host>                       provision one node at a time
-#
-# Post-reboot: a separate verification play waits on the installed OS
-# (reached via the production sietch-ceph-<name> SSH alias / ansible-iac
-# user with key) and confirms the provisioning marker is in place.
-
-# --- Preflight: controller-side prerequisites -------------------------
-#
-# Runs BEFORE the target hosts are touched. Verifies the ansible-iac
-# deploy keypair exists on the controller (it gets installed into every
-# node's ~ansible-iac/.ssh/authorized_keys via file lookup during the
-# main play). Keypair generation is strictly opt-in via
-# -e provision_create_iac_keypair=true — default behavior is to fail
-# fast with a clear message if the keypair is missing.
+# Targets must already be booted into the Debian 12 live image (user/live) and
+# reachable on bond_ip:
+#   CEPH_ENV=inventories/<cluster>/inventory-provision.ini \
+#     scripts/ansible-play.sh provision.yml -e confirm_wipe=true
+# Flags: confirm_wipe=true (required, DESTROYS SSD data);
+#   provision_create_iac_keypair=true (opt-in keypair autogen);
+#   provision_skip_reboot=true (skip reboot + verify, chroot canary inspection);
+#   --limit <host> (one node at a time).
 
 - name: Preflight — verify controller prerequisites
   hosts: localhost
@@ -115,41 +93,24 @@
   gather_facts: false
   become: false
   tasks:
-    # Verification runs on localhost via delegate_to + the production
-    # sietch-ceph-<name> SSH alias. That avoids having to juggle live
-    # vs installed credentials inside a single play.
-
+    # Runs on localhost via the production SSH alias, avoiding live-vs-installed
+    # credential juggling in one play.
     - name: Skip verification play when reboot was intentionally skipped
       ansible.builtin.meta: end_play
       when: provision_skip_reboot | default(false) | bool
 
-    # Give the box a head start before we start hammering ssh. R730xd
-    # POST + GRUB + initramfs + systemd brings the bond up in ~60-90s.
+    # Head start: R730xd POST->systemd brings the bond up in ~60-90s.
     - name: Initial reboot wait
       delegate_to: localhost
       ansible.builtin.pause:
         seconds: "{{ provision_reboot_wait_delay | default(60) }}"
 
-    # The ssh probe is the actual gate — it honors ~/.ssh/config
-    # (including any ProxyJump or ProxyCommand entries) so it works
-    # from the controller regardless of whether the target subnet is
-    # directly routable. wait_for/tcp does NOT honor ssh_config, so
-    # we rely on retries here instead.
-    #
-    # We force user + identity explicitly with -l / -i / IdentitiesOnly
-    # because ~/.ssh/config for the host alias lands as the 'ops' human
-    # user (which has NO authorized_keys on a fresh provision — operator
-    # keys are distributed out-of-band). The verify play is an automation
-    # reachability test, so it uses ansible-iac (the same identity
-    # ansible_ssh_private_key_file points at in inventory.ini).
-    #
-    # UserKnownHostsFile=/dev/null + StrictHostKeyChecking=no bypass
-    # known_hosts entirely: fresh provisioning generates new host keys,
-    # and on reprovisioning a stale known_hosts entry would otherwise
-    # trigger "REMOTE HOST IDENTIFICATION HAS CHANGED" and abort. The
-    # real identity check happens via the marker assertion below, not
-    # via the SSH host key cache. LogLevel=ERROR suppresses the
-    # "Warning: Permanently added..." noise.
+    # ssh (not wait_for/tcp) is the gate because it honors ~/.ssh/config
+    # (ProxyJump etc.). Force -l/-i/IdentitiesOnly: the host alias defaults to
+    # 'ops', which has NO authorized_keys on a fresh provision. known_hosts is
+    # bypassed because provisioning mints new host keys and a stale entry would
+    # abort with "REMOTE HOST IDENTIFICATION HAS CHANGED"; real identity check
+    # is the marker assertion below.
     - name: Probe installed OS via production SSH alias (as ansible-iac)
       delegate_to: localhost
       ansible.builtin.command:

--- a/ansible/ceph/rados-bench.yml
+++ b/ansible/ceph/rados-bench.yml
@@ -1,8 +1,5 @@
 ---
-# RADOS benchmark — tests raw cluster I/O bypassing RGW/S3.
-# Useful for isolating storage performance from S3 overhead.
-#
-# Usage:
+# Raw cluster I/O, bypassing RGW/S3.
 #   scripts/ansible-play.sh rados-bench.yml                        # 30s write, replicated
 #   scripts/ansible-play.sh rados-bench.yml -e rados_ec=true       # EC 8+3 (matches RGW data pool)
 #   scripts/ansible-play.sh rados-bench.yml -e rados_mode=seq      # sequential read

--- a/ansible/ceph/reprovision.yml
+++ b/ansible/ceph/reprovision.yml
@@ -1,9 +1,4 @@
 ---
-# Reprovision Hetzner SX295 ceph nodes via the Robot API + installimage.
-# Ansible-native replacement for the out-of-band installimage step:
-#   arm rescue (uri) -> hw reset (uri) -> wait for rescue -> [zap OSD HDDs] ->
-#   installimage -> reboot -> verify installed OS. Then hand off to `mise run deploy`.
-#
 # ALWAYS DESTRUCTIVE to the NVMe OS disks. NEVER fold this into deploy/converge.
 # Launch ONLY via `mise run reprovision` (wraps op run --env-file=../../tf/.env.prod,
 # which materializes HETZNER_ROBOT_* and lets ansible-play.sh op-inject secrets).

--- a/ansible/ceph/roles/baseline/defaults/main.yml
+++ b/ansible/ceph/roles/baseline/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
-# Post-boot OS baseline — runs via ansible-iac after provisioning.
-# Configures everything that doesn't need to be in the chroot.
+# Runs via ansible-iac after provisioning.
 
-# --- iac automation access (convergence twin of the reprovision -x chroot) ---
-# Ensures root's iac key + the ansible-iac sudo account on already-installed nodes
+# Convergence twin of the reprovision -x chroot: ensures root's iac key + the ansible-iac sudo account on already-installed nodes
 # without reimaging. baseline_iac_pubkey derives from the cluster's iac key; the
 # iac-access task is gated on provision_iac_ssh_key_path so clusters without one
 # skip. Override baseline_iac_pubkey directly to authorize a different key.
@@ -11,31 +9,25 @@ baseline_iac_user: ansible-iac
 baseline_iac_pubkey: >-
   {{ lookup('file', (provision_iac_ssh_key_path | expanduser) ~ '.pub') }}
 
-# --- Intel ice NIC firmware (DDP) ---
-# nic-firmware.yml reboots an E810 host once to load the DDP (exit Safe Mode) after
-# firmware-misc-nonfree is installed. Set false to install the package but skip the
-# activating reboot (an operator can reboot on their own schedule).
+# nic-firmware.yml reboots an E810 host once to load the DDP (exit Safe Mode).
+# false = install firmware-misc-nonfree but skip the activating reboot.
 baseline_nic_firmware_activate: true
 baseline_nic_firmware_reboot_timeout: 600
 
-# --- ops user ---
 baseline_ops_user: ops
 baseline_ops_uid: 1001
 baseline_ops_sudo: "ALL"      # "ALL" = password required; "NOPASSWD:ALL" for dev
 
-# Operator SSH public keys authorized on the ops account. Sourced from the
-# identity registry (tf/shared/modules/identity, members of a `server`-mapped
-# group) and rendered into group_vars/all/operators.yml by
-# render-inventories.sh. Default empty: with no keys, ops stays password-only.
+# Operator pubkeys for ops, rendered into group_vars/all/operators.yml by
+# render-inventories.sh from the identity registry (tf/shared/modules/identity).
+# Empty = ops stays password-only.
 ops_authorized_keys: []
 
-# --- /etc/hosts ---
 # Rendered from the same cluster variables used by ceph_deploy/hosts.j2.
 # Keeps host entries converged even if ceph_deploy hasn't run yet.
 baseline_manage_hosts: true
 
-# --- Packages ---
-# Podman ecosystem (needed by cephadm)
+# Needed by cephadm.
 baseline_podman_packages:
   - podman
   - catatonit
@@ -44,7 +36,6 @@ baseline_podman_packages:
   - slirp4netns
   - uidmap
 
-# Diagnostic and ops toolset
 baseline_diag_packages:
   - smartmontools
   - ipmitool
@@ -64,35 +55,25 @@ baseline_diag_packages:
   - bsdmainutils
   - python3-boto3
 
-# Per-cluster hardware/site-specific packages, merged with baseline_diag_packages
-# at install time. Default empty so the role stays hardware-agnostic; each
-# cluster declares its own set in inventories/<cluster>/group_vars/all/vars.yml
-# (e.g. sietch's Mellanox + SAS-enclosure tools). A different cluster (spice,
-# ...) sets its own list or leaves it empty.
+# Per-cluster hardware packages, merged with baseline_diag_packages; declared in
+# each cluster's group_vars (e.g. sietch's Mellanox + SAS tools). Empty default.
 baseline_extra_packages: []
 
-# Load-bearing host packages frozen at their installed version via a dpkg hold, so
-# a stray `apt upgrade` cannot move them out from under a live cluster. We run NO
-# unattended-upgrades by design; upgrading these is a deliberate, health-gated act
-# (unhold -> upgrade -> re-hold, ideally through the serial converge). The default
-# covers cephadm's container runtime (podman + ecosystem) and the chrony time
-# source that mon quorum depends on. Diagnostic/ops tools are intentionally NOT
-# held (a version drift there is harmless). Extend per cluster, or set [] to
-# disable. For an exact-version pin (rather than freeze-at-installed) add an apt
-# preferences entry; the hold covers the common "do not let it drift" need.
+# dpkg-hold load-bearing packages at installed version so a stray `apt upgrade`
+# can't move them under a live cluster (no unattended-upgrades by design;
+# upgrade = deliberate unhold -> upgrade -> re-hold via the serial converge).
+# Covers cephadm's podman runtime + chrony (mon quorum is skew-sensitive); diag
+# tools deliberately NOT held. [] disables; exact pins need apt preferences.
 baseline_held_packages: "{{ baseline_podman_packages + ['chrony'] }}"
 
-# --- Time sync (chrony) ---
-# Pinned NTP sources for chrony.conf. Default to the Debian pool as a safe,
-# explicit fallback; each cluster overrides with a consistent low-latency set
-# (e.g. spice -> Hetzner NTP). Owned by chrony.yml (install+config+enable), NOT
-# baseline_enable_services, so system.yml never starts a not-yet-installed unit.
+# Debian-pool fallback; clusters override with a low-latency set (spice ->
+# Hetzner NTP). Owned by chrony.yml, NOT baseline_enable_services, so system.yml
+# never starts a not-yet-installed unit.
 chrony_ntp_servers:
   - 0.debian.pool.ntp.org
   - 1.debian.pool.ntp.org
   - 2.debian.pool.ntp.org
 
-# --- Services ---
 baseline_enable_services:
   - dbus
   - podman.socket

--- a/ansible/ceph/roles/baseline/tasks/apt-daily.yml
+++ b/ansible/ceph/roles/baseline/tasks/apt-daily.yml
@@ -1,11 +1,8 @@
 ---
-# Neutralize Debian's stock periodic apt before any dpkg/apt task runs.
-#
-# On a freshly-imaged node the apt-daily / unattended-upgrades units fire at boot
-# and hold the dpkg frontend lock. A converge that then runs apt or dpkg races
-# them and fails ("dpkg frontend lock was locked by another process"). We run no
-# unattended upgrades by design (load-bearing packages are dpkg-held), so masking
-# these units is both the intended end state and the fix for that race.
+# Neutralize Debian's periodic apt before any dpkg/apt task: on a fresh image the
+# apt-daily/unattended-upgrades units hold the dpkg frontend lock at boot and the
+# converge races them. We run no unattended upgrades by design (load-bearing
+# packages are dpkg-held), so masking is both the end state and the fix.
 
 - name: Stop and mask the periodic apt units
   ansible.builtin.systemd:

--- a/ansible/ceph/roles/baseline/tasks/drift.yml
+++ b/ansible/ceph/roles/baseline/tasks/drift.yml
@@ -1,7 +1,6 @@
 ---
-# Drift checks for baseline. Read-only.
-# Included by drift.yml via include_role + tasks_from -- see the precedence
-# note in roles/os_tuning/tasks/drift.yml.
+# Read-only. Included via include_role + tasks_from -- see the precedence note in
+# roles/os_tuning/tasks/drift.yml.
 
 # ssh-hardening.yml writes "PasswordAuthentication no" as a literal, not from a
 # variable, so the expectation is a literal here too. If that ever becomes

--- a/ansible/ceph/roles/baseline/tasks/hold-packages.yml
+++ b/ansible/ceph/roles/baseline/tasks/hold-packages.yml
@@ -1,17 +1,9 @@
 ---
-# Freeze the load-bearing host packages at their installed version.
-#
-# We deliberately do NOT run unattended-upgrades: an apt upgrade that moved the
-# cephadm container runtime (podman + ecosystem) or the time source (chrony, which
-# mon quorum depends on) out from under a live cluster is exactly the kind of
-# uncoordinated change we avoid. Instead we HOLD what matters (dpkg selection) so
-# `apt upgrade` skips them; upgrading them becomes a deliberate, health-gated act
-# (unhold -> upgrade -> re-hold, ideally through the serial converge). Diagnostic
-# and ops tools are intentionally not held (a version drift there is harmless).
-#
-# Runs last in the baseline role so every held package is already installed.
-# Idempotent: dpkg_selections only reports changed when the selection differs.
-# Set baseline_held_packages: [] to disable holds entirely.
+# dpkg-hold the load-bearing packages (podman ecosystem, chrony) so `apt upgrade`
+# cannot move them under a live cluster; upgrading = deliberate unhold -> upgrade
+# -> re-hold via the serial converge (full rationale on baseline_held_packages).
+# Runs last in the role so everything held is already installed;
+# baseline_held_packages: [] disables.
 
 - name: Freeze load-bearing packages at their installed version (dpkg hold)
   ansible.builtin.dpkg_selections:

--- a/ansible/ceph/roles/baseline/tasks/main.yml
+++ b/ansible/ceph/roles/baseline/tasks/main.yml
@@ -1,9 +1,7 @@
 ---
-# Post-boot OS baseline.
-# Runs via ansible-iac on the installed OS (not in chroot).
-# Assumes: ansible-iac user exists with key-only SSH + NOPASSWD sudo
-#          (created by provision_host during initial OS install).
-# Everything here is convergeable via normal deploy pipeline.
+# Runs via ansible-iac on the installed OS (not in chroot); assumes the
+# ansible-iac user exists with key-only SSH + NOPASSWD sudo, as provision_host
+# created it during the initial OS install.
 
 # First, before any dpkg/apt task: stop Debian's periodic apt and drain any
 # boot-time apt still holding the dpkg lock, so the converge cannot race it.

--- a/ansible/ceph/roles/baseline/tasks/nic-firmware.yml
+++ b/ansible/ceph/roles/baseline/tasks/nic-firmware.yml
@@ -1,16 +1,11 @@
 ---
-# Intel E810 (ice) NICs need their DDP package (intel/ice/ddp/ice.pkg, provided by
-# firmware-misc-nonfree, installed via baseline_extra_packages). Without it the NIC
-# boots into Safe Mode: the packet classifier is crippled and drops reserved-multicast
-# control frames (LACP 01:80:c2:00:00:02, LLDP ..:0e), so the 25G fabric bond never
-# aggregates even though the switch is correctly configured. The DDP only loads when
-# ice (re)probes, so once the package is present a single reboot clears Safe Mode.
-#
-# Safe by design: only acts on hosts with an ice NIC; only reboots when the NIC is
-# actually in Safe Mode AND the DDP file is present (so the reboot will fix it, and
-# healthy nodes are never rebooted); refuses to reboot if the DDP is still missing
-# (would loop). The WAN is on a separate igb NIC, so the reboot keeps the node
-# reachable (coexistence). Idempotent: a converged node is a no-op.
+# Intel E810 (ice) DDP (intel/ice/ddp/ice.pkg from firmware-misc-nonfree):
+# without it the NIC boots into Safe Mode, whose crippled classifier drops
+# reserved-multicast control frames (LACP 01:80:c2:00:00:02, LLDP ..:0e) so the
+# 25G bond never aggregates. DDP loads only on ice (re)probe -> one reboot clears
+# it. Only reboots when the NIC IS in Safe Mode AND the DDP file exists (never
+# healthy nodes; refuses if DDP missing -- would loop). WAN rides a separate igb
+# NIC, so the reboot keeps the node reachable.
 
 - name: Find an ice-bound netdev (is this an E810 host?)
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/baseline/tasks/ssh-hardening.yml
+++ b/ansible/ceph/roles/baseline/tasks/ssh-hardening.yml
@@ -1,17 +1,11 @@
 ---
-# Early SSH lockdown. Runs in baseline (right after iac-access authorizes the iac
-# key on root), NOT gated behind the harden stage -- so a freshly installimaged
-# node is never left with root PASSWORD login exposed on the public WAN before
-# harden runs (installimage ships PermitRootLogin yes + a root password). The
-# security role's 50-hardening.conf applies the FULL sshd hardening later; this is
-# the security-critical subset only (root key-only, no password auth, locked root
-# password), using the SAME values so the two drop-ins never disagree.
-#
-# Safe on both clusters and idempotent on live nodes: ansible reaches every node
-# by KEY (root on spice, ansible-iac on sietch) and iac-access has already
-# authorized the key on root, so disabling password auth and locking the root
-# password cannot lock anyone out. The Validate->Reload handler chain reloads
-# (never restarts) only on change, after sshd -t passes.
+# Early SSH lockdown, right after iac-access -- NOT deferred to harden, so an
+# installimaged node (PermitRootLogin yes + root password) is never left
+# root-password-open on the WAN mid-campaign. Security-critical subset only
+# (root key-only, no password auth, locked root password) with the SAME values
+# as the security role's 50-hardening.conf so the drop-ins never disagree.
+# Lockout-safe: ansible connects by key and iac-access already authorized it on
+# root. Handler chain reloads (never restarts) only after sshd -t passes.
 
 - name: Deploy the baseline SSH lockdown drop-in
   ansible.builtin.copy:

--- a/ansible/ceph/roles/baseline/tasks/users.yml
+++ b/ansible/ceph/roles/baseline/tasks/users.yml
@@ -1,6 +1,5 @@
 ---
-# ops user - human-interactive account.
-# Convergeable: running this again fixes drift in password, sudo, shell.
+# The ops user is the human-interactive account.
 
 - name: Ensure ops user exists
   ansible.builtin.user:
@@ -27,11 +26,9 @@
 - name: Set ops user password
   ansible.builtin.user:
     name: "{{ baseline_ops_user }}"
-    # password_hash draws a RANDOM salt by default, so the hash differs every run
-    # and the user module rewrites /etc/shadow (reporting 'changed') on every
-    # converge. Derive a STABLE salt from the password (one-way sha256, so the
-    # public salt in /etc/shadow leaks nothing) to make the hash deterministic and
-    # the task idempotent, while still reconciling an out-of-band password change.
+    # Stable salt (sha256 of the password; salt is public anyway) so the hash is
+    # deterministic -- a random salt would rewrite /etc/shadow ('changed') every
+    # converge. Still reconciles an out-of-band password change.
     password: "{{ ops_password | password_hash('sha512', salt=(ops_password | hash('sha256'))[:16]) }}"
   no_log: true
 

--- a/ansible/ceph/roles/ceph_backup/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_backup/defaults/main.yml
@@ -1,30 +1,24 @@
 ---
-# Scheduled Ceph cluster-state backup defaults.
-#
 # The capture is read-only (dumps config/topology maps via the on-node admin
-# keyring) and writes to a root-only local dir, so it is universally safe. Set
-# ceph_backup_enabled: false in a cluster's group_vars to opt out.
+# keyring) and writes to a root-only local dir, so it is universally safe.
 ceph_backup_enabled: true
 
-# Local landing dir for tarballs. Root-only (0700): the capture set is
-# config/topology only, but keep it locked down regardless.
 ceph_backup_dir: /var/backups/ceph
 
 # Prune tarballs older than N days on each run. 0 disables pruning.
 ceph_backup_retention_days: 14
 
-# Where the capture script is installed on the bootstrap node.
 ceph_backup_script_path: /usr/local/sbin/ceph-backup.sh
 
-# Offsite sync target - EMPTY BY DEFAULT (operator decision; do not hardcode a
-# destination). When set the script ships each tarball after capture:
+# EMPTY BY DEFAULT (operator decision). When set the script ships each tarball
+# after capture:
 #   rsync form: user@host:/path/  or  rsync://host/module/path
 #   S3 form:    s3://bucket/prefix  (requires the aws CLI on the bootstrap node)
 # TODO(operator): choose + wire an offsite destination for true DR.
 ceph_backup_offsite_dest: ""
 
-# systemd timer schedule + jitter. Daily with an up-to-1h randomized delay so a
-# fleet of clusters does not stampede a shared offsite target at the same second.
+# Randomized delay so a fleet of clusters does not stampede a shared offsite
+# target at the same second.
 ceph_backup_oncalendar: "daily"
 ceph_backup_randomized_delay: "1h"
 

--- a/ansible/ceph/roles/ceph_backup/meta/main.yml
+++ b/ansible/ceph/roles/ceph_backup/meta/main.yml
@@ -1,9 +1,7 @@
 ---
-# No dependencies - deploys a self-contained capture script + systemd timer on
-# the bootstrap node. Independent of the deploy pipeline; run deliberately via
-# backup-ceph.yml. Complements post-deploy-capture.yml (secrets -> 1P) and
-# backup-config.yml (one-shot controller-local export) with a SCHEDULED,
-# on-node config/topology backup.
+# Independent of the deploy pipeline; run deliberately via backup-ceph.yml.
+# Complements post-deploy-capture.yml (secrets -> 1P) and backup-config.yml
+# (one-shot controller-local export) with a SCHEDULED on-node backup.
 dependencies: []
 
 galaxy_info:

--- a/ansible/ceph/roles/ceph_backup/tasks/main.yml
+++ b/ansible/ceph/roles/ceph_backup/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
-# Deploy the scheduled cluster-state backup: capture script + systemd
-# service/timer on the bootstrap node. Read-only capture to a root-only local
-# dir, so it is universally safe; gate with ceph_backup_enabled to opt out.
+# Read-only capture to a root-only local dir on the bootstrap node, so it is
+# universally safe.
 
 - name: Scheduled backup install
   when: ceph_backup_enabled | bool

--- a/ansible/ceph/roles/ceph_deploy/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_deploy/defaults/main.yml
@@ -1,153 +1,83 @@
 ---
-# Ceph release train. Upstream publishes per-release apt trees at
-# download.ceph.com/debian-<release>/, and each tree has subdirectories
-# per Debian codename. prerequisites.yml pins the codename to 'bookworm'
-# in the sources.list entry - when upgrading the base OS to Trixie,
-# flip the codename there. This split keeps the Ceph release and the
-# Debian release independently versionable.
+# Ceph release train. prerequisites.yml pins the Debian codename ('bookworm')
+# separately in sources.list -- flip it there when moving the base OS to Trixie.
 ceph_release: tentacle
-ceph_release_version: "20.2.*"  # pin to patch range; set "20.2.1" to pin exactly
+ceph_release_version: "20.2.*"  # patch range; "20.2.1" pins exactly
 ceph_repo_url: "https://download.ceph.com/debian-{{ ceph_release }}/"
 ceph_repo_key_url: "https://download.ceph.com/keys/release.asc"
 cephadm_install_method: repo   # 'repo' or 'curl'
 
-# Initial PG counts per pool. The autoscaler is left on and will adjust
-# over time, but starting at pg_num=1 (the ceph default) causes PG
-# splitting under load which tanks performance during the first fill.
-# These values are sized for ~36 OSDs. Scale proportionally for larger
-# clusters.
-ceph_pg_init_data: 128        # EC data pool - bulk of I/O
-ceph_pg_init_index: 16        # bucket index
-ceph_pg_init_non_ec: 16       # multipart uploads
+# Initial PG counts (autoscaler stays on; pg_num=1 default splits under load and
+# tanks the first fill). Sized for ~36 OSDs -- scale proportionally.
+ceph_pg_init_data: 128
+ceph_pg_init_index: 16
+ceph_pg_init_non_ec: 16
 ceph_pg_init_meta: 8          # .rgw.root, .meta, .log, .control
 
-# RGW EC data-pool min_size (write-availability floor). Ceph defaults an EC pool
-# to min_size = k+1, which is the correct floor: at k+1 up shards a PG stays
-# writable, so writes tolerate up to m-1 host losses while reads still tolerate m.
-# Pin it EXPLICITLY (get-then-set in rgw.yml) so the value is documented and
-# cannot drift. NEVER set below k+1: permitting writes at k shards risks data loss
-# if another shard is lost mid-recovery. Derived from ceph_rgw_ec_k so it tracks
-# whatever profile a cluster runs (spice 16+4 -> 17, sietch 8+3 -> 9).
+# EC data-pool min_size floor, pinned explicitly in rgw.yml so it can't drift.
+# k+1 = writes tolerate m-1 host losses, reads m. NEVER below k+1 (writes at k
+# shards risk data loss mid-recovery). Tracks each cluster's profile via ceph_rgw_ec_k.
 ceph_rgw_ec_min_size: "{{ (ceph_rgw_ec_k | int) + 1 }}"
 
-# MGR daemon count (1 active + standbys). cephadm's default and upstream guidance
-# is a small fixed count; deploying one per host (e.g. 47 on spice) is wasteful and
-# non-standard. count:N lets cephadm place them (caps at the host count on small
-# clusters like sietch).
+# MGR count (1 active + standbys). Small fixed count per upstream guidance, not
+# one per host; cephadm caps at host count on small clusters.
 ceph_mgr_count: 3
 
-# --- Service bind/advertise policy (per-cluster; fabric-only on spice) ---
-# ceph_service_ip (the address Ceph point-services advertise + bind on: mon
-# --mon-ip, the cephadm host-add address, the dashboard monitoring URLs) is
-# defined in each cluster's group_vars, NOT here. join/rgw/monitoring read it
-# through hostvars[<host>], and role defaults are INVISIBLE via hostvars (a role
-# default raises "HostVarsVars object has no attribute ceph_service_ip" and aborts
-# the deploy), whereas group_vars resolve through hostvars per host. spice sets it
-# to the fabric ceph_public_ip; sietch (flat) to bond_ip. It is NOT the ansible/SSH
-# connection address (that is bond_ip / ansible_host).
+# ceph_service_ip (mon --mon-ip / cephadm host-add / dashboard URLs) lives in
+# group_vars, NOT here: role defaults are invisible via hostvars[] ("HostVarsVars
+# object has no attribute" aborts the deploy). Not the SSH address (bond_ip).
 #
-# CIDR(s) cephadm restricts daemon binds to, injected as the `networks:` field of
-# the RGW + monitoring service specs. mon/mgr/OSD already bind per public_network/
-# cluster_network; this closes the remaining daemons (beast RGW, prometheus,
-# grafana, alertmanager, node-exporter, ceph-exporter) that otherwise bind 0.0.0.0.
-# EMPTY by default: no `networks:` field is emitted and the monitoring re-spec is
-# skipped, so daemons bind every interface exactly as cephadm ships them - flat
-# clusters like sietch are untouched. A cluster that must be fabric-only (spice)
-# opts in by setting this to its fabric CIDR(s) in group_vars.
+# CIDR(s) injected as `networks:` in the RGW + monitoring specs, closing the
+# daemons that otherwise bind 0.0.0.0 (beast, prometheus, grafana, alertmanager,
+# exporters). EMPTY default = no field emitted, monitoring re-spec skipped, flat
+# clusters (sietch) untouched; fabric-only clusters opt in via group_vars.
 ceph_bind_networks: []
 
-# --- Device-class CRUSH pool placement (per-cluster; opt-in) ---
-# Pools listed here are pinned to the named device-class CRUSH rule after RGW is
-# up. EMPTY by default so a cluster's pools stay on whatever rule they already
-# carry - re-homing a live pool triggers a full rebalance under load, so this is
-# never applied implicitly. A cluster with a dedicated fast tier (spice's ssd-osd
-# NVMe) opts in via group_vars. The rule names must match crush-rules.yml.
+# Pools listed here get pinned to the named rule after RGW is up. EMPTY default:
+# re-homing a live pool forces a full rebalance, so never implicit. Rule names
+# must match crush-rules.yml.
 ceph_rgw_ssd_crush_rule: replicated_ssd
 ceph_rgw_hdd_crush_rule: replicated_hdd
 ceph_rgw_ssd_pools: []
 ceph_rgw_hdd_pools: []
 
-# --- RGW ingress: health-checked S3 VIP (haproxy + keepalived; per-cluster; opt-in) ---
-# A cephadm `ingress` service that puts a keepalived-managed floating VIP with
-# haproxy health checks in front of RGW, in TLS TERMINATION mode (haproxy
-# `mode http`: haproxy terminates the client TLS on the VIP with the reused RGW
-# self-signed cert, then re-encrypts to the RGW backends). A dead RGW node is then
-# dropped from the VIP instead of blackholing ~1/N of S3 connections. DEFAULT OFF:
-# no ingress spec is rendered or applied, so flat/dev clusters (sietch) and any
-# cluster that has not opted in are a complete no-op.
-#
-# (Terminate, not L4 passthrough, because passthrough for an RGW backend needs
-# IngressSpec.use_tcp_mode_over_rgw, a post-20.2.2 upstream field absent on the
-# pinned 20.2.2 -- source-verified; an unknown spec key makes `orch apply`
-# TypeError. Terminate is the only health-checked ingress mode available here.)
-#
-# A cluster opts in by setting ceph_rgw_ingress_enabled: true AND
-# ceph_rgw_ingress_vip in its group_vars. Three hard preconditions, all asserted
-# at apply time:
-#   1. ceph_rgw_ingress_vip must be set (the VIP the clients hit).
-#   2. ceph_bind_networks must be non-empty - otherwise beast binds
-#      0.0.0.0:<ceph_rgw_port> and the co-located haproxy VIP bind on the same
-#      port collides (EADDRINUSE). Restricted beast binds a per-node IP, the VIP
-#      is a distinct socket, so they coexist.
-#   3. ceph_rgw_ssl must be true - haproxy terminates with the RGW self-signed
-#      cert (rgw_ssl_cert_combined_pem), which only exists when RGW ssl is on.
+# keepalived VIP + haproxy health checks in front of RGW, TLS TERMINATION mode
+# (reused RGW self-signed cert, re-encrypt to backends); a dead node is dropped
+# instead of blackholing ~1/N of S3 connections. DEFAULT OFF (no spec rendered).
+# Terminate, not L4 passthrough: passthrough needs IngressSpec.use_tcp_mode_over_rgw,
+# absent on pinned 20.2.2 (unknown spec key => `orch apply` TypeError).
+# Asserted preconditions: ceph_rgw_ingress_vip set; ceph_bind_networks non-empty
+# (else beast binds 0.0.0.0:<port> and the co-located VIP bind EADDRINUSEs);
+# ceph_rgw_ssl true (haproxy terminates with rgw_ssl_cert_combined_pem).
 ceph_rgw_ingress_enabled: false
-# Floating VIP the S3 clients hit (bare IP; the prefix is added below). Empty by
-# default; a cluster that opts in sets this to an address on its RGW-facing
-# network (e.g. spice fabric public 10.40.20.250).
-ceph_rgw_ingress_vip: ""
-# CIDR prefix of the network the VIP lives on - MUST match the prefix of the
-# public/RGW-facing network (spice fabric public = /23) so keepalived binds the
-# VIP to the right interface.
+ceph_rgw_ingress_vip: ""             # bare IP on the RGW-facing network
+# MUST match the RGW-facing network's prefix (spice fabric public = /23) so
+# keepalived binds the VIP to the right interface.
 ceph_rgw_ingress_vip_prefix: 23
-# Port clients hit on the VIP. Must match ceph_rgw_port (the S3/beast port).
+# Must match ceph_rgw_port.
 ceph_rgw_ingress_frontend_port: 443
-# haproxy stats/monitor port (load-balancer status; not the S3 data path).
-ceph_rgw_ingress_monitor_port: 1967
-# Number of haproxy + keepalived instances cephadm spreads across nodes (VRRP
-# needs >= 2 for failover; 3 tolerates one node loss with quorum to spare).
+ceph_rgw_ingress_monitor_port: 1967  # haproxy stats, not the S3 data path
+# VRRP needs >= 2 instances; 3 tolerates a node loss.
 ceph_rgw_ingress_count: 3
 
-# --- Alert delivery (per-cluster; opt-in) ---
-# cephadm auto-deploys alertmanager but with NO receiver, so the ~89 Prometheus
-# alert rules (OSD down, host down, PG degraded, near-full) fire into the default
-# null route and no human is notified. Set this to one or more webhook URLs (a
-# chat incoming-webhook, or a pager like Opsgenie/PagerDuty, or a FUTO endpoint)
-# and the alertmanager service spec routes all alerts there via cephadm's
-# user_data.default_webhook_urls. Values may be op:// refs resolved before the
-# play. EMPTY by default: no receiver is wired (cephadm default is unchanged), and
-# verify.yml warns that alert delivery is not configured. TODO(operator): set the
-# destination for spice.
+# cephadm deploys alertmanager with NO receiver, so the ~89 rules fire into the
+# null route unnoticed. Webhook URLs here are routed via cephadm's
+# user_data.default_webhook_urls; values may be op:// refs. EMPTY default: no
+# receiver wired, verify.yml warns. TODO(operator): set the destination for spice.
 ceph_alertmanager_webhook_urls: []
 
 # Repair cephadm's alertmanager route tree so `default_webhook_urls` is live.
-#
-# WHY: upstream's 'ceph-dashboard' child route carries no matchers, so it
-# matches every alert. Its `continue: true` is emitted only inside the
-# snmp_gateway_urls conditional. Alertmanager falls back to the parent receiver
-# only when no child matched. On a cluster with no SNMP gateway, every alert
-# therefore stops at 'ceph-dashboard' and never reaches 'default', which is
-# where the webhooks above land. Notifications report success; nothing arrives.
-#
-# Required whenever ceph_alertmanager_webhook_urls is non-empty, because without
-# it that setting is inert. It stays a separate flag because it rewrites a
-# cephadm-managed config, so setting a webhook URL never rewrites that config on
-# its own.
+# Upstream's 'ceph-dashboard' child route has no matchers and `continue: true`
+# only under snmp_gateway_urls, so without SNMP every alert stops there and
+# 'default' (the webhooks) never fires -- silently. Required whenever
+# ceph_alertmanager_webhook_urls is non-empty; separate flag because it rewrites
+# a cephadm-managed config.
 ceph_alertmanager_fix_route_tree: false
 
-# Drop the `description` label from alerts before they reach alertmanager.
-#
-# WHY: `ceph_pool_metadata` carries a label named `description`, whose value is
-# the pool's EC profile (`ec:16+4`, `replica:3`). Three rules join that metric
-# with group_left and inherit the label: CephPGsUnclean, CephPGsInactive,
-# CephPoolGrowthWarning. Zulip's alertmanager integration resolves its `desc`
-# field against labels first and annotations second. With `desc=description`
-# those three alerts render as the string `ec:16+4` instead of their annotation.
-#
-# The label is incidental pool metadata. Nothing routes, silences or groups on
-# it. This relabels alerts only, so the metric keeps the label and dashboards
-# are unaffected.
-#
-# Only meaningful when the receiver resolves annotations by name. Harmless
-# otherwise, but defaults false so no cluster changes alert content implicitly.
+# Drop the `description` label from alerts (relabel only; metric/dashboards keep it).
+# ceph_pool_metadata's `description` label (EC profile, e.g. `ec:16+4`) is
+# group_left-inherited by CephPGsUnclean/CephPGsInactive/CephPoolGrowthWarning;
+# Zulip resolves `desc` against labels before annotations, so those alerts render
+# as `ec:16+4`. Nothing routes/silences/groups on the label. Defaults false so no
+# cluster changes alert content implicitly.
 ceph_prometheus_drop_description_label: false

--- a/ansible/ceph/roles/ceph_deploy/meta/main.yml
+++ b/ansible/ceph/roles/ceph_deploy/meta/main.yml
@@ -1,13 +1,7 @@
 ---
-# Advisory: os_tuning and hardware_tuning should run before this role.
-# Not declared as hard dependencies because the tuning playbooks are
-# separate operational steps, not automatic prerequisites.
-#
-# Execution order:
-#   1. provision_host (bare metal → Debian)
-#   2. os_tuning (sysctl, ulimits)
-#   3. hardware_tuning (I/O scheduler, readahead)
-#   4. ceph_deploy (this role)
+# Advisory order: provision_host -> os_tuning -> hardware_tuning -> ceph_deploy.
+# The tuning roles are not hard dependencies because their playbooks are separate
+# operational steps.
 dependencies: []
 
 galaxy_info:

--- a/ansible/ceph/roles/ceph_deploy/tasks/bootstrap.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/bootstrap.yml
@@ -1,5 +1,4 @@
 ---
-# Phase 2: Bootstrap cluster (first node only)
 
 - name: Check if Ceph cluster already exists
   ansible.builtin.stat:
@@ -69,15 +68,10 @@
     # its SSH key to managed hosts during `ceph orch host add`. No
     # manual capture or distribution needed.
 
-# --- Idempotent dashboard password enforcement ---
-# The bootstrap task above only sets the dashboard password on the very first
-# `cephadm bootstrap` (guarded by `not ceph_conf.stat.exists`), and
-# `--dashboard-password-noupdate` means it is never re-applied afterwards. If a
-# cluster was ever bootstrapped out-of-band (or before this var existed),
-# cephadm generated a *random* admin password and no playbook run would ever
-# correct it; the vaulted password stays aspirational. These tasks reconcile
-# the running cluster to `ceph_dashboard_password` on every converge, so the
-# vault is the single source of truth for both initial set and rotation.
+# Bootstrap sets the password only on first run (--dashboard-password-noupdate
+# never re-applies), so an out-of-band bootstrap leaves a random admin password
+# forever. Reconcile to ceph_dashboard_password every converge -- the vault is
+# the single source of truth for initial set and rotation.
 - name: Write dashboard password to temp file (reconcile)
   ansible.builtin.copy:
     content: "{{ ceph_dashboard_password }}"

--- a/ansible/ceph/roles/ceph_deploy/tasks/crush-rules.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/crush-rules.yml
@@ -1,6 +1,4 @@
 ---
-# Phase 5.5: Create CRUSH device-class rules
-# Ensures pools can target HDD-only or SSD-only OSDs
 
 - name: Check existing CRUSH rules
   ansible.builtin.command: ceph osd crush rule ls

--- a/ansible/ceph/roles/ceph_deploy/tasks/join.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/join.yml
@@ -1,9 +1,6 @@
 ---
-# Phase 3: Add nodes to cluster (from bootstrap node)
-#
-# Only attempts to add hosts that are in the current play (--limit aware).
-# This prevents failures when nodes are defined in inventory
-# but not yet available.
+# --limit aware: only adds hosts in the current play, so not-yet-available
+# inventory nodes don't fail it.
 
 - name: Build list of joinable hosts
   ansible.builtin.set_fact:
@@ -13,11 +10,9 @@
          | list }}
   when: inventory_hostname in groups['ceph_bootstrap']
 
-# cephadm adds hosts by SSHing to root@<addr> with the cluster key it generated
-# at bootstrap (/etc/ceph/ceph.pub). On a fresh install that key is not yet in
-# the join nodes' root authorized_keys, so `ceph orch host add` fails with
-# "Permission denied". Distribute it here (ansible connects as ansible-iac and
-# becomes root) before adding the hosts.
+# cephadm SSHes root@<addr> with its bootstrap key (/etc/ceph/ceph.pub); on a
+# fresh install the key isn't in the join nodes' root authorized_keys yet and
+# `ceph orch host add` fails "Permission denied". Distribute it first.
 - name: Get cephadm cluster SSH pubkey from the bootstrap node
   ansible.builtin.command: ceph cephadm get-pub-key
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
@@ -70,7 +65,6 @@
 - name: Add remaining nodes to Ceph cluster
   ansible.builtin.shell: |
     set -o pipefail
-    # Check if host already added
     if ceph orch host ls --format json |
        grep -q '"{{ hostvars[item]['hostname_short'] }}"'; then
       echo "Host {{ hostvars[item]['hostname_short'] }} already in cluster"

--- a/ansible/ceph/roles/ceph_deploy/tasks/lvm-setup.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/lvm-setup.yml
@@ -1,38 +1,17 @@
 ---
-# Phase 4.5: Ensure Ceph block.db LVM is set up on each node (sietch-shape only)
-#
-# This task is sietch-shape-specific: it assumes dual SAS-attached SSDs each
-# with partition 5 -> its own VG, with 6 db-slot LVs per VG (12 total). It
-# ensures PVs, VGs, and LVs exist. Idempotent - skips if already present.
-# Provides a recovery path if the LVM was destroyed by `mise run destroy`.
-#
-# Painbox-shape (Hetzner SX295, NVMe RAID-1 -> single vg0 with all LVs created
-# by installimage post-install) skips the whole block - its host_vars don't
-# define `sas_path_prefix` so the gate below short-circuits.
-#
-# Required host_vars (sietch-shape only):
-#   sas_path_prefix  - by-path prefix for SSD discovery (e.g., pci-0000:02:00.0-sas-exp...)
-#   ssd1_phy, ssd2_phy - PHY slot numbers for the two SSDs
-#   ceph_db_vg1, ceph_db_vg2 - VG names for SSD1/SSD2 partition 5
-#
-# VG mapping: ceph_db_vg1 on SSD1 partition 5, ceph_db_vg2 on SSD2 partition 5
-# LV naming: db-slot0..5 on VG1, db-slot6..11 on VG2 (one per HDD OSD)
-
-# NVMe-RAID shape (spice): a single vg0 on the NVMe RAID-1 already carries the
-# OS LVs from installimage. Create the block.db LVs (one per HDD OSD) + one
-# ssd-osd LV here at converge, before osds.yml. This replaces painbox's fragile
-# installimage -x chroot post-install with an idempotent, observable ansible
-# step. Gated on ceph_db_lvs_per_node (spice sets it; genuinely
-# externally-managed hosts do not).
+# Also the recovery path after `mise run destroy`. Two shapes, gated on host_vars:
+# - sietch (sas_path_prefix + ssd1/2_phy + ceph_db_vg1/2): dual SAS SSDs,
+#   part5 -> own VG, db-slot0..5 on VG1 / 6..11 on VG2 (one per HDD OSD).
+# - spice NVMe-RAID (ceph_db_lvs_per_node, no sas_path_prefix): single vg0 from
+#   installimage; db LVs + ssd-osd created here at converge, before osds.yml
+#   (replaces painbox's fragile installimage -x chroot post-install).
 - name: Set up LVM (NVMe-RAID single-vg0 topology)
   when:
     - sas_path_prefix is undefined
     - ceph_db_lvs_per_node is defined
-  # DATA SAFETY: never let lvol SHRINK an existing LV -- reconciling a drifted
-  # db-slot down would truncate a live block.db and corrupt the OSD. shrink:false
-  # means lvol still creates and may grow, but leaves a larger existing LV alone
-  # (the old shell skipped existing LVs entirely). opts -Wy wipes stale signatures
-  # on (re)created LVs, preserving the destroy->recreate recovery-path freshness.
+  # DATA SAFETY: shrink:false -- shrinking a drifted db-slot would truncate a
+  # live block.db and corrupt the OSD (create/grow still allowed). -Wy wipes
+  # stale signatures on (re)created LVs (destroy->recreate freshness).
   module_defaults:
     community.general.lvol:
       shrink: false
@@ -50,12 +29,9 @@
         state: present
       loop: "{{ range(0, ceph_db_lvs_per_node | int) | list }}"
 
-    # ssd-osd is sized as (vg0 free - reserve); lvol has no "free minus N GiB"
-    # primitive, so compute the GiB with a read-only shell and feed it to lvol.
-    # Gate the compute + create on the LV being absent: once ssd-osd exists, vg0
-    # free == reserve, so recomputing would yield <= 0 and the original shell's
-    # FATAL guard would (correctly) refuse -- and an unforced lvol resize would
-    # fail. The existence check preserves that idempotency exactly.
+    # lvol has no "free minus N GiB" primitive; compute via shell. Gate on the
+    # LV being absent: once ssd-osd exists, vg0 free == reserve, so a recompute
+    # would yield <= 0 and trip the FATAL guard.
     - name: Check whether the ssd-osd LV already exists on vg0
       ansible.builtin.command: lvs {{ ceph_db_vg }}/{{ ceph_ssd_osd_lv }}
       register: vg0_ssd_check
@@ -99,7 +75,6 @@
       ansible.builtin.debug:
         msg: "{{ vg0_lvm_state.stdout_lines }}"
 
-# Genuinely externally-managed LVM (neither sietch dual-SSD nor spice NVMe-RAID).
 - name: Skip in-role LVM setup (externally-managed LVM)
   ansible.builtin.debug:
     msg: >-
@@ -143,10 +118,9 @@
       changed_when: false
       failed_when: false
 
-    # lvg runs "pvcreate -f" but not "--yes", so it will not clear a stale
-    # foreign (ceph/ext) signature on a reused partition. Preserve the original
-    # wipefs -af, gated exactly as before on the VG being absent, so we never
-    # wipe a live PV. lvg then creates the PV+VG idempotently.
+    # lvg runs "pvcreate -f" without "--yes", so it won't clear a stale foreign
+    # (ceph/ext) signature on a reused partition; wipefs -af first, gated on the
+    # VG being absent so a live PV is never wiped.
     - name: Wipe stale signatures on SSD1 partition 5
       ansible.builtin.command: wipefs -af {{ ssd1_dev.stdout }}5
       when: vg1_check.rc != 0
@@ -169,9 +143,7 @@
         pvs: "{{ ssd2_dev.stdout }}5"
         state: present
 
-    # Fixed slots first, then the 100%FREE remainder, so the remainder LV only
-    # claims the space left after the fixed LVs (matches the sequential order of
-    # the original single-loop shell).
+    # Fixed slots first so the 100%FREE remainder only claims what is left.
     - name: Create fixed-size block.db LVs on VG1 (slots 0-4 at 240G)
       community.general.lvol:
         vg: "{{ ceph_db_vg1 }}"
@@ -202,12 +174,9 @@
         size: 100%FREE
         state: present
 
-    # --- SSD OSD data LVs (partition 6) ---
-    # part6 of each SSD is the SSD-class OSD data device. cephadm cannot deploy
-    # an OSD on a bare partition (only a whole disk or an LV), so wrap each
-    # part6 in its own VG + a 100%FREE LV that ceph_ssd_osds references as
-    # `<vg>/osd-ssd`. Gated on ceph_ssd_vg1/2: clusters that want no SSD tier
-    # simply omit those vars and these tasks no-op.
+    # cephadm can't deploy an OSD on a bare partition (whole disk or LV only):
+    # wrap each part6 in a VG + 100%FREE LV referenced as `<vg>/osd-ssd`.
+    # Gated on ceph_ssd_vg1/2; clusters without an SSD tier omit them.
     - name: Check if SSD OSD VG1 exists
       ansible.builtin.shell: vgs {{ ceph_ssd_vg1 }} 2>/dev/null
       register: ssd_vg1_check

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -1,14 +1,5 @@
 ---
-# Phase 5.8: Monitoring stack - dashboard integration
-#
-# cephadm auto-deploys the full monitoring stack (node-exporter,
-# ceph-exporter, prometheus, alertmanager, grafana) during bootstrap.
-# This task file only:
-#   1. Ensures the prometheus mgr module is enabled
-#   2. Waits for all monitoring daemons to come up
-#   3. Configures dashboard integration URLs and credentials
-
-# --- Step 1: Enable prometheus mgr module ---
+# cephadm auto-deploys the monitoring daemons at bootstrap; nothing here deploys them.
 
 - name: Check prometheus mgr module status
   ansible.builtin.shell: |
@@ -31,8 +22,6 @@
     - inventory_hostname in groups['ceph_bootstrap']
     - "'disabled' in prometheus_module.stdout"
   changed_when: true
-
-# --- Step 2: Wait for cephadm to deploy monitoring ---
 
 - name: Wait for monitoring daemons to start
   ansible.builtin.shell: |
@@ -62,14 +51,10 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-# --- Step 2.5: Re-spec the monitoring stack (fabric bind + alert delivery) ---
-# cephadm auto-deployed the stack binding all interfaces and with NO alertmanager
-# receiver. Re-apply the spec to (a) restrict the bind to ceph_bind_networks
-# (fabric-only on spice, so ceph never listens on the WAN) and (b) route alerts to
-# ceph_alertmanager_webhook_urls. Placement matches cephadm's defaults, so no
-# daemon relocates. Each piece is independently gated in the template, and the
-# whole re-spec is SKIPPED when BOTH are empty (flat clusters with no alerting, like
-# sietch) - the auto-deployed stack is then left exactly as cephadm shipped it.
+# Auto-deployed stack binds all interfaces with NO alertmanager receiver; re-spec
+# restricts binds to ceph_bind_networks and routes alerts to
+# ceph_alertmanager_webhook_urls. Placement matches cephadm defaults (no daemon
+# relocates); skipped entirely when BOTH are empty (sietch keeps the stock stack).
 - name: Render monitoring service spec (fabric bind + alert receiver)
   ansible.builtin.template:
     src: monitoring-spec.yaml.j2
@@ -84,12 +69,10 @@
       or (ceph_alertmanager_webhook_urls | default([]) | length) > 0
   register: monitoring_spec_render
 
-# `ceph orch apply -i` exits 0 even when the mgr rejects the spec, so rc alone
-# proves nothing. cephadm parses every document in the file before it applies
-# any of them, so one rejected document discards the whole apply. The result is
-# a silent no-op that reads as a successful converge. Seen 2026-07-31: a
-# `networks:` key on the ceph-exporter document failed the apply while the play
-# reported ok, so an updated alertmanager webhook URL never reached the cluster.
+# `ceph orch apply -i` exits 0 even when the mgr rejects the spec, and one bad
+# document discards the whole multi-doc apply -- a silent no-op that reads as a
+# successful converge (2026-07-31: `networks:` on the ceph-exporter doc dropped
+# an updated webhook URL). Hence the stderr/stdout failed_when.
 - name: Apply monitoring service spec
   ansible.builtin.command: ceph orch apply -i /etc/ceph/monitoring-spec.yaml
   when:
@@ -104,23 +87,12 @@
       or 'Invalid argument' in (monitoring_spec_apply.stderr | default(''))
       or 'Error' in (monitoring_spec_apply.stdout | default(''))
 
-# --- Step 2.55: Correct the alertmanager route tree ---
-#
-# Without this the webhook configured above is never reached. cephadm's shipped
-# alertmanager.yml.j2 gives the 'ceph-dashboard' child route no matchers, so it
-# matches every alert, and emits its `continue: true` only when an SNMP gateway
-# is configured. Alertmanager dispatches to the parent's receiver ONLY when no
-# child matched, so every alert terminates at 'ceph-dashboard' and 'default' --
-# where default_webhook_urls land -- never fires. Notifications report success
-# the whole time, so the failure is silent.
-#
-# cephadm renders service configs through a template that first checks the mon
-# config-key store (mgr/cephadm/<name minus .j2>), falling back to the packaged
-# one. Storing a corrected copy there is the supported override; see the header
-# of files/alertmanager.yml.j2 for the diff against upstream.
-#
-# Gated on a webhook actually being configured: a cluster with no receiver has
-# nothing to deliver and is left on the stock template.
+# Stock cephadm alertmanager.yml.j2 gives the 'ceph-dashboard' child route no
+# matchers and `continue: true` only with an SNMP gateway, so every alert
+# terminates there and 'default' (where the webhook lands) never fires --
+# silently. Fix = store a corrected copy in the mon config-key store
+# (mgr/cephadm/<name minus .j2>), cephadm's supported override; diff vs upstream
+# in the header of files/alertmanager.yml.j2. Gated on a webhook being configured.
 - name: Stage corrected alertmanager config template
   ansible.builtin.copy:
     src: alertmanager.yml.j2
@@ -166,35 +138,16 @@
     - alertmanager_template_set is changed
   changed_when: true
 
-# --- Step 2.6: Pin the mgr dashboard + prometheus module bind to the fabric ---
-#
-# The dashboard (8443) and the prometheus mgr module (9283) run INSIDE the active
-# ceph-mgr, not as standalone cephadm daemons, so the monitoring re-spec above
-# does not reach them -- they bind :: (every interface, WAN included) and are
-# closed only by nftables. Pin each mgr instance's own server_addr to that
-# instance's fabric IP (ceph_service_ip) so whichever mgr is active listens on
-# the fabric, never the WAN.
-#
-# PER-INSTANCE, not global: the active mgr fails over across the mgr hosts and
-# each host has a DIFFERENT fabric IP (ceph_service_ip = 10.40.20.<index>). A
-# single global mgr/dashboard/server_addr would bind a foreign IP after failover
-# and the dashboard could not start. Ceph resolves the localized key
-# mgr/<module>/<mgr_id>/server_addr ahead of the global one (the module reads it
-# via get_localized_module_option), and each mgr reads ITS OWN value when its
-# module starts serving (on mgr start / failover), so per-instance binding is
-# inherently failover-safe. The mgr_id is the cephadm daemon name (<host>.<rand>,
-# e.g. spice-ceph-adelia.abcdef), NOT hostname_short -- it is discovered at
-# runtime from `ceph orch ps`, and the daemon's host is mapped back to that
-# host's ceph_service_ip.
-#
-# TIMING: the new bind takes effect the next time each mgr (re)starts its module
-# (mgr restart, failover, or upgrade); nftables keeps the WAN closed until then.
-# We deliberately do NOT force a live module reload (disable/enable) -- that would
-# drop the dashboard mid-converge for no durability gain, and the per-instance
-# config can never leave the dashboard unbindable the way a global one could.
-#
-# Opt-in: only when ceph_bind_networks is non-empty. sietch (empty) is a no-op
-# and keeps cephadm's bind-all default.
+# Dashboard (8443) + prometheus module (9283) run INSIDE the mgr, so the re-spec
+# above misses them; unpinned they bind :: (WAN included), closed only by nftables.
+# PER-INSTANCE keys (mgr/<module>/<mgr_id>/server_addr), not global: mgr fails
+# over across hosts with different fabric IPs, and a global key would bind a
+# foreign IP post-failover, leaving the dashboard unable to start. The localized
+# key wins and each mgr reads its own on module start -> failover-safe. mgr_id is
+# the cephadm daemon name (<host>.<rand>), NOT hostname_short; discovered from
+# `ceph orch ps`. Takes effect on next module (re)start; deliberately no forced
+# disable/enable (would drop the dashboard mid-converge for no gain). Opt-in via
+# ceph_bind_networks; sietch (empty) keeps bind-all.
 - name: Pin mgr dashboard + prometheus module bind to the fabric (per mgr instance)
   ansible.builtin.shell: |
     set -o pipefail
@@ -238,25 +191,14 @@
   register: mgr_module_bind
   changed_when: "'CHANGED' in (mgr_module_bind.stdout | default(''))"
 
-# --- Step 2.7: Monitoring config overrides (derived from the shipped template) ---
-#
-# cephadm renders every monitoring config from a Jinja template.
-# TemplateMgr.render() reads the mon config-key store at
-# mgr/cephadm/services/<path> before the packaged template (cephadm/template.py:
-# `store_name = name.rstrip('.j2')`). cephadm renders a stored value as Jinja
-# with the same context, so an override keeps the dynamic parts intact: service
-# discovery URLs, TLS branches, fsid.
-#
-# These overrides are derived, not pinned. The task reads the template that the
-# running mgr ships and injects a small block at an asserted anchor. It does not
-# commit a copy of the upstream file. A committed copy goes stale on every Ceph
-# upgrade and someone has to re-diff it by hand. Deriving picks up an upgraded
-# template on the next converge. The cost is a dependency on an anchor string,
-# so each injection asserts its anchor and fails the play rather than storing a
-# config built on a guess.
-#
-# Two overrides, independently gated. Each flag's default carries the why:
-# ceph_alertmanager_fix_route_tree, ceph_prometheus_drop_description_label.
+# TemplateMgr.render() reads mgr/cephadm/services/<path> from the config-key
+# store before the packaged template (template.py: name.rstrip('.j2')) and still
+# renders it as Jinja, so dynamic parts (discovery URLs, TLS, fsid) survive.
+# Overrides are DERIVED, not pinned: read the running mgr's template, inject at
+# an asserted anchor -- a committed upstream copy would go stale on every Ceph
+# upgrade. Anchor mismatch fails the play rather than storing a guess. Two
+# overrides, independently gated; the why lives on each flag's default
+# (ceph_alertmanager_fix_route_tree, ceph_prometheus_drop_description_label).
 - name: Derive and store the cephadm monitoring config overrides
   ansible.builtin.shell: |
     set -o pipefail
@@ -391,18 +333,12 @@
   changed_when: "'CHANGED' in (monitoring_overrides.stdout | default(''))"
   tags: [alert_rendering]
 
-# cephadm only re-renders a monitoring config when it redeploys the daemon, so
-# the config-key writes above are inert until each daemon is redeployed. Gated on
-# that specific service having changed, so a steady-state converge bounces
-# nothing and a prometheus-only change does not interrupt alert delivery.
-#
-# alertmanager also redeploys when the service spec itself changed. cephadm saves
-# a new spec but does NOT redeploy on a `user_data` change -- the webhook URL is
-# not part of the daemon's dependency hash, so the running alertmanager keeps
-# serving the old config indefinitely. Observed 2026-07-31: spec saved at
-# 19:04:12, daemon still 15m old and still rendering the previous URL six minutes
-# later. Without this, changing the receiver URL is a no-op until something else
-# happens to bounce the daemon.
+# cephadm re-renders monitoring configs only on redeploy, so the config-key
+# writes above are inert until then; gated per service so steady-state bounces
+# nothing. alertmanager also redeploys on spec change: cephadm saves a new spec
+# but does NOT redeploy on a `user_data` change (webhook URL is outside the
+# dependency hash), so a receiver-URL change is otherwise a no-op indefinitely
+# (observed 2026-07-31).
 - name: Redeploy monitoring daemons whose override or spec changed
   ansible.builtin.command: "ceph orch redeploy {{ item }}"
   loop: "{{ ['alertmanager', 'prometheus'] }}"
@@ -414,7 +350,6 @@
   changed_when: true
   tags: [alert_rendering]
 
-# --- Step 3: Configure dashboard integrations ---
 # The dashboard runs on the active mgr and reaches these services on the fabric;
 # advertise ceph_service_ip (fabric on spice), not bond_ip (the 1G WAN), so the
 # URLs stay inside ceph_firewall_trusted_networks after harden.
@@ -446,14 +381,10 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-# --- Step 4: Set Grafana admin credentials ---
-
-# The Grafana admin LOGIN password is seeded by cephadm only at first deploy,
-# and nothing reconciled it, so it drifted from the vault. That broke both
-# direct login at :3000 and the dashboard Grafana API calls below (which
-# authenticate as this same admin user). Enforce it from the vault on every
-# converge. reset-admin-password writes Grafana's sqlite DB on the host volume,
-# so the change persists across container restarts and redeploys.
+# The Grafana admin password is seeded only at first deploy and drifted from the
+# vault, breaking :3000 login and the dashboard API calls below. Enforce from the
+# vault every converge; reset-admin-password writes the sqlite DB on the host
+# volume, so it survives restarts/redeploys.
 - name: Find Grafana container
   ansible.builtin.shell: >
     set -o pipefail;
@@ -482,13 +413,10 @@
     - grafana_container.stdout | default('') | length > 0
   register: grafana_pw_reset
   changed_when: false
-  # grafana-cli exits 0 when there is NO admin user to reset (it prints
-  # "specify a user-id" over an empty user list), so rc alone green-lights a
-  # no-op and the vault password never lands (spice, 2026-07-21: fresh
-  # tentacle grafana ships disable_initial_admin_creation, user table empty,
-  # this task "ok" on every converge). The admin is seeded by
-  # initial_admin_password in the monitoring spec; if it is still absent,
-  # fail loudly instead.
+  # grafana-cli exits 0 with NO admin user to reset ("specify a user-id"), so rc
+  # alone green-lights a no-op (spice 2026-07-21: tentacle grafana ships
+  # disable_initial_admin_creation, empty user table, task "ok" forever). Admin
+  # is seeded by initial_admin_password in the monitoring spec; fail loudly if absent.
   failed_when: >-
     (grafana_pw_reset.rc | default(1)) != 0
     or 'specify a user-id'
@@ -513,13 +441,9 @@
   changed_when: false
   no_log: true
 
-# --- Step 4.5: Provision custom Grafana dashboards ---
-
-# Dashboards committed under files/grafana-dashboards/ are uploaded via the
-# Grafana API as the (now seeded) admin, so they live in the repo instead of
-# hand-uploads that a fresh cluster silently lacks (spice shipped without the
-# RGW capacity dashboard until 2026-07-21). overwrite keeps them converged;
-# the cephadm file-provisioned stock dashboards are untouched.
+# files/grafana-dashboards/ uploaded via the API so a fresh cluster doesn't
+# silently lack hand-uploads (spice missed the RGW capacity dashboard until
+# 2026-07-21). overwrite keeps them converged; stock dashboards untouched.
 - name: Upload custom Grafana dashboards
   ansible.builtin.uri:
     url: "https://{{ hostvars[groups['ceph_bootstrap'][0]]['ceph_service_ip'] }}:{{ ceph_grafana_port }}/api/dashboards/db"
@@ -541,8 +465,6 @@
   changed_when: false
   no_log: true
   tags: [grafana_dashboards]
-
-# --- Step 5: Display monitoring endpoints ---
 
 - name: Show monitoring status
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/ceph_deploy/tasks/osds.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/osds.yml
@@ -1,29 +1,12 @@
 ---
-# Phase 5: Create OSDs via cephadm orch service spec
+# osd-spec.yml.j2 covers both the sietch (SAS expander, sas_path_prefix REQUIRED)
+# and NVMe-RAID (sas_path_prefix omitted) shapes. Required host_vars: ceph_hdd_osds
+# ({path_phy, db}), ceph_ssd_osds ({path_phy+partition} SAS / {lv} NVMe-RAID).
 #
-# Renders a multi-document OSD service spec (one document per host TYPE, see
-# templates/osd-spec.yml.j2) and applies via `ceph orch apply osd`. Cephadm
-# handles per-disk LUKS provisioning, LVM creation, daemon deployment, and
-# CRUSH placement internally; the role no longer iterates disks.
-#
-# Hardware-shape independence: the template's Jinja conditionals handle
-# both sietch (SAS expander + dual-SSD-VG) and NVMe-RAID hosts (PCI-ATA + single
-# NVMe-RAID VG + LV-backed SSD OSD) without per-shape branching here.
-#
-# Required host_vars (per host, in inventories/<cluster>/host_vars/<host>.yml):
-#   ceph_hdd_osds   : list of {path_phy, db} mappings per HDD
-#   ceph_ssd_osds   : list of {path_phy + partition} (SAS shape) or {lv} (NVMe-RAID shape)
-#   sas_path_prefix : REQUIRED for sietch; OMITTED for NVMe-RAID-shape hosts
-#
-# Idempotent: re-applying the same spec is a no-op when OSDs match.
-#
-# Whether cephadm acts on the spec depends on ceph_osd_spec_unmanaged. Left
-# false (sietch) the spec is managed and cephadm picks up new disks on its own,
-# which is the behaviour this role has always had. Set true (spice) the spec is
-# registered but inert, because reconciling a managed spec costs a ceph-volume
-# lvm+raw list per host on every serve-loop pass and that dominated the loop at
-# 48 hosts. Provisioning from an inert spec then needs the explicit window
-# below.
+# ceph_osd_spec_unmanaged: false (sietch) = managed, cephadm auto-adopts new
+# disks; true (spice) = registered but inert -- reconciling a managed spec costs
+# a ceph-volume lvm+raw list per host per serve-loop pass, which dominated the
+# loop at 48 hosts. Inert specs provision only via the window below.
 
 - name: Render OSD service spec on bootstrap node
   ansible.builtin.template:
@@ -55,22 +38,13 @@
     'Scheduled' in (orch_apply.stdout | default(''))
     or 'created' in (orch_apply.stdout | default('') | lower)
 
-# Provisioning window.
-#
-# An unmanaged spec creates nothing, so a cluster that sets
-# ceph_osd_spec_unmanaged has to hand cephadm a bounded interval in which to
-# build the OSDs: set-managed, wait, set-unmanaged. Opt in with
-# `-e ceph_osd_allow_spec_provisioning=true`.
-#
-# INITIAL PROVISIONING ONLY. Do not open this window to rebuild a replaced
-# disk. With one blank disk and one free db slot cephadm may recreate the OSD
-# without its block.db (Ceph tracker #68436, open against 18.2.4), which on the
-# NVMe-RAID shape means block.db silently colocated on the 22TB HDD instead of
-# the vg0 db-slot LV. docs/runbooks/replace-disk.md drives ceph-volume directly
-# for exactly that reason.
-#
-# `always` closes the window even if a wait times out, so a failed run cannot
-# leave the specs managed and the serve loop crawling.
+# Provisioning window for unmanaged specs: set-managed, wait, set-unmanaged.
+# Opt in with `-e ceph_osd_allow_spec_provisioning=true`. INITIAL PROVISIONING
+# ONLY -- never open it to rebuild a replaced disk: cephadm may recreate the OSD
+# without its block.db (Ceph tracker #68436), silently colocating it on the 22TB
+# HDD on the NVMe-RAID shape; docs/runbooks/replace-disk.md drives ceph-volume
+# directly instead. `always` closes the window even on timeout, so a failed run
+# cannot leave specs managed and the serve loop crawling.
 - name: Provision OSDs from the service spec
   vars:
     spec_window: >-
@@ -169,23 +143,16 @@
       changed_when: true
       when: spec_window | bool
 
-# Safety net: an OSD that comes up at reweight 0 because a noin flag was set
-# before this run never takes data until something reweights it back.
-#
-# "up with reweight 0" is ambiguous, though -- it is equally the signature of a
-# drain (`ceph orch osd rm`, or the plain `ceph osd out` that replace-disk.md
-# step 2 prescribes), and nothing in the osdmap distinguishes the two. Guessing
-# wrong is expensive in one direction only: reweighting a draining OSD back to
-# 1.0 refills the disk you are removing, silently and mid-drain, whereas failing
-# to fix a genuinely stuck OSD leaves it visibly at reweight 0 in `ceph osd
-# tree`. So this task corrects an OSD only when it can name the cause:
-#
-#   in the cephadm removal queue  -> skip, cephadm is draining it
-#   noin set                      -> reweight to 1.0, the documented cause
-#   neither                       -> warn and leave alone; someone outed it
-#
-# noin is read before the "clear noin flag" task below unsets it. A `destroyed`
-# OSD needs no special case: it is not `up`, so the status filter passes over it.
+# Safety net: an OSD up at reweight 0 (noin set pre-run) takes no data. But
+# "up with reweight 0" is also the signature of a drain (orch osd rm / manual
+# `ceph osd out` per replace-disk.md), and the osdmap can't tell them apart --
+# reweighting a draining OSD back to 1.0 silently refills the disk being
+# removed, while a stuck OSD is at least visible in `ceph osd tree`. So only
+# correct when the cause is known:
+#   in cephadm removal queue -> skip (draining); noin set -> reweight 1.0;
+#   neither -> warn and leave (someone outed it).
+# noin is read before the clear-noin task below; `destroyed` OSDs are not `up`
+# so the filter skips them.
 
 - name: Fix any OSDs stuck at reweight 0
   ansible.builtin.shell: |
@@ -266,9 +233,6 @@
   register: reweight_fix
   changed_when: "'Fixed' in reweight_fix.stdout"
 
-# Without this the warnings sit unread inside reweight_fix. An OSD left at
-# reweight 0 holds no data, so it is worth putting in front of the operator
-# even though it is deliberately not an error.
 - name: Surface OSDs left at reweight 0
   ansible.builtin.debug:
     msg: "{{ reweight_fix.stdout_lines | select('search', '^WARNING:') | list }}"
@@ -305,10 +269,8 @@
       in MON config-key database
   run_once: true
 
-# Defensive: clear the noin flag if it's set. The current spec-apply flow
-# doesn't set noin (cephadm orch handles backfill rollout gracefully), but
-# a prior failed run of this role's older imperative OSD-creation flow may
-# have set it and not unset it. Unset is idempotent: a no-op when already off.
+# Defensive: the spec-apply flow doesn't set noin, but a failed run of the old
+# imperative flow may have left it set. Unset is a no-op when off.
 
 - name: Defensive - clear noin flag if set
   ansible.builtin.command: ceph osd unset noin

--- a/ansible/ceph/roles/ceph_deploy/tasks/placement.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/placement.yml
@@ -1,13 +1,7 @@
 ---
-# Phase 4: Configure MON and MGR placement
-#
-# MON placement strategy:
-#   1. If ceph_mon group is defined and non-empty: use those hosts (explicit)
-#   2. Else if <=2 active hosts: 1 MON (bootstrap only, avoids 2-MON fragility)
-#   3. Else: MON on all active hosts
-#
-# MGR deploys a capped count (ceph_mgr_count, default 3: 1 active + standbys),
-# not one per host -- cephadm schedules them and caps at the host count.
+# Phase 4: MON/MGR placement. MON: explicit ceph_mon group if non-empty; else
+# 1 MON when <=2 active hosts (avoids 2-MON fragility); else all active hosts.
+# MGR: capped count (ceph_mgr_count), cephadm schedules and caps at host count.
 
 - name: Determine active cluster hosts
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/ceph_deploy/tasks/prerequisites.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/prerequisites.yml
@@ -1,5 +1,4 @@
 ---
-# Phase 1: Prerequisites (all nodes)
 
     # /etc/hosts is managed by the baseline role.
 
@@ -24,11 +23,9 @@
     mode: '0644'
 
 - name: Update apt cache
-  # Always refresh — no cache_valid_time. Hetzner installimage runs apt
-  # during install, leaving the cache "fresh" (~minutes old) but without the
-  # Ceph repo's Packages file. cache_valid_time=3600 here would skip refresh
-  # and apt install would only see Debian's older cephadm (16.x) → version
-  # pin fails. Always-refresh is the safe default for any new repo addition.
+  # Always refresh, no cache_valid_time: installimage leaves a "fresh" cache
+  # without the Ceph repo's Packages file, so a skipped refresh only sees
+  # Debian's cephadm 16.x and the version pin fails.
   ansible.builtin.apt:
     update_cache: true
 
@@ -55,10 +52,9 @@
     mode: '0644'
   notify: Restart sshd
 
-# Apply the kex change NOW. Handlers flush at end of play, so an aborted run
-# leaves the drop-in on disk with the old sshd still offering sntrup761 -- the
-# very hang this task exists to prevent then keeps killing the runs that would
-# have flushed the handler (2026-07-16..20: four days unapplied on spice; hung
-# CI sessions and three mgr serve loops before a manual fleet sshd restart).
+# Apply the kex change NOW, not at end-of-play handler flush: an aborted run
+# leaves sshd still offering sntrup761 and the resulting hang keeps killing the
+# runs that would have flushed it (2026-07-16..20 on spice: four days unapplied,
+# hung CI sessions + three mgr serve loops until a manual fleet sshd restart).
 - name: Flush handlers so the running sshd stops offering sntrup761
   ansible.builtin.meta: flush_handlers

--- a/ansible/ceph/roles/ceph_deploy/tasks/rgw.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/rgw.yml
@@ -1,9 +1,4 @@
 ---
-# Phase 5.75: RadosGW (S3 Object Gateway)
-# Deploys RGW with EC data pool, realm/zonegroup/zone, and S3 service user
-
-# --- Step 1: EC profile ---
-
 - name: Check existing EC profiles
   ansible.builtin.command: ceph osd erasure-code-profile ls
   register: ec_profiles
@@ -20,8 +15,6 @@
     - inventory_hostname in groups['ceph_bootstrap']
     - "ceph_rgw_ec_profile not in ec_profiles.stdout"
   changed_when: true
-
-# --- Step 2-3: EC data pool ---
 
 - name: Check existing pools
   ansible.builtin.command: ceph osd pool ls
@@ -47,10 +40,8 @@
   changed_when: true
 
 - name: Mark the EC data pool as bulk (autoscaler sizing floor)
-  # bulk=true tells the pg_autoscaler to target a pg_num sized for the pool's
-  # expected full capacity, so it will not shrink the pre-seeded pg_num
-  # (ceph_pg_init_data) back toward 1 during the first fill. Idempotent: only sets
-  # when not already true.
+  # bulk=true sizes the autoscaler for full capacity, so it won't shrink the
+  # pre-seeded ceph_pg_init_data back toward 1 during the first fill.
   ansible.builtin.shell: |
     set -o pipefail
     [ "$(ceph osd pool get {{ ceph_rgw_data_pool }} bulk | awk '{print $2}')" = "true" ] || { ceph osd pool set {{ ceph_rgw_data_pool }} bulk true; echo CHANGED; }
@@ -63,13 +54,9 @@
   changed_when: "'CHANGED' in (bulk_flag_result.stdout | default(''))"
 
 - name: Pin EC data pool min_size to k+1 ({{ ceph_rgw_ec_min_size }})
-  # The EC pool otherwise inherits Ceph's default min_size = k+1 implicitly. Pin
-  # it EXPLICITLY so the write-availability floor is documented and cannot drift:
-  # k+1 keeps a PG writable while at least k+1 shards are up, so writes tolerate
-  # up to m-1 host losses while reads still tolerate m. NEVER set below k+1 --
-  # allowing writes at k shards risks data loss if another shard is lost during
-  # recovery. Idempotent get-then-set; gated on the pool existing (fresh run:
-  # create_data_pool changed; re-run: pool already in pool_list).
+  # Pin the implicit default explicitly so the floor can't drift. k+1 = writes
+  # tolerate m-1 host losses, reads m. NEVER below k+1: writes at k shards risk
+  # data loss if another shard dies during recovery.
   ansible.builtin.shell: |
     set -o pipefail
     cur=$(ceph osd pool get {{ ceph_rgw_data_pool }} min_size | awk '{print $2}')
@@ -84,8 +71,6 @@
     - (create_data_pool is changed) or (ceph_rgw_data_pool in pool_list.stdout)
   register: ec_min_size_result
   changed_when: "'CHANGED' in (ec_min_size_result.stdout | default(''))"
-
-# --- Step 4: Replicated index pool ---
 
 - name: Create replicated index pool {{ ceph_rgw_index_pool }}
   ansible.builtin.command: >
@@ -105,8 +90,6 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-# --- Step 5: Replicated non-EC pool (multipart uploads) ---
-
 - name: Create replicated non-EC pool {{ ceph_rgw_extra_pool }}
   ansible.builtin.command: >
     ceph osd pool create {{ ceph_rgw_extra_pool }} replicated
@@ -124,8 +107,6 @@
     executable: /bin/bash
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
-
-# --- Step 6: Pool application tags ---
 
 - name: Check pool application tags
   ansible.builtin.command: "ceph osd pool application get {{ item }}"
@@ -149,19 +130,12 @@
   loop_control:
     label: "{{ item.item | default('skipped') }}"
 
-# --- Step 6.5: Initial PG counts ---
-#
-# Pools are created with pg_num=1 (ceph default). The autoscaler will
-# eventually grow them, but splitting PGs under load causes latency
-# spikes and throughput drops. Pre-sizing avoids this penalty during
-# the first fill. Idempotent: only increases pg_num, never decreases.
+# Pools start at pg_num=1; autoscaler splits under load cause latency spikes, so
+# pre-size before the first fill. Only ever increases pg_num.
 
-# The top-of-file pool_list snapshot predates the data/index/non-EC pools
-# created just above, so on a fresh run 1 it does NOT contain them and every
-# "in pool_list.stdout" gate below would skip - deferring all pre-sizing to a
-# second converge. Re-query now that the explicit pools exist so run 1 sizes
-# them. (The lazily-created .rgw.* system pools are handled later, after the
-# RGW daemon is up.)
+# Re-query: the top-of-file pool_list predates the pools created above, so on run 1
+# the gates below would skip and defer pre-sizing to a second converge. (Lazily
+# created .rgw.* system pools are handled after the RGW daemon is up.)
 - name: Re-query pools after explicit RGW pools are created
   ansible.builtin.command: ceph osd pool ls
   register: pool_list
@@ -207,10 +181,8 @@
     - pg_extra_result.rc != 0
     - "'is not >= current' not in pg_extra_result.stderr | default('')"
 
-# NB: the .rgw.* system-pool PG-count and size/min_size pins are NOT here - those
-# pools are created lazily by the realm/zone setup and the RGW daemon, so they do
-# not exist yet at this point in the play. They are pinned in Step 13.6 below,
-# after the RGW readiness wait, against a freshly re-queried pool list.
+# The .rgw.* system-pool pins run post-RGW-readiness below: those pools are
+# created lazily and do not exist yet here.
 
 - name: Wait for PG peering to complete
   ansible.builtin.shell: |
@@ -237,8 +209,6 @@
   changed_when: false
   timeout: 330
 
-# --- Step 7: Realm ---
-
 - name: Check existing realms
   ansible.builtin.command: radosgw-admin realm list
   register: realm_list
@@ -260,8 +230,6 @@
     radosgw-admin realm default --rgw-realm={{ ceph_rgw_realm }}
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
-
-# --- Step 8: Zonegroup ---
 
 - name: Check existing zonegroups
   ansible.builtin.command: radosgw-admin zonegroup list
@@ -306,8 +274,6 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: "'CHANGED' in (set_api_name.stdout | default(''))"
 
-# --- Step 9: Zone ---
-
 - name: Check existing zones
   ansible.builtin.command: radosgw-admin zone list
   register: zone_list
@@ -328,8 +294,6 @@
     - inventory_hostname in groups['ceph_bootstrap']
     - "ceph_rgw_zone not in (zone_list.stdout | default(''))"
   changed_when: true
-
-# --- Step 10: Zone placement targets ---
 
 - name: Configure zone placement targets for EC pools
   ansible.builtin.shell: |
@@ -368,14 +332,9 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: "'CHANGED' in (zone_placement.stdout | default(''))"
 
-# --- Step 10.5: Zonegroup hostnames ---
-#
-# The dashboard connects to RGW using the node's hostname or IP in the
-# Host header. RGW validates the Host header during S3 signature
-# verification: if the hostname isn't in the zonegroup's hostnames
-# list, signature verification fails with SignatureDoesNotMatch (403).
-# Adding all node hostnames and IPs ensures both dashboard and direct
-# client access work regardless of which address is used.
+# RGW validates the Host header during S3 signature verification: any hostname/IP
+# not in the zonegroup hostnames list fails with SignatureDoesNotMatch (403), so
+# add every node hostname + IP (dashboard and direct clients both work).
 
 - name: Add cluster hostnames and IPs to zonegroup
   ansible.builtin.shell: |
@@ -412,24 +371,13 @@
   register: zonegroup_hostnames
   changed_when: "'CHANGED' in zonegroup_hostnames.stdout"
 
-# --- Step 11: Commit period ---
-#
-# Committing a period is not free: it notifies every RGW watching
-# realms.<realm-id>.control (48 of them on spice). Each one pauses its beast
-# frontend and cancels in-flight connections, so live requests abort with 500s
-# and 409s, and under load the teardown can trip a use-after-free in the
-# frontend teardown path; five RGWs segfaulted that way on 2026-07-27.
-#
-# `period update --commit` is also not idempotent: it bumps the epoch even when
-# the period content is unchanged (epoch 3 -> 4 on 2026-07-27 differed by that
-# single field and nothing else). So only commit when there is something to
-# commit: either a task above changed the realm/zonegroup/zone, or the
-# committed period has drifted from the live zonegroup.
-#
-# The drift probe repairs a run that changed config but died before committing.
-# Its reach is the zonegroup only (creation, api_name, hostnames, endpoints),
-# because that is all the period map carries. Zone params such as placement
-# pools live outside the period, so they are not self-healing here.
+# A commit notifies every RGW on realms.<realm-id>.control; each pauses beast and
+# cancels in-flight requests (500s/409s), and under load the teardown can trip a
+# use-after-free -- five RGWs segfaulted on spice 2026-07-27. `period update
+# --commit` is also NOT idempotent (bumps the epoch even when content is unchanged,
+# seen 2026-07-27). So commit only when a task above changed realm/zonegroup/zone
+# or the committed period drifted. The drift probe covers the zonegroup only (all
+# the period map carries); zone params like placement pools are not self-healing here.
 
 - name: Check whether the committed period matches the live zonegroup
   ansible.builtin.shell: |
@@ -458,8 +406,7 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
   failed_when: false
-  # Read-only probe, so let it run under --check too; otherwise check mode
-  # would skip it and the gate below would report a commit that isn't needed.
+  # Read-only probe; runs under --check too so the commit gate stays accurate.
   check_mode: false
 
 - name: Commit the period
@@ -477,14 +424,6 @@
       ('MATCH' not in (period_drift.stdout | default('')))
   changed_when: true
 
-# --- Step 11.5: rgw_dns_name for virtual-hosted bucket addressing ---
-#
-# With this set, a request to bucket.{{ ceph_rgw_dns_name }} is
-# recognized as the bucket "bucket" rather than a literal bucket whose
-# name is the full FQDN. Clients can then use either path-style
-# ({{ ceph_rgw_scheme }}://{{ ceph_rgw_dns_name }}/bucket/key) or
-# virtual-hosted style ({{ ceph_rgw_scheme }}://bucket.{{ ceph_rgw_dns_name }}/key).
-
 - name: Get current rgw_dns_name
   ansible.builtin.command: ceph config get client.rgw rgw_dns_name
   register: current_rgw_dns_name
@@ -500,30 +439,11 @@
     - "(current_rgw_dns_name.stdout | default('')) | trim != ceph_rgw_dns_name"
   changed_when: true
 
-# --- Step 11.6: Self-signed TLS cert for RGW frontend ---
-#
-# Generated on the bootstrap node via openssl, handed to cephadm via the
-# service spec template below. cephadm distributes the combined PEM to
-# every RGW daemon container on apply.
-#
-# Idempotent via `creates:`; the openssl run only fires if the cert file
-# is absent. To rotate: delete /etc/ceph/rgw-ssl.{crt,key} on the bootstrap
-# node and re-run the role.
-#
-# SANs include:
-#   - the canonical DNS name (CN)
-#   - a wildcard under the same name for virtual-hosted buckets
-#   - per-node FQDNs so direct-host addressing also validates
-#   - per-node bond IPs so IP-based S3 clients also validate
-#   - the RGW ingress VIP (only when ceph_rgw_ingress_enabled) so a client hitting
-#     the health-checked VIP, where haproxy terminates TLS with this cert, validates
+# Cert rotation: delete /etc/ceph/rgw-ssl.{crt,key} on the bootstrap node and re-run.
 
-# Build the -subj and SAN as single-line strings up front. Doing this inline in
-# the openssl command forced a backslash-newline INSIDE the quoted args, which
-# folds the next line's indentation into the value (e.g. C="DE    ") and openssl
-# aborts on the over-length field. Precomputing here keeps the shell one flat line
-# per arg. The {%- ... %} whitespace-control strips the fold-inserted spaces so the
-# SAN concatenates with no embedded whitespace.
+# Precompute -subj/SAN: inline backslash-newlines inside quoted openssl args fold
+# the next line's indentation into the value (C="DE    ") and openssl aborts.
+# The {%- %} whitespace control keeps the SAN free of embedded spaces.
 - name: Build RGW self-signed cert subject and SAN
   ansible.builtin.set_fact:
     _rgw_cert_subj: >-
@@ -575,18 +495,10 @@
     - ceph_rgw_ssl | default(false) | bool
   no_log: true
 
-# --- Step 12: Deploy RGW daemons via cephadm service spec ---
-#
-# We render a YAML service spec rather than using `ceph orch apply rgw
-# <realm> <zone> --placement=... --port=...` because the command-line
-# form doesn't accept cert content. The YAML spec supports both
-# `ssl: true` and inline `rgw_frontend_ssl_certificate`, and cephadm
-# distributes the cert to every RGW container.
-#
-# Placement is pinned to groups['ceph_nodes'] (not ansible_play_batch)
-# so a --limit re-run doesn't accidentally shrink the spec and
-# de-deploy daemons on omitted hosts (cephadm is declarative: applying
-# a smaller placement REMOVES daemons).
+# YAML spec (not `ceph orch apply rgw ...` CLI) because only the spec accepts
+# inline rgw_frontend_ssl_certificate. Placement pinned to groups['ceph_nodes'],
+# not the play batch: cephadm is declarative, so a --limit re-run with a smaller
+# placement would REMOVE daemons on omitted hosts.
 
 - name: Render RGW service spec
   ansible.builtin.template:
@@ -603,11 +515,8 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-# --- Step 12.5: Dashboard RGW SSL verify ---
-#
-# With self-signed certs the dashboard's RGW client rejects the cert
-# and returns 500 on the Object Gateway page. Disable verification so
-# the dashboard can talk to the local RGW endpoints.
+# Self-signed cert makes the dashboard's RGW client 500 on the Object Gateway
+# page unless verification is off.
 
 - name: Disable dashboard RGW API SSL verification (self-signed cert)
   ansible.builtin.command: ceph dashboard set-rgw-api-ssl-verify false
@@ -621,8 +530,6 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-# --- Step 13: Wait for RGW daemons ---
-
 - name: Wait for RGW daemons to start
   ansible.builtin.shell: |
     set -eo pipefail
@@ -635,48 +542,24 @@
   args:
     executable: /bin/bash
   register: rgw_running_count
-  # Wait for RGW on the nodes in THIS run (respects --limit), not all ceph_nodes,
-  # so a subset deploy does not block forever waiting for daemons on hosts it never
-  # joined. The rgw-spec placement stays pinned to all ceph_nodes (it must not
-  # shrink on a --limit re-run); only the readiness gate is play-scoped.
+  # Readiness gate is play-scoped (respects --limit) so a subset deploy doesn't
+  # block forever; the rgw-spec placement itself stays pinned to all ceph_nodes.
   until: "(rgw_running_count.stdout | int) >= (groups['ceph_nodes'] | intersect(ansible_play_hosts) | length)"
   retries: 30
   delay: 10
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
 
-# --- Step 13.7: RGW ingress (haproxy + keepalived) -- health-checked S3 VIP ---
-#
-# Opt-in floating VIP in front of RGW in TLS TERMINATION mode: haproxy `mode http`
-# terminates the client's TLS on the VIP with the RGW self-signed cert (reused,
-# combined cert+key -- see template), then re-encrypts to each RGW/beast backend
-# (default-server ssl / verify none). The keepalived VIP + haproxy per-backend
-# health check drop a dead RGW node from rotation instead of blackholing ~1/N of
-# S3 connections.
-#
-# Runs HERE, after the RGW readiness wait above, on purpose: the ingress spec's
-# backend_service references the RGW service, which must already exist and be
-# running before cephadm can wire the ingress to it. It also needs
-# rgw_ssl_cert_combined_pem, the fact built in Step 11.6.
-#
-# WHY TERMINATE, not passthrough: L4 passthrough (`mode tcp`) for an RGW backend
-# requires IngressSpec.use_tcp_mode_over_rgw, a post-20.2.2 upstream field absent
-# on the pinned 20.2.2 (source-verified: an unknown spec key makes `ceph orch
-# apply` TypeError). Terminate is the only health-checked ingress mode available
-# here. haproxy forwards the Host header in mode http, so virtual-hosted buckets
-# keep working against haproxy's wildcard cert.
-#
-# NO 443 COLLISION: haproxy terminates on VIP:{{ ceph_rgw_ingress_frontend_port }},
-# beast binds each node's fabric IP:{{ ceph_rgw_port }} -- distinct sockets. This
-# holds ONLY when the RGW spec restricts beast to a specific IP (ceph_bind_networks
-# non-empty); otherwise beast binds 0.0.0.0 and the co-located VIP bind collides.
-# Asserted below.
-#
-# APPLY ORDERING (cross-tool): the DNS cutover that points s3.<domain> at the VIP
-# is done separately in TF and MUST NOT precede this ingress being live, or S3
-# resolves to a VIP that nothing answers.
-#
-# Idempotent + declarative: `ceph orch apply -i` reconciles to the spec.
+# TLS TERMINATION mode: haproxy terminates on the VIP with the reused RGW cert
+# (combined PEM from Step 11.6), re-encrypts to beast; health checks drop a dead
+# node instead of blackholing ~1/N of S3 connections. Must run AFTER the RGW
+# readiness wait (backend_service must exist). Terminate, not L4 passthrough:
+# passthrough needs IngressSpec.use_tcp_mode_over_rgw, absent on pinned 20.2.2
+# (unknown spec key => `ceph orch apply` TypeError); Host header is forwarded so
+# virtual-hosted buckets keep working. No 443 collision ONLY while beast binds a
+# specific IP (ceph_bind_networks non-empty; asserted below), else 0.0.0.0 collides
+# with the co-located VIP. ORDERING: the TF DNS cutover of s3.<domain> to the VIP
+# MUST NOT precede this ingress being live.
 
 - name: Assert RGW ingress preconditions (VIP + restricted beast bind + RGW ssl)
   ansible.builtin.assert:
@@ -717,20 +600,11 @@
     - (ceph_rgw_ingress_vip | default('')) | length > 0
   changed_when: false
 
-# --- Step 13.6: Pin pools to device-class CRUSH rules ---
-#
-# crush-rules.yml creates replicated_ssd/replicated_hdd but binds no pool, so
-# every replicated pool falls to the default class-agnostic rule and the
-# omap-heavy bucket index lands on HDD while the ssd-osd NVMe tier sits idle.
-# Pin the latency-sensitive index/metadata/mgr pools to the SSD rule and the
-# bulk non-EC pool to HDD.
-#
-# Runs HERE (after RGW readiness) on purpose: .rgw.root and the prod-z1.rgw.*
-# metadata pools are created lazily by the realm/zone setup and the RGW daemon,
-# so a pool snapshot taken before the daemon is up (like the top-of-file one)
-# would miss them. Re-query fresh, and gate each pin on the pool existing now.
-# Opt-in per cluster via ceph_rgw_ssd_pools / ceph_rgw_hdd_pools (empty default
-# leaves a live cluster's pools where they are - re-homing forces a rebalance).
+# crush-rules.yml creates replicated_ssd/hdd but binds no pool; unpinned, the
+# omap-heavy index falls to the class-agnostic default rule on HDD while the NVMe
+# tier idles. Runs after RGW readiness because the .rgw.* pools are created lazily.
+# Opt-in per cluster via ceph_rgw_ssd_pools/hdd_pools -- empty default leaves a
+# live cluster alone (re-homing forces a rebalance).
 
 - name: Re-query pools after RGW is up (system pools are created lazily)
   ansible.builtin.command: ceph osd pool ls
@@ -757,14 +631,10 @@
     - "'is not >= current' not in pg_meta_result.stderr | default('')"
 
 - name: Pin replica size on the RGW metadata + mgr pools (durability)
-  # These otherwise inherit the cluster-spec osd_pool_default_size / min_size,
-  # unlike index/extra which are pinned. Losing 2 OSDs behind a metadata PG would
-  # take out the RGW/mgr control plane, and min_size 1 permits single-replica
-  # writes. Pin to the same replicated size (spice 3/2; sietch stays 2/1 via its
-  # own var). Runs here, after RGW readiness, because these pools are created
-  # lazily by the daemon; the pre-daemon snapshot missed them so run 1 skipped
-  # the pin and they sat at the inherited 2/1 until a second converge. Idempotent:
-  # only sets when the current value differs.
+  # These otherwise inherit osd_pool_default_size/min_size (min_size 1 = single-
+  # replica writes; 2 OSD losses could take out the RGW/mgr control plane). Pin to
+  # ceph_rgw_replicated_size (spice 3/2, sietch 2/1). After RGW readiness because
+  # these pools are lazily created; the pre-daemon snapshot missed them on run 1.
   ansible.builtin.shell: |
     set -o pipefail
     ch=0
@@ -821,11 +691,8 @@
   register: hdd_pin_result
   changed_when: "'CHANGED' in (hdd_pin_result.stdout | default(''))"
 
-# --- Step 13.5: Ensure dashboard RGW user has admin caps ---
-#
-# cephadm auto-creates a "dashboard" RGW user with system=true but
-# zero caps. Without admin caps the dashboard's Object Gateway page
-# returns 403 SignatureDoesNotMatch on every admin API call.
+# cephadm auto-creates the "dashboard" user with system=true but zero caps;
+# without admin caps the Object Gateway page 403s (SignatureDoesNotMatch).
 
 - name: Ensure dashboard RGW user has admin caps
   ansible.builtin.shell: |
@@ -844,8 +711,6 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   register: dashboard_caps
   changed_when: "'CHANGED' in dashboard_caps.stdout"
-
-# --- Step 14: Create S3 user ---
 
 - name: Check if S3 user exists
   ansible.builtin.command: "radosgw-admin user info --uid={{ ceph_rgw_s3_user_uid }}"
@@ -869,13 +734,7 @@
   changed_when: true
   no_log: true
 
-# --- Step 14.5: Metrics-worker RGW admin user (read-only) ---
-#
-# A dedicated RGW user the metrics worker uses to scrape usage/bucket/user
-# stats via the radosgw admin ops API. Keys are TF-minted in 1P
-# (<CLUSTER>_METRICS_WORKER_{ACCESS,SECRET}_KEY) and passed here so the consumer
-# is pre-configured with matching credentials. Read-only admin caps only -- it
-# can read stats but cannot mutate buckets or users.
+# Metrics-worker keys are TF-minted in 1P (<CLUSTER>_METRICS_WORKER_{ACCESS,SECRET}_KEY).
 
 - name: Check if metrics-worker RGW user exists
   ansible.builtin.command: "radosgw-admin user info --uid={{ ceph_rgw_metrics_user_uid }}"
@@ -917,17 +776,10 @@
   register: metrics_caps
   changed_when: "'CHANGED' in metrics_caps.stdout"
 
-# --- Step 15: Converge S3 user keys to the 1P canonical key (gated rotation) ---
-#
-# For clusters that predate the predetermined-keys pattern, the user exists
-# with a cephadm-generated random key instead of the 1P one. When rotate_s3_keys
-# is set, converge to exactly the canonical 1P key: add it if missing, then
-# retire every other (stray) key so no undocumented credential is left valid.
-# Gated behind rotate_s3_keys because rotating a live S3 key is disruptive to
-# whatever already uses it. The canonical key is added before any stray is
-# removed, so the user is never left without a working key. (A stray with the
-# same access key but a different secret is not auto-corrected; that is rare and
-# would need a manual key create.)
+# Pre-pattern clusters carry a cephadm-generated random key. Gated behind
+# rotate_s3_keys (rotating a live key is disruptive). Canonical key is added
+# before strays are retired, so the user is never keyless. A stray sharing the
+# access key with a different secret is not auto-corrected (manual key create).
 
 - name: Get current S3 user info
   ansible.builtin.command: "radosgw-admin user info --uid={{ ceph_rgw_s3_user_uid }}"
@@ -1003,8 +855,6 @@
       - "Path-style:        {{ ceph_rgw_scheme }}://{{ ceph_rgw_dns_name }}:{{ ceph_rgw_port }}/<bucket>"
   when: inventory_hostname in groups['ceph_bootstrap']
   no_log: false
-
-# --- Step 16: Show RGW status ---
 
 - name: Show RGW status
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/ceph_deploy/tasks/verify.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/verify.yml
@@ -1,5 +1,4 @@
 ---
-# Phase 6: Verify cluster health
 
 - name: Show cluster status
   ansible.builtin.shell: |
@@ -43,12 +42,9 @@
     msg: "{{ cluster_status.stdout_lines }}"
   when: inventory_hostname in groups['ceph_bootstrap']
 
-# --- Drift guard: assert the live dashboard credential matches the vault ---
-# Functional check (dependency-free: no bcrypt needed). We discover the
-# dashboard URL from `ceph mgr services` and attempt an API login with the
-# vaulted credential; HTTP 201 means the cluster password matches IaC. If the
-# bootstrap reconcile task is ever removed or fails, this fails the play loudly
-# instead of letting the credential silently drift.
+# Functional check, dependency-free (no bcrypt): an API login with the vaulted
+# credential returns HTTP 201 only when the cluster password still matches IaC.
+# Without it, a removed or failed bootstrap reconcile would drift silently.
 - name: Probe dashboard login with the vaulted credential
   ansible.builtin.shell: |
     set -o pipefail
@@ -85,12 +81,9 @@
       Re-run the ceph_deploy role to reconcile, or investigate an out-of-band change.
   when: inventory_hostname in groups['ceph_bootstrap']
 
-# --- Validation: device-class CRUSH pool placement ---
-# Guards the "rule created but no pool bound" failure mode surfaced by the deep
-# review: assert every pool we intended on a tier actually carries that rule, and
-# that the SSD rule bound to live OSDs (a rule whose device class has zero OSDs
-# selects nothing and leaves the pinned pool's PGs inactive). Only runs when the
-# cluster opts in to pinning (ceph_rgw_ssd_pools / _hdd_pools); skips absent pools.
+# Guards "rule created but no pool bound": every intended pool must carry its
+# tier's rule, and the SSD rule must bind live OSDs -- a rule whose device class
+# has zero OSDs selects nothing and leaves the pinned pool's PGs inactive.
 - name: Validate device-class pool placement
   ansible.builtin.shell: |
     set -o pipefail
@@ -127,7 +120,6 @@
     - inventory_hostname in groups['ceph_bootstrap']
     - crush_placement_check.stdout_lines is defined
 
-# --- Alert delivery status ---
 # cephadm's alertmanager ships with no receiver, so a cluster with no configured
 # webhook routes every alert rule into a null route. Surface this loudly rather
 # than failing the play (the destination is a deliberate per-cluster decision).
@@ -142,12 +134,9 @@
                ~ 'Set ceph_alertmanager_webhook_urls to a webhook/pager endpoint.') }}
   when: inventory_hostname in groups['ceph_bootstrap']
 
-# --- Validation: RGW replicated-pool durability ---
-# Guards the run-1 durability regression surfaced by the deep review: the
-# .rgw.* system pools are created lazily by the RGW daemon, so a size/min_size
-# pin taken before the daemon is up skips them and they sit at the inherited
-# 2/1. Assert every RGW replicated pool that exists carries the cluster's target
-# size/min_size, so a miss fails the play instead of shipping single-replica.
+# The .rgw.* system pools are created lazily by the RGW daemon, so a size/min_size
+# pin taken before the daemon is up skips them and they sit at the inherited 2/1.
+# A miss must fail the play instead of shipping single-replica.
 - name: Validate RGW replicated-pool durability
   ansible.builtin.shell: |
     set -o pipefail

--- a/ansible/ceph/roles/ceph_destroy/tasks/cleanup.yml
+++ b/ansible/ceph/roles/ceph_destroy/tasks/cleanup.yml
@@ -1,16 +1,7 @@
 ---
-# Phase 5: Clean up LVM, device signatures, and leftover Ceph state on all nodes
-#
-# Order matters:
-#   1. Close dm-crypt/LUKS mappings (devices are locked until closed)
-#   2. Remove device-mapper entries
-#   3. Remove LVM volume groups and physical volumes
-#   4. Wipe device signatures (HDD and SSD OSD partitions)
-#   5. Clean stale LVM metadata files
-#   6. Reset failed systemd units
-#   7. Remove Ceph directories
+# ORDER MATTERS: LUKS close (devices locked until closed) -> DM entries -> VGs/PVs
+# -> wipe signatures -> stale LVM metadata -> reset failed units -> remove dirs.
 
-# --- Step 1: Close dm-crypt LUKS mappings ---
 # ceph-volume --dmcrypt creates LUKS volumes on OSD devices. These persist after
 # cephadm rm-cluster and lock the underlying block devices. Must close before wipefs.
 - name: Close dm-crypt LUKS mappings
@@ -29,7 +20,6 @@
   register: luks_cleanup
   changed_when: "'Closing LUKS' in luks_cleanup.stdout"
 
-# --- Step 2: Remove leftover device mapper entries ---
 - name: Remove Ceph device mapper entries
   ansible.builtin.shell: |
     set -o pipefail
@@ -45,7 +35,6 @@
   register: dm_cleanup
   changed_when: "'Removing DM' in dm_cleanup.stdout"
 
-# --- Step 3: Remove Ceph LVM volume groups ---
 # Catches both ceph-db VGs (ceph-db-rear12, ceph-db-rear13) and ceph-volume
 # created VGs (ceph-<uuid> from dmcrypt OSDs).
 - name: Remove Ceph LVM volume groups
@@ -63,7 +52,6 @@
   register: vg_cleanup
   changed_when: "'Removing VG' in vg_cleanup.stdout"
 
-# --- Step 4: Remove LVM physical volumes ---
 # After VG removal, PVs are orphaned (no VG name in pvs output). Must catch BOTH
 # PVs that still reference a ceph VG AND orphaned PVs on HDD/SSD OSD devices.
 - name: Remove Ceph LVM physical volumes (named VGs)
@@ -121,10 +109,8 @@
   register: pv_cleanup_ssd
   changed_when: "'Removing orphaned PV' in pv_cleanup_ssd.stdout"
 
-# --- Step 5: Wipe device signatures ---
-# Wipe ALL rotational (HDD) devices that have any filesystem/LVM/LUKS signatures.
-# Every HDD in these servers is a Ceph OSD - no ambiguity about which to wipe.
-# Only wipes devices that actually have signatures (idempotent on clean disks).
+# Wipes ALL rotational devices with signatures: every HDD in these servers is a
+# Ceph OSD, no ambiguity. Idempotent on clean disks.
 - name: Wipe HDD device signatures
   ansible.builtin.shell: |
     set -o pipefail
@@ -171,9 +157,7 @@
   register: ssd_zap
   changed_when: "'Wiping' in ssd_zap.stdout"
 
-# --- Step 6: Clean stale LVM metadata ---
-# ceph-volume operations generate LVM archive/backup files that accumulate across
-# cluster lifecycles. Hundreds of ceph-* files can build up in /etc/lvm/.
+# ceph-volume accumulates hundreds of ceph-* archive/backup files in /etc/lvm/.
 - name: Remove stale Ceph LVM archive and backup files
   ansible.builtin.shell: |
     REMOVED=0
@@ -188,7 +172,6 @@
   register: lvm_meta_cleanup
   changed_when: "lvm_meta_cleanup.stdout is not search('Removed 0')"
 
-# --- Step 7: Reset failed Ceph systemd units ---
 - name: Reset failed Ceph systemd units
   ansible.builtin.shell: |
     set -o pipefail
@@ -204,7 +187,6 @@
   register: systemd_cleanup
   changed_when: "'Resetting failed unit' in systemd_cleanup.stdout"
 
-# --- Step 8: Remove Ceph directories ---
 - name: Clean up leftover Ceph directories
   ansible.builtin.file:
     path: "{{ item }}"

--- a/ansible/ceph/roles/ceph_destroy/tasks/purge.yml
+++ b/ansible/ceph/roles/ceph_destroy/tasks/purge.yml
@@ -1,7 +1,4 @@
 ---
-# Phase 4: Purge Ceph from all nodes using cephadm
-# This removes all containers, config, and cluster state.
-#
 # cephadm rm-cluster only purges ONE FSID at a time. Join nodes can accumulate
 # containers from multiple cluster FSIDs (e.g., failed bootstrap + rebuild).
 # We discover ALL FSIDs present on each node and purge each one.
@@ -11,15 +8,12 @@
     set -o pipefail
     FSIDS=""
 
-    # Source 1: running ceph cluster
     LIVE=$(timeout 10 ceph fsid 2>/dev/null || true)
     [ -n "$LIVE" ] && FSIDS="$LIVE"
 
-    # Source 2: ceph.conf
     CONF=$(grep -oP '(?<=fsid = )[a-f0-9-]+' /etc/ceph/ceph.conf 2>/dev/null || true)
     [ -n "$CONF" ] && FSIDS="$FSIDS $CONF"
 
-    # Source 3: /var/lib/ceph directories (each FSID has a subdirectory)
     if [ -d /var/lib/ceph ]; then
       for d in /var/lib/ceph/*/; do
         DIRNAME=$(basename "$d")
@@ -29,20 +23,17 @@
       done
     fi
 
-    # Source 4: podman containers with ceph FSID in their name
     UUID_RE='[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}'
     for name in $(podman ps -a --format '{{ '{{' }}.Names{{ '}}' }}' 2>/dev/null \
         | grep -oP "$UUID_RE" || true); do
       FSIDS="$FSIDS $name"
     done
 
-    # Source 5: systemd units referencing ceph FSIDs
     for unit in $(systemctl list-units --all --no-legend 'ceph-*' 2>/dev/null \
         | grep -oP "$UUID_RE" || true); do
       FSIDS="$FSIDS $unit"
     done
 
-    # Deduplicate — output nothing if no FSIDs found
     echo "$FSIDS" | tr ' ' '\n' | sort -u | grep -P '^[a-f0-9]{8}-' || true
   args:
     executable: /bin/bash

--- a/ansible/ceph/roles/ceph_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/defaults/main.yml
@@ -1,55 +1,38 @@
 ---
-# Post-deploy Ceph cluster tuning
-# These require a running cluster (ceph config set / ceph commands).
+# Requires a running cluster (ceph config set).
 
-# Enable telemetry phone-home. Yucca is built in the open, so the cluster
-# contributes anonymized data upstream to the Ceph project (all channels; no
-# contact/org attached; leaderboard off). Set false per-cluster to opt out.
+# Anonymized upstream telemetry (all channels, no contact/org, leaderboard off).
+# Set false per-cluster to opt out.
 ceph_telemetry_enabled: true
 
-# === Ceph config model ===
-#
-# One map instead of a scalar per option. Keys are anything `ceph config set`
-# accepts as its `<who>`: a section (`global`, `osd`, `mon`), a single daemon
-# (`osd.5`), or a section plus a mask (`osd/class:hdd`, `osd/host:<node>`).
-# Ceph resolves those most-specific-first on its own, so per-class and per-host
-# tuning needs no Ansible machinery -- it is another key in this map.
-#
-# Per-host Ceph settings belong here rather than in Ansible host_vars: these
-# tasks run only on the bootstrap node, because the mon config database is
-# cluster-wide state, so another host's host_vars are not in scope. host_vars
-# stays for facts about the machine -- host_index, bond_ip, the disk map.
-#
-# Three layers, merged in tasks/main.yml:
-#   ceph_config_defaults   role                    - safe on any cluster
-#   ceph_config_cluster    group_vars/all/vars.yml - cluster shape
-#   ceph_config_host       group_vars/all/vars.yml - per-host/class exceptions
-# Merged with combine(recursive=True), so a cluster overriding one option keeps
-# the rest of the section instead of replacing it wholesale.
+# Keys are anything `ceph config set` accepts as `<who>`: section (`global`,
+# `osd`), daemon (`osd.5`), or section+mask (`osd/class:hdd`, `osd/host:<node>`)
+# -- Ceph resolves most-specific-first itself. Per-host Ceph settings go HERE,
+# not host_vars: these tasks run only on the bootstrap node (mon config db is
+# cluster-wide) so other hosts' host_vars are out of scope.
+# Three layers merged in tasks/main.yml with combine(recursive=True) (partial
+# override keeps the rest of a section):
+#   ceph_config_defaults (role) < ceph_config_cluster < ceph_config_host (group_vars)
 ceph_config_defaults:
   global:
     mon_target_pg_per_osd: 100
-    # `global`, not `osd`: the active mgr emits PG_NOT_DEEP_SCRUBBED from its
-    # own copy of this option, so an `osd` entry moves the OSD schedule and
-    # leaves the health check warning against the old interval. A cluster that
-    # widens this overrides it here, in `global`.
-    # docs.ceph.com/en/tentacle/rados/operations/health-checks/
+    # `global`, not `osd`: the mgr emits PG_NOT_DEEP_SCRUBBED from its own copy,
+    # so an `osd` entry moves the OSD schedule but leaves the health check on the
+    # old interval. docs.ceph.com/en/tentacle/rados/operations/health-checks/
     osd_deep_scrub_interval: 604800
   osd:
-    # Recovery/backfill. Conservative values sized for a small cluster on a
-    # shared network; a cluster with a dedicated replication fabric should raise
-    # them in its own ceph_config_cluster.
+    # Recovery/backfill, conservative for small/shared-network clusters; raise
+    # per cluster in ceph_config_cluster if it has a dedicated fabric.
     osd_recovery_max_active: 1
     osd_recovery_sleep_hdd: 0.1
     osd_max_backfills: 1
-    # Required for the three options above to stick. Under the mclock scheduler
-    # (the default since Reef) an operator-set recovery limit is reverted to the
-    # mclock default unless this gate is on, and that default is 1000, not 1.
-    # tasks/main.yml applies gate keys ahead of the options they gate and will
-    # not prune the superseded `global` entries until the running OSD values are
-    # confirmed, so a rejected write cannot quietly uncap backfill.
+    # Required for the three options above to stick: under mclock (default since
+    # Reef) operator-set recovery limits silently revert to the mclock default of
+    # 1000 without this gate. main.yml applies gate keys first and only prunes the
+    # superseded `global` entries after confirming running OSD values, so a
+    # rejected write cannot quietly uncap backfill.
     osd_mclock_override_recovery_settings: true
-    # Scrub window -- 2-6 AM. osd_deep_scrub_interval lives in `global` above.
+    # osd_deep_scrub_interval lives in `global` above.
     osd_scrub_begin_hour: 2
     osd_scrub_end_hour: 6
     # BlueStore block.db: 0 means use the entire LV.
@@ -63,30 +46,20 @@ ceph_config_host: {}
 ceph_config_gate_keys:
   - osd_mclock_override_recovery_settings
 
-# Options the gate keys above unlock, confirmed against a running OSD before any
-# prune. These are the ones where a silently-reverted write is dangerous rather
-# than cosmetic: both fall back to the mclock default of 1000.
-#
-# osd_recovery_sleep_hdd is deliberately absent. mclock forces the recovery-sleep
-# options to 0 whatever the database says, so a running OSD reports 0.000000
-# against a declared 0.1 and would fail this check forever. The declared value
-# still matters if a cluster is moved back to the wpq scheduler, so it stays in
-# the model; it just cannot be verified against a live daemon under mclock.
+# Gate-unlocked options, confirmed on a running OSD before any prune (both fall
+# back to mclock's 1000 if silently reverted). osd_recovery_sleep_hdd deliberately
+# absent: mclock forces recovery-sleep to 0 regardless of the db, so the check
+# would fail forever; declared value stays in the model for a wpq fallback.
 ceph_config_gated_options:
   - osd_max_backfills
   - osd_recovery_max_active
 
-# One-time reconciliation: entries this model now owns in another section,
-# left behind by an earlier bootstrap. cephadm bootstrap wrote the recovery
-# throttles into `global` while this role writes `osd`. `osd` wins, so the stale
-# `global` copies changed no behaviour, but they read as intent and sent more
-# than one investigation down the wrong path.
-#
-# This is an explicit allowlist and has to stay one. The mon database also holds
-# keys owned by other systems -- cephadm's per-host osd_memory_target masks, the
-# dashboard credentials, the telemetry channels, container_image -- so pruning
-# "everything the model does not declare" would be destructive. Entries already
-# absent are skipped rather than failing.
+# One-time reconciliation of stale entries from earlier bootstraps (cephadm wrote
+# recovery throttles into `global`; `osd` wins, but the stale copies misled
+# investigations). MUST stay an explicit allowlist: the mon db also holds keys
+# owned by other systems (cephadm osd_memory_target masks, dashboard creds,
+# telemetry, container_image) -- pruning everything undeclared would be
+# destructive. Absent entries are skipped.
 ceph_config_prune:
   - {section: global, name: osd_recovery_max_active}
   - {section: global, name: osd_recovery_sleep_hdd}
@@ -96,9 +69,7 @@ ceph_config_prune:
   # on the old interval. Set runs before rm, so the value never dips.
   - {section: osd, name: osd_deep_scrub_interval}
 
-# Log rotation retention (days)
 ceph_log_retention_days: 30
 
-# Audit logging: records ceph admin commands to the cluster log channel.
-# Viewable via: ceph log last -W audit
+# View the audit log: ceph log last -W audit
 ceph_audit_enabled: true

--- a/ansible/ceph/roles/ceph_tuning/tasks/drift.yml
+++ b/ansible/ceph/roles/ceph_tuning/tasks/drift.yml
@@ -1,8 +1,7 @@
 ---
-# Drift checks for ceph_tuning. Read-only. Bootstrap node only -- these read
-# cluster-wide state from the mon config database, not per-host state.
-# Included by drift.yml via include_role + tasks_from -- see the precedence
-# note in roles/os_tuning/tasks/drift.yml.
+# Read-only, bootstrap node only: these read cluster-wide state from the mon
+# config database, not per-host state. Included via include_role + tasks_from --
+# see the precedence note in roles/os_tuning/tasks/drift.yml.
 #
 # Compares against `ceph config dump` matched on (section, mask, name), reusing
 # the diff engine tasks/main.yml applies with, so drift and converge cannot

--- a/ansible/ceph/roles/ceph_tuning/tasks/main.yml
+++ b/ansible/ceph/roles/ceph_tuning/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-# Post-deploy Ceph cluster tuning.
-# Requires a running cluster -- all tasks use ceph CLI commands.
-# Runs from the bootstrap node only.
-#
-# Every config-set task checks the current value first and only
-# applies changes when needed, so re-runs report accurate changed counts.
-
-# --- Telemetry ---
-
 - name: Check telemetry status
   ansible.builtin.command: ceph telemetry status --format json
   register: telemetry_status
@@ -30,18 +21,13 @@
     - (telemetry_status.stdout | from_json).enabled | default(true)
   changed_when: true
 
-# --- Ceph config model ---
-#
-# Merge the three layers, diff against the live mon database, apply only what
-# differs. The diff is a script rather than a Jinja comparison because
-# `ceph config dump` reports every value as a string (604800.000000 for an int
-# option, "true" for a bool) while the model holds real YAML types, and the
-# `float` filter returns 0.0 for anything non-numeric -- which would read
-# "balanced" and "high_recovery_ops" as equal.
+# Diff is a script, not Jinja: `ceph config dump` stringifies every value while
+# the model holds YAML types, and Jinja's `float` returns 0.0 for non-numerics
+# ("balanced" == "high_recovery_ops").
 
-# A render that predates the TF ceph_config model lacks the generated file;
-# the model would then fall back to role defaults and REVERT cluster tuning
-# (e.g. spice's deep scrub interval back to 7d). Fail instead of converging.
+# A render predating the TF ceph_config model lacks the generated file; falling
+# back to role defaults would REVERT cluster tuning (spice deep scrub back to
+# 7d). Fail instead of converging.
 - name: Require the TF-rendered ceph config (guards against a stale render)
   ansible.builtin.assert:
     that: >-
@@ -84,9 +70,8 @@
       {{ ceph_config_changes.rm | length }} superseded entry(ies) to remove
   when: inventory_hostname in groups['ceph_bootstrap']
 
-# Gate keys sort first (the script orders them), so
-# osd_mclock_override_recovery_settings lands before the recovery limits it
-# gates rather than depending on dict ordering in the model.
+# Gate keys sort first (script-ordered): osd_mclock_override_recovery_settings
+# lands before the recovery limits it gates.
 - name: Apply Ceph config values
   ansible.builtin.command:
     argv: ["ceph", "config", "set", "{{ item.who }}", "{{ item.key }}", "{{ item.value }}"]
@@ -96,12 +81,10 @@
     label: "{{ item.who }}/{{ item.key }}: {{ item.current | default('unset') }} -> {{ item.value }}"
   changed_when: true
 
-# Safety interlock for the prune below. The recovery limits are moving from
-# `global` to `osd`, and under mclock an `osd`-section write can be reverted.
-# If that happened and we removed the `global` copy anyway, the effective value
-# would fall through to the mclock default of 1000 concurrent backfills. So
-# confirm the running daemons actually report the declared values first; a
-# mismatch fails the play with `global` still in place, which is the safe state.
+# Prune interlock: under mclock an `osd`-section write can be silently reverted;
+# removing the `global` copy anyway would drop the effective value to mclock's
+# 1000 backfills. Confirm running OSDs report the declared values first -- a
+# mismatch fails the play with `global` still in place (the safe state).
 - name: Verify gated options landed on a running OSD
   ansible.builtin.shell: |
     set -o pipefail
@@ -162,8 +145,6 @@
     label: "{{ item.section }}/{{ item.name }} (was {{ item.current }})"
   changed_when: true
 
-# --- Crash daemon ---
-
 - name: Verify ceph-crash daemon is deployed
   ansible.builtin.shell: |
     set -o pipefail
@@ -186,8 +167,6 @@
     - (crash_daemon_count.stdout | default('0') | int) == 0
   changed_when: true
 
-# --- Log rotation ---
-
 - name: Check log rotation config exists
   ansible.builtin.find:
     paths: /etc/logrotate.d
@@ -203,8 +182,6 @@
          else 'WARNING: No Ceph logrotate config found' }}
   when: inventory_hostname in groups['ceph_bootstrap']
 
-# --- CRUSH tunables ---
-
 - name: Ensure CRUSH tunables are optimal
   ansible.builtin.shell: |
     set -o pipefail
@@ -217,10 +194,7 @@
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: "'CHANGED' in (crush_tunables.stdout | default(''))"
 
-# --- Prometheus alerting rules ---
-# cephadm ships 89 built-in alert rules across 16 groups (OSD, MON, PG,
-# pool, MDS, hardware, network, etc.). No custom rules needed -- verify
-# they're loaded.
+# cephadm ships 89 rules across 16 groups; no custom rules, just verify loaded.
 
 - name: Verify Prometheus alert rules are loaded
   ansible.builtin.shell: |
@@ -239,8 +213,6 @@
     executable: /bin/bash
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
-
-# --- Audit logging ---
 
 - name: Check audit logging state
   ansible.builtin.command: >
@@ -261,8 +233,6 @@
     - ceph_audit_enabled | bool
     - audit_state.stdout | default('') | trim != 'true'
   changed_when: true
-
-# --- Summary ---
 
 - name: Show applied Ceph tuning
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/fluentbit/defaults/main.yml
+++ b/ansible/ceph/roles/fluentbit/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Ship each node's journald to o11y's VictoriaLogs over the NetBird overlay.
-# One agent per node, straight to the mesh vmauth. No aggregation tier.
+# One agent per node straight to the mesh vmauth over the NetBird overlay; no
+# aggregation tier.
 ceph_fluentbit_enabled: false
 
 # Pinned + dpkg-held: the journald field mapping is version-coupled.
@@ -11,10 +11,9 @@ ceph_fluentbit_repo: >-
   deb [signed-by=/etc/apt/keyrings/fluentbit.gpg]
   https://packages.fluentbit.io/debian/bookworm bookworm main
 
-# /insert/journald is not routed by o11y's mesh vmauth; /insert/jsonline is.
-# The name resolves over the mesh: o11y distributes its DNS zone to the ceph
-# group (immich-app/yucca-o11y#153). Envoy routes by Host/SNI, so connect by
-# name, not by the gateway IP.
+# vmauth routes /insert/jsonline, NOT /insert/journald. Name resolves over the
+# mesh (o11y DNS zone -> ceph group, immich-app/yucca-o11y#153); Envoy routes by
+# Host/SNI, so connect by name, never the gateway IP.
 ceph_fluentbit_o11y_host: vmauth.o11y.futo.network
 ceph_fluentbit_o11y_port: 443
 
@@ -23,38 +22,28 @@ ceph_fluentbit_cluster_label: "{{ cluster_name }}"
 ceph_fluentbit_site_label: htz-fsn1
 ceph_fluentbit_env_label: prod
 
-# Field names these must match, confirmed against fluent-bit v5.0.9 source
-# (plugins/in_systemd/systemd.c). Strip_Underscores drops exactly one leading
-# underscore, and only when the key starts with one (:408), so journald's
-# _HOSTNAME arrives as HOSTNAME while MESSAGE and SYSLOG_IDENTIFIER are already
-# underscore-free and pass through unchanged. That matters because VictoriaLogs
-# reserves _-prefixed names for _msg/_time/_stream.
-# The plugin's `lowercase` option defaults to false (:757) and the role does not
-# set it. If a future version flips that default, every field here arrives
-# lowercased, these stream fields match nothing, and logs still ship with no
-# stream identity - so re-check it on a version bump.
-# SYSLOG_IDENTIFIER is the ceph daemon type: ceph-mon, ceph-mgr, ceph-osd, radosgw.
+# Confirmed against fluent-bit v5.0.9 source (plugins/in_systemd/systemd.c):
+# Strip_Underscores drops exactly one LEADING underscore (:408), so _HOSTNAME ->
+# HOSTNAME (VictoriaLogs reserves _-prefixed names). `lowercase` defaults false
+# (:757); if a future version flips it these fields match nothing and logs ship
+# with no stream identity -- RE-CHECK on any version bump.
+# SYSLOG_IDENTIFIER = ceph daemon type (ceph-mon/-mgr/-osd, radosgw).
 ceph_fluentbit_stream_fields: "HOSTNAME,SYSLOG_IDENTIFIER"
 
-# The fleet emits ~2.4M lines/hour, nearly all mon/mgr status chatter (all 15
-# OSDs on a node emit ~200/hr). These two patterns are most of it. The mon
-# cluster health channel is not matched.
+# Fleet emits ~2.4M lines/hr, nearly all mon/mgr chatter; these two patterns are
+# most of it. The mon cluster health channel is not matched.
 ceph_fluentbit_drop_regex: '(pgmap v[0-9]+|_set_new_cache_sizes)'
 
-# Disk queue for the o11y output. Retries never give up, but the queue is
-# bounded: when it fills, Fluent Bit drops its oldest chunks to make room.
-# This sizes how long a node rides out an o11y or overlay outage. It does not
-# guarantee that nothing is lost.
+# Bounded disk queue (oldest chunks dropped when full): sizes how long a node
+# rides out an o11y/overlay outage, not a no-loss guarantee.
 ceph_fluentbit_buffer_limit: 512M
 
-# Fluent Bit's own metrics. The security role opens this port from the trusted
-# networks alongside the other exporters, so it is reachable once harden.yml has
-# converged. Only the vmagent scrape job itself is still a follow-up.
+# Own metrics port; security role opens it from trusted networks once harden.yml
+# converges. vmagent scrape job still a follow-up.
 ceph_fluentbit_http_port: 2020
-# Bind the fabric VLAN-120 address, not 0.0.0.0. Do not listen on the 1G WAN at
-# all: the bind is the control here, not the nftables drop policy. The fabric is
-# where vmagent scrapes. Tradeoff: NetBird peers cannot reach the endpoint.
+# Bind the fabric VLAN-120 address, never 0.0.0.0/WAN -- the bind is the control,
+# not the nftables drop policy. Tradeoff: NetBird peers cannot reach the endpoint.
 ceph_fluentbit_http_listen: "{{ ceph_public_ip }}"
-# How long the ExecStartPre drop-in waits for that address at boot. LACP and
-# MLAG convergence on the 25G bond is seconds; this is slack, not a real budget.
+# ExecStartPre wait for that address at boot; LACP/MLAG converge in seconds, this
+# is slack.
 ceph_fluentbit_bind_wait_secs: 60

--- a/ansible/ceph/roles/fluentbit/molecule/default/molecule.yml
+++ b/ansible/ceph/roles/fluentbit/molecule/default/molecule.yml
@@ -1,11 +1,9 @@
 ---
-# Template-rendering scenario, same shape as roles/security and
-# roles/ceph_deploy: `mise run test` runs `molecule verify` only, never a
-# converge. That is what makes this role testable at all -- tasks/main.yml
-# installs a pinned .deb from an apt repo, asserts the node is on the NetBird
-# overlay, resolves an o11y name over mesh DNS and starts a systemd unit, none
-# of which exist in a test environment. The rendered config is the part that
-# breaks silently, so the rendered config is what gets exercised.
+# `mise run test` runs `molecule verify` only, never a converge: tasks/main.yml
+# installs a pinned .deb from an apt repo, asserts NetBird overlay membership,
+# resolves an o11y name over mesh DNS and starts a systemd unit, none of which
+# exist in a test environment. The rendered config is what breaks silently, so
+# the rendered config is what gets exercised.
 driver:
   name: default
 

--- a/ansible/ceph/roles/fluentbit/molecule/default/verify.yml
+++ b/ansible/ceph/roles/fluentbit/molecule/default/verify.yml
@@ -1,7 +1,4 @@
 ---
-# Verify fluent-bit.conf.j2 renders the pipeline o11y depends on: journald in,
-# noise dropped, cluster/site/env stamped on, jsonline out over TLS.
-#
 # The load-bearing check is the grep filter's Exclude regex. It is tested as
 # behaviour -- matched against real journal lines -- not as a string compare,
 # because what matters is which lines it eats. Rewording the regex stays green;
@@ -104,8 +101,6 @@
         success_msg: "Exclude regex drops pgmap and _set_new_cache_sizes lines"
 
     - name: Assert the Exclude regex never drops a cluster health line
-      # The failure mode we most fear: HEALTH_ERR filtered out at the node, so
-      # o11y stays quiet while the cluster is degraded.
       ansible.builtin.assert:
         that:
           - fluentbit_health_err is not search(fluentbit_exclude_regex)

--- a/ansible/ceph/roles/fluentbit/tasks/main.yml
+++ b/ansible/ceph/roles/fluentbit/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# Install Fluent Bit (pinned) and ship journald to o11y over the NetBird overlay.
 
 - name: Assert the node is on the overlay
   # Without it there is no route to the gateway VIP, and fluent-bit would spin

--- a/ansible/ceph/roles/hardware_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/hardware_tuning/defaults/main.yml
@@ -1,37 +1,25 @@
 ---
-# Hardware tuning defaults for Ceph OSD nodes
-
-# I/O scheduler per device class
 ceph_hdd_scheduler: mq-deadline
 ceph_ssd_scheduler: none
 
-# Read-ahead in KB per device class
-# HDDs benefit from large read-ahead for sequential recovery/deep-scrub.
-# SSDs don't benefit and excess read-ahead wastes DRAM.
+# HDDs benefit from large read-ahead for sequential recovery/deep-scrub; SSDs
+# don't, and excess read-ahead wastes DRAM.
 ceph_hdd_readahead_kb: 4096     # 4 MB
 ceph_ssd_readahead_kb: 128      # 128 KB (kernel default)
 
-# nr_requests (disk queue depth); 0 means leave at kernel default
+# Disk queue depth; 0 = leave at the kernel default.
 ceph_hdd_nr_requests: 128
-ceph_ssd_nr_requests: 0         # NVMe/SSD defaults are fine
+ceph_ssd_nr_requests: 0
 
-# Enable weekly SSD TRIM for OS partitions (ESP, boot).
-# BlueStore manages discard for OSD devices internally.
+# Weekly TRIM covers the OS partitions only; BlueStore manages discard for OSD
+# devices internally.
 ceph_enable_fstrim_timer: true
 
-# SATA link power management (ALPM).
-#
-# The AMD FCH AHCI ports come up as min_power_with_partial, which lets the SATA
-# PHY drop into Partial/Slumber between I/Os. Waking it costs milliseconds, and
-# on 2026-07-24 that surfaced as a BlueStore slow-op alert on osd.155 (curtis
-# sdk): PHYRdyChg/CommWake in dmesg, drive itself healthy.
-#
-# An OSD HDD is never idle enough for the power saving to be worth the wake
-# latency, so pin the link to max_performance. Applied live and persisted via
-# the same udev rules file as the block-device tuning.
-#
-# NOTE: writing this attribute schedules a libata EH cycle on the port, so roll
-# it out per node (serial: 1) rather than fleet-wide in one pass.
+# SATA link power management (ALPM): AMD FCH AHCI ports default to
+# min_power_with_partial; the ms-scale PHY wake surfaced as a BlueStore slow-op
+# alert (osd.155, curtis sdk, 2026-07-24: PHYRdyChg/CommWake in dmesg, healthy
+# drive). Pin max_performance; persisted via the block-tuning udev rules. NOTE:
+# writing the attribute schedules a libata EH cycle per port -- roll out serial: 1.
 ceph_sata_link_pm_enabled: true
 ceph_sata_link_pm_policy: max_performance
 
@@ -42,13 +30,11 @@ ceph_thp_enabled: true
 ceph_thp_mode: madvise          # /sys/kernel/mm/transparent_hugepage/enabled
 ceph_thp_defrag: madvise        # /sys/kernel/mm/transparent_hugepage/defrag
 
-# CPU governor: force performance mode (disables power saving C-states)
-# Useful for dedicated Ceph nodes where latency matters more than power.
+# performance disables power-saving C-states: latency over power draw.
 ceph_cpu_governor_enabled: false
 ceph_cpu_governor: performance
 ceph_cpu_max_cstate: 1    # kernel param processor.max_cstate
 
-# LVM device filter: restrict LVM scanning to known VGs.
-# Prevents LVM from scanning raw OSD disks (speeds up lvscan/pvscan).
+# Restricting the scan to known VGs keeps lvscan/pvscan off the raw OSD disks.
 ceph_lvm_filter_enabled: false
 ceph_lvm_filter: '[ "a|/dev/vg0/.*|", "a|/dev/md.*|", "r|.*|" ]'

--- a/ansible/ceph/roles/hardware_tuning/tasks/drift.yml
+++ b/ansible/ceph/roles/hardware_tuning/tasks/drift.yml
@@ -1,7 +1,6 @@
 ---
-# Drift checks for hardware_tuning. Read-only.
-# Included by drift.yml via include_role + tasks_from -- see the precedence
-# note in roles/os_tuning/tasks/drift.yml.
+# Read-only. Included via include_role + tasks_from -- see the precedence note in
+# roles/os_tuning/tasks/drift.yml.
 
 - name: Check HDD I/O scheduler
   ansible.builtin.shell: |
@@ -55,7 +54,6 @@
                  == ceph_ssd_scheduler
       }] }}
 
-# SATA link power management
 # Every AHCI port matters here, not a representative one: a single port
 # back on min_power_with_partial is enough to stall an OSD, so report the
 # distribution when the ports disagree.

--- a/ansible/ceph/roles/hardware_tuning/tasks/main.yml
+++ b/ansible/ceph/roles/hardware_tuning/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
-# Hardware-level tuning for Ceph OSD nodes.
-# Sets I/O scheduler, readahead, and queue depth per device class.
-# All changes apply live and persist via udev rules (no reboot).
+# All changes apply live and persist via udev rules; no reboot.
 
 - name: Deploy udev rules for disk tuning
   ansible.builtin.template:
@@ -77,8 +75,6 @@
     state: started
   when: ceph_enable_fstrim_timer | bool
 
-# ---------- SATA link power management ----------
-
 # The udev rule above covers boot and hot-plug; this applies the policy to
 # ports that are already up. Writing the attribute schedules a libata EH cycle
 # on that port, which is why this role wants serial: 1 on a serving cluster.
@@ -101,7 +97,6 @@
   changed_when: "'CHANGED' in (_sata_lpm.stdout | default(''))"
   when: ceph_sata_link_pm_enabled | bool
 
-# ---------- Transparent Huge Pages ----------
 
 - name: Set Transparent Huge Pages live
   ansible.builtin.shell: |
@@ -142,7 +137,6 @@
     daemon_reload: true
   when: ceph_thp_enabled | bool
 
-# ---------- CPU governor tuning ----------
 
 - name: Install cpupower package
   ansible.builtin.package:
@@ -195,7 +189,6 @@
   notify: Update GRUB
   when: ceph_cpu_governor_enabled | bool
 
-# ---------- LVM device filter ----------
 
 - name: Set LVM device filter in lvm.conf
   ansible.builtin.lineinfile:
@@ -205,7 +198,6 @@
     insertafter: '^\s*# filter\s*='
   when: ceph_lvm_filter_enabled | bool
 
-# ---------- Verification ----------
 
 - name: Verify I/O scheduler on sample devices
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/netbird/defaults/main.yml
+++ b/ansible/ceph/roles/netbird/defaults/main.yml
@@ -1,38 +1,28 @@
 ---
-# NetBird enrollment defaults for ceph nodes. Endpoints only: no router role,
-# no IP forwarding, no route acceptance (the ceph peer group is kept out of
-# every network's distribution groups in TF, so the client receives zero
-# overlay routes and the fabric stays authoritative for cluster traffic).
-# Access to the node over the overlay is governed by NetBird policies
-# (yucca operators via the auto policy, CI via ci-to-ceph tcp/22); the node
-# firewall accepts wt0 wholesale (security role ceph_firewall_trusted_ifaces).
+# NetBird enrollment for ceph nodes -- endpoints only: no routing/forwarding, and
+# the ceph peer group stays out of every network's TF distribution groups so the
+# fabric stays authoritative. Overlay access is governed by NetBird policies
+# (operators auto policy, CI ci-to-ceph tcp/22); node firewall accepts wt0 wholesale.
 ceph_netbird_enabled: false
 
-# Pinned + dpkg-held: netbird is load-bearing access infrastructure and its
-# ssh/DNAT behavior was audited against this version's source. Upgrades are
-# deliberate: bump the pin here (the install task unholds, installs, re-holds).
+# Pinned + dpkg-held: ssh/DNAT behavior audited against this version's source.
+# Upgrade = bump the pin (install task unholds, installs, re-holds).
 ceph_netbird_version: "0.73.2"
 
 ceph_netbird_management_url: "https://api.netbird.io"
 
-# Setup key - NEVER committed. `mise run netbird` reads it from 1Password
-# (op://yucca_tf_prod/NETBIRD_YUCCA_PROD_HTZ_FSN1_CEPH_SETUP_KEY) and passes
-# it as an extra-var. Only FRESH enrollment needs it; converging an already
-# connected node skips `netbird up` entirely, so the CI deploy pipeline can
-# carry this role with no secrets plumbing. A reimaged node fails the assert
-# below with instructions until an operator runs `mise run netbird` for it.
+# Setup key -- NEVER committed. `mise run netbird` reads
+# op://yucca_tf_prod/NETBIRD_YUCCA_PROD_HTZ_FSN1_CEPH_SETUP_KEY as an extra-var.
+# Only FRESH enrollment needs it (connected nodes skip `netbird up`, so CI needs
+# no secrets plumbing); a reimaged node fails the assert with instructions.
 ceph_netbird_setup_key: ""
 
-# --- NetBird SSH server (SSO/policy-gated human access over the overlay) ---
-# When true, netbird runs its own SSH server and DNATs overlay :22 -> :22022
-# (the DNAT is wt0-scoped, so sshd keeps fabric+WAN :22 and cephadm + ansible
-# are unaffected). Humans reach nodes with `netbird ssh ops@<node>` and sudo;
-# root login is deliberately OFF. Enabling needs BOTH the client flag below AND
-# ssh_enabled=true on the management side, which is a per-peer NetBird API call
-# (the client flag alone is not enough - verified 2026-07-22). So the API token
-# must be provided: `mise run netbird` reads it from op://shared_tf/
-# NETBIRD_TF_PAT. A token-less converge (CI deploy pipeline) is a no-op on
-# already-enabled peers and leaves un-enabled ones for `mise run netbird`.
+# netbird's own SSH server, DNAT overlay :22 -> :22022 (wt0-scoped: sshd keeps
+# fabric+WAN :22, cephadm/ansible unaffected). Humans: `netbird ssh ops@<node>`
+# + sudo; root deliberately OFF. Needs BOTH the client flag AND per-peer API
+# ssh_enabled=true (client flag alone insufficient -- verified 2026-07-22), so
+# the API token is required: `mise run netbird` reads op://shared_tf/NETBIRD_TF_PAT.
+# Token-less converge (CI) is a no-op on enabled peers.
 ceph_netbird_ssh_server: false
 ceph_netbird_ssh_sftp: true
 ceph_netbird_api_url: "https://api.netbird.io"

--- a/ansible/ceph/roles/netbird/tasks/main.yml
+++ b/ansible/ceph/roles/netbird/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
-# Install NetBird (pinned) and join the overlay as an endpoint peer.
-# Convergeable: install is pin+hold, `netbird up` is skipped when connected.
-# Adapted from ansible/mgmt/roles/netbird, minus the route-peer parts (no IP
-# forwarding here - ceph nodes must never route or receive overlay routes).
+# From mgmt/roles/netbird minus the route-peer parts -- ceph nodes must never
+# route or receive overlay routes.
 
 - name: Ensure keyrings directory exists
   ansible.builtin.file:
@@ -38,9 +36,8 @@
   failed_when: false
 
 - name: Unhold netbird only when the pinned version differs (keeps converge clean)
-  # rc != 0 means dpkg has never seen the package. That is every fresh node.
-  # dpkg_selections fails hard on an unknown package, and there is no hold to
-  # release before the first install, so skip it there.
+  # rc != 0 = dpkg never saw the package (fresh node); dpkg_selections fails
+  # hard on unknown packages and there is no hold to release yet, so skip.
   ansible.builtin.dpkg_selections:
     name: netbird
     selection: install
@@ -102,9 +99,8 @@
   retries: 6
   delay: 5
   until: "'Management: Connected' in ceph_netbird_status_post.stdout"
-  # Same condition as the join task: a node that was already connected never
-  # joined, so there is nothing to re-check (and _post stays undefined for the
-  # asserts' default() fallback).
+  # Same condition as the join: already-connected nodes never joined, so _post
+  # stays undefined for the asserts' default() fallback.
   when: "'Management: Connected' not in ceph_netbird_status.stdout"
 
 - name: Assert connected
@@ -116,10 +112,9 @@
     success_msg: "{{ inventory_hostname }}: NetBird connected"
 
 - name: Assert no overlay routes were received (fabric stays authoritative)
-  # `Networks: -` is the 0.73.x status line for zero received routes. If this
-  # fires, the ceph group leaked into a network's distribution groups in TF -
-  # an overlay route here could shadow the node's fabric paths. Format is
-  # version-coupled; revisit when bumping ceph_netbird_version.
+  # `Networks: -` = zero received routes on 0.73.x (format is version-coupled;
+  # revisit on version bump). Firing means the ceph group leaked into a network's
+  # TF distribution groups -- an overlay route could shadow the fabric paths.
   ansible.builtin.assert:
     that:
       - >-
@@ -130,7 +125,6 @@
       group must stay out of all NetBird network distribution groups. Fix the
       TF (tf/deployment/prod/htz-fsn1/netbird) before enrolling further nodes.
 
-# --- NetBird SSH server (SSO-gated human access; ops+sudo, root off) ---
 # Gated on the API token so a token-less converge is a no-op on already-enabled
 # peers. The DNAT is wt0-scoped, so cephadm (fabric) and ansible (WAN) keep
 # key-based sshd on :22 - verified on the philip canary 2026-07-22.
@@ -191,11 +185,10 @@
     - ceph_netbird_api_token | length > 0
 
 - name: Apply the server-ssh client flags (down/up over WAN)
-  # `netbird up` short-circuits on a connected peer ("Already connected"), so a
-  # down/up cycle is needed to (re)apply client flags. Safe: ansible connects
-  # over the WAN, and the cycle drops only the overlay. The server binds once
-  # both the client flag and management ssh_enabled agree. Idempotent - skipped
-  # once :22022 already listens. No --enable-ssh-root: humans use ops + sudo.
+  # `netbird up` short-circuits when connected, so a down/up cycle (re)applies
+  # client flags; safe -- ansible rides the WAN, only the overlay drops. Server
+  # binds once client flag AND management ssh_enabled agree; skipped when :22022
+  # already listens. No --enable-ssh-root: humans use ops + sudo.
   ansible.builtin.shell: |
     set -e
     netbird down

--- a/ansible/ceph/roles/networkd/defaults/main.yml
+++ b/ansible/ceph/roles/networkd/defaults/main.yml
@@ -1,35 +1,18 @@
 ---
-# systemd-networkd bond configuration, in one of two modes (see
-# networkd_replace_ifupdown): full migration off ifupdown, or coexistence beside it.
-#
-# Prerequisites:
-#   - systemd-networkd is installed (present in Debian 12 base)
-#   - bond_ip, bond_interfaces, bond_mode, gateway, dns_server
-#     defined in group_vars / host_vars
-#
-# Safety:
-#   - /etc/network/interfaces is left on disk as rollback backup
-#   - Rollback script deployed to /usr/local/sbin/rollback-networkd.sh
-#   - networkd is started live and verified before any boot-service toggle
-
-# Master toggle. When false, the entire role is skipped.
+# Requires bond_ip/bond_interfaces/bond_mode/gateway/dns_server in group_vars or
+# host_vars. Safety: /etc/network/interfaces kept as rollback backup,
+# rollback-networkd.sh deployed, networkd verified live before any boot-service
+# toggle.
 networkd_enabled: false
 
-# Replace ifupdown entirely (full migration) vs coexist with it.
-#   true (default): networkd owns ALL networking; commit.yml disables ifupdown for
-#                   future boots. For flat clusters (sietch) where the bond is the
-#                   only/management interface, so there is nothing else to keep.
-#   false         : COEXISTENCE. ifupdown keeps the interfaces it already owns --
-#                   the 1G WAN (oob_nic) that installimage configured in
-#                   /etc/network/interfaces and that carries the default route --
-#                   while networkd manages ONLY the bond + VLANs. commit.yml leaves
-#                   networking.service enabled, so the reachability-critical WAN is
-#                   never migrated and cannot be lost by a networkd error (spice).
-#                   An explicit Unmanaged=yes guard fences oob_nic off from networkd.
-#                   Requires oob_nic to be defined.
+# true (default): networkd owns ALL networking, commit.yml disables ifupdown at
+#   boot (flat clusters like sietch -- nothing else to keep).
+# false: COEXISTENCE (spice). ifupdown keeps the 1G WAN (oob_nic, default route,
+#   installimage-configured); networkd manages ONLY bond + VLANs, commit.yml
+#   leaves networking.service enabled so a networkd error can't cost the
+#   reachability link. Unmanaged=yes fences oob_nic; requires oob_nic defined.
 networkd_replace_ifupdown: true
 
-# --- Bond ---
 networkd_bond_name: bond0
 networkd_bond_mode: "{{ bond_mode | default('active-backup') }}"
 networkd_bond_miimon: 100                          # MII link monitoring interval (ms)
@@ -39,23 +22,17 @@ networkd_bond_miimon: 100                          # MII link monitoring interva
 networkd_bond_lacp_rate: fast                      # 1s LACPDUs (vs 30s 'slow')
 networkd_bond_xmit_hash_policy: layer3+4           # spread flows across both members
 
-# Tagged VLAN sub-interfaces carried on the bond (opt-in). Each entry:
-#   { id: <vlan id>, address: <CIDR>, dns: <optional>, mtu: <optional> }
-# Empty     -> bond0 carries bond_ip directly (flat active-backup clusters).
-# Non-empty -> bond0 carries NO L3; each VLAN sub-interface carries its address
-#              (spice: VLAN 120 public + VLAN 122 private on the 25G LACP bond).
-# A VLAN opts into jumbo with its own `mtu:` (e.g. 9000 on the private/replication
-# VLAN); VLANs without `mtu:` default to 1500.
+# Tagged VLANs on the bond: { id, address, dns?, mtu? }. Empty -> bond0 carries
+# bond_ip directly (flat clusters); non-empty -> bond0 carries NO L3, each VLAN
+# carries its address (spice). Per-VLAN `mtu:` opts into jumbo; default 1500.
 networkd_bond_vlans: []
 
-# Bond MTU ceiling = the largest child VLAN MTU (a VLAN child cannot exceed its
-# parent), defaulting to 1500. Raising a single VLAN to jumbo raises the bond and
-# its 25G members to match, so the jumbo VLAN's frames are not silently capped by a
-# 1500 parent/slave. Flat clusters (no VLANs) resolve to 1500 -> no MTU is emitted.
+# Bond MTU = max child VLAN MTU (a VLAN cannot exceed its parent): one jumbo
+# VLAN raises the bond + members so its frames aren't capped by a 1500 parent.
+# Flat clusters resolve to 1500 -> no MTU emitted.
 networkd_bond_mtu: >-
   {{ (networkd_bond_vlans | map(attribute='mtu', default=1500) | map('int') | max)
      if (networkd_bond_vlans | length > 0) else 1500 }}
 
-# --- Paths ---
 networkd_config_dir: /etc/systemd/network
 networkd_rollback_script: /usr/local/sbin/rollback-networkd.sh

--- a/ansible/ceph/roles/networkd/tasks/activate.yml
+++ b/ansible/ceph/roles/networkd/tasks/activate.yml
@@ -1,7 +1,6 @@
 ---
-# Start systemd-networkd to adopt the existing bond0.
-# ifupdown's networking.service is active (exited) - no daemon to conflict.
-# networkd sees bond0 already exists and adopts it without disruption.
+# ifupdown's networking.service is active (exited), so there is no daemon to
+# conflict: networkd adopts the existing bond0 without disruption.
 
 - name: Flush handlers (ensure daemon-reload before start)
   ansible.builtin.meta: flush_handlers
@@ -11,21 +10,16 @@
     name: systemd-networkd.service
     state: started
 
-# Apply any config delta to an ALREADY-running networkd. On the initial migration
-# `state: started` above brings the stack up; on a re-run (e.g. adding a bond VLAN)
-# networkd is already active, so `started` is a no-op and the freshly written
-# .netdev/.network files would sit unapplied. `networkctl reload` re-reads the
-# config and creates the added sub-interfaces without tearing down the existing
-# links (unchanged bond0 + VLANs are untouched; the WAN, on ifupdown, is untouched
-# regardless).
+# On a re-run `started` is a no-op and fresh .netdev/.network files sit
+# unapplied; `networkctl reload` picks them up and creates added sub-interfaces
+# without touching existing links (or the ifupdown WAN).
 - name: Apply networkd config (idempotent; picks up added VLAN sub-interfaces)
   ansible.builtin.command: networkctl reload
   changed_when: false
 
-# networkctl reload creates + addresses sub-interfaces asynchronously; wait for each
-# bond VLAN to carry its address before verify asserts on it. A sub-interface that
-# never comes up (e.g. a reload that could not create the netdev) fails here and,
-# with max_fail_percentage 0 + serial 1, halts the roll on that one node.
+# reload creates/addresses sub-interfaces asynchronously; wait for each VLAN's
+# address before verify asserts. A sub-interface that never comes up fails here
+# and (max_fail_percentage 0 + serial 1) halts the roll on that node.
 - name: Wait for bond VLAN sub-interfaces to acquire their addresses
   ansible.builtin.command: "ip -4 addr show {{ networkd_bond_name }}.{{ vlan.id }}"
   register: networkd_vlan_settle

--- a/ansible/ceph/roles/networkd/tasks/commit.yml
+++ b/ansible/ceph/roles/networkd/tasks/commit.yml
@@ -1,7 +1,6 @@
 ---
-# Lock in the migration: disable ifupdown, enable networkd for future boots.
-# Only runs after verify.yml passes. If verify failed, we never reach here
-# and ifupdown still owns the next boot.
+# Only reached after verify.yml passes; on a verify failure ifupdown still owns
+# the next boot.
 
 # Full migration only: hand the whole stack to networkd. In coexistence mode
 # (spice) ifupdown MUST stay enabled -- it owns the 1G WAN, and disabling it would

--- a/ansible/ceph/roles/networkd/tasks/deploy.yml
+++ b/ansible/ceph/roles/networkd/tasks/deploy.yml
@@ -1,6 +1,5 @@
 ---
-# Write systemd-networkd config files and rollback script.
-# No services are started or stopped. Safe to re-run.
+# No services are started or stopped here.
 
 # Coexistence only: explicitly fence the 1G WAN off from networkd so it stays on
 # ifupdown. The 05- prefix settles this match before any bond file. Flat clusters

--- a/ansible/ceph/roles/networkd/tasks/main.yml
+++ b/ansible/ceph/roles/networkd/tasks/main.yml
@@ -1,15 +1,9 @@
 ---
-# systemd-networkd bond configuration. Live activation, no reboot required:
-#   1. deploy: write .netdev/.network configs (+ WAN unmanaged guard in
-#      coexistence mode) + rollback script
-#   2. activate: start networkd (brings up the bond + VLANs; the WAN is untouched)
-#   3. verify: assert the bond/VLANs are correct and, in coexistence, that the WAN
-#      kept its address + default route
-#   4. commit: enable networkd for future boots; disable ifupdown ONLY in full-
-#      migration mode (coexistence leaves it enabled to keep the WAN)
-#
-# If verify fails the play halts before commit, so ifupdown still owns next boot.
-# Gated on networkd_enabled (default: false); mode set by networkd_replace_ifupdown.
+# systemd-networkd bond config, live (no reboot): deploy configs (+ WAN
+# unmanaged guard in coexistence) -> activate -> verify (incl. WAN address +
+# default route intact in coexistence) -> commit (disable ifupdown ONLY in
+# full-migration mode). Verify failure halts before commit, so ifupdown still
+# owns next boot. Gated on networkd_enabled; mode = networkd_replace_ifupdown.
 
 - name: Deploy networkd configs
   ansible.builtin.import_tasks: deploy.yml

--- a/ansible/ceph/roles/networkd/tasks/verify.yml
+++ b/ansible/ceph/roles/networkd/tasks/verify.yml
@@ -1,6 +1,4 @@
 ---
-# Post-reboot verification for systemd-networkd migration.
-# All checks are read-only assertions.
 
 - name: Check systemd-networkd is active
   ansible.builtin.systemd:

--- a/ansible/ceph/roles/os_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/os_tuning/defaults/main.yml
@@ -1,29 +1,23 @@
 ---
-# Kernel / OS tuning defaults for Ceph OSD nodes
-#
 # cephadm does NOT assert these (unlike ceph-ansible), so they must be
 # applied explicitly. Values sourced from Red Hat Ceph Storage hardening
 # guide and Heinlein Support's production tuning.
 
-# --- VM ---
 ceph_sysctl_vm_swappiness: 10
 ceph_sysctl_vm_min_free_kbytes: 4194303    # ~4 GB — headroom to prevent OSD OOM
 ceph_sysctl_vm_zone_reclaim_mode: 0        # disable NUMA zone reclaim (causes stalls)
 
-# --- FS ---
 ceph_sysctl_fs_aio_max_nr: 1048576         # async I/O slots — OSD prepare fails if too low
-ceph_sysctl_fs_file_max: 26234859          # file descriptor ceiling
+ceph_sysctl_fs_file_max: 26234859
 # inotify headroom for cephadm-on-podman container scale (many daemons/units per
 # node); Debian's default max_user_instances=128 is a known podman-at-scale limit.
 ceph_sysctl_fs_inotify_max_user_instances: 512
 ceph_sysctl_fs_inotify_max_user_watches: 524288
 
-# --- Kernel ---
 ceph_sysctl_kernel_pid_max: 4194304        # high OSD count spawns many threads
 
-# --- Network (TCP buffer tuning for OSD replication) ---
-ceph_sysctl_net_core_rmem_max: 56623104    # ~54 MB receive buffer
-ceph_sysctl_net_core_wmem_max: 56623104    # ~54 MB send buffer
+ceph_sysctl_net_core_rmem_max: 56623104    # ~54 MB
+ceph_sysctl_net_core_wmem_max: 56623104    # ~54 MB
 ceph_sysctl_net_core_rmem_default: 56623104
 ceph_sysctl_net_core_wmem_default: 56623104
 ceph_sysctl_net_core_optmem_max: 40960
@@ -36,20 +30,18 @@ ceph_sysctl_net_ipv4_tcp_tw_reuse: 1
 ceph_sysctl_net_ipv4_tcp_max_tw_buckets: 2000000
 ceph_sysctl_net_ipv4_ip_local_port_range: "8192 65535"
 
-# --- Security hardening (host kernel / network) ---
-# Universally-good host settings; safe on all clusters.
-ceph_sysctl_net_ipv4_tcp_syncookies: 1                  # SYN flood mitigation
-ceph_sysctl_net_ipv4_conf_all_accept_redirects: 0       # ignore ICMP redirects
+ceph_sysctl_net_ipv4_tcp_syncookies: 1
+ceph_sysctl_net_ipv4_conf_all_accept_redirects: 0
 ceph_sysctl_net_ipv4_conf_default_accept_redirects: 0
-ceph_sysctl_net_ipv4_conf_all_send_redirects: 0         # do not send ICMP redirects
+ceph_sysctl_net_ipv4_conf_all_send_redirects: 0
 ceph_sysctl_net_ipv4_conf_default_send_redirects: 0
-ceph_sysctl_net_ipv4_conf_all_accept_source_route: 0    # drop source-routed packets
+ceph_sysctl_net_ipv4_conf_all_accept_source_route: 0
 ceph_sysctl_net_ipv4_conf_default_accept_source_route: 0
 ceph_sysctl_net_ipv6_conf_all_accept_redirects: 0
 ceph_sysctl_net_ipv6_conf_all_accept_source_route: 0
-ceph_sysctl_kernel_kptr_restrict: 1                     # hide kernel pointers from /proc
-ceph_sysctl_kernel_dmesg_restrict: 1                    # restrict dmesg to privileged users
-ceph_sysctl_net_ipv4_conf_all_log_martians: 1           # log packets with impossible addresses
+ceph_sysctl_kernel_kptr_restrict: 1
+ceph_sysctl_kernel_dmesg_restrict: 1
+ceph_sysctl_net_ipv4_conf_all_log_martians: 1
 # rp_filter LOOSE (2), NOT strict (1). The spice nodes are multi-homed: a 1G
 # WAN carries the default route while the 25G fabric VLAN sub-interfaces
 # (bond0.120/.122/.124) carry cluster traffic. STRICT reverse-path filtering
@@ -57,17 +49,13 @@ ceph_sysctl_net_ipv4_conf_all_log_martians: 1           # log packets with impos
 ceph_sysctl_net_ipv4_conf_all_rp_filter: 2
 ceph_sysctl_net_ipv4_conf_default_rp_filter: 2
 
-# --- Persistent journald ---
 # The KVM-only headless nodes default to volatile journald (Storage=auto with
 # no /var/log/journal), so logs are lost across the pipeline's own reboots.
 # Make the journal persistent and bound its on-disk / runtime footprint.
 ceph_journald_storage: persistent
-ceph_journald_system_max_use: 2G      # cap persistent journal at ~2 GB
-ceph_journald_runtime_max_use: 200M   # cap volatile (tmpfs) journal at ~200 MB
+ceph_journald_system_max_use: 2G      # persistent journal cap
+ceph_journald_runtime_max_use: 200M   # volatile (tmpfs) journal cap
 
-# --- Centralized logging (opt-in) ---
-# When enabled, configures rsyslog to forward all logs to a remote syslog
-# server. Disabled by default — enable when a log aggregator is available.
 ceph_logging_enabled: false
 ceph_logging_target: ""          # e.g., "10.10.10.50:514"
 ceph_logging_protocol: tcp       # tcp or udp

--- a/ansible/ceph/roles/os_tuning/tasks/drift.yml
+++ b/ansible/ceph/roles/os_tuning/tasks/drift.yml
@@ -1,15 +1,9 @@
 ---
-# Drift checks for os_tuning. Read-only.
-#
-# Included by drift.yml with include_role + tasks_from, NOT vars_files.
-# vars_files loads a role's defaults at precedence 14, which outranks inventory
-# group_vars (4) and host_vars (9): every check would then compare the live host
-# against the role default rather than what the cluster actually declares, and
-# any per-cluster or per-host override would read as drift. include_role loads
-# defaults at precedence 2, so the normal layering applies.
-#
-# Appends to the play-level drift_results accumulator. set_fact (19) outranks
-# role defaults, so a later role's defaults cannot reset it.
+# Read-only. Included via include_role + tasks_from, NOT vars_files: vars_files loads role
+# defaults at precedence 14 (outranking group_vars 4 / host_vars 9), so cluster
+# overrides would read as drift; include_role loads them at 2 (normal layering).
+# Appends to drift_results; set_fact (19) outranks role defaults, so a later
+# role's defaults cannot reset the accumulator.
 
 - name: Check sysctl values
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/provision_host/defaults/main.yml
+++ b/ansible/ceph/roles/provision_host/defaults/main.yml
@@ -1,56 +1,39 @@
 ---
-# provision-host role defaults
-#
-# Drives fresh-install provisioning of a Ceph cluster node from its
-# Debian 12 live image. All values here are overridable via
-# group_vars / host_vars / extra-vars.
-
-# Target path on the live image where the new OS is mounted during install.
 provision_mnt: /mnt
 
-# Idempotency marker written to the provisioned system at finalize.
-# Project-scoped (not cluster-scoped) so every Ceph cluster writes the same
-# filename; the marker's CONTENTS identify which cluster + host.
+# Idempotency marker written at finalize. Same filename on every cluster; the
+# CONTENTS identify cluster + host.
 provision_marker_path: /etc/ceph-provisioned.json
 
-# Safety gate — set to true via extra-vars before any destructive disk work.
+# Gates all destructive disk work:
 #   scripts/ansible-play.sh provision.yml -e confirm_wipe=true
 confirm_wipe: false
 
-# Opt-in: also zap the OSD data HDDs (wipe-osds.yml). Default off so a normal
-# re-provision (e.g. replacing an OS SSD) keeps OSD data. Set true for a clean
-# rebuild where the HDDs must be cleared so cephadm can recreate OSDs.
+# Opt-in: also zap OSD data HDDs (wipe-osds.yml). Default off so a re-provision
+# keeps OSD data; true only for a clean rebuild.
 #   ... provision.yml -e confirm_wipe=true -e provision_wipe_osd_disks=true
 provision_wipe_osd_disks: false
 
-# Canary / inspection gate — when true, the role completes everything
-# (wipe → install → configure → bootloader → marker → ESP mirror) but
-# stops short of unmounting /mnt and rebooting. Lets you `chroot /mnt`
-# from the live image to verify state before committing to the reboot.
+# Canary gate: complete everything through the ESP mirror but stop before
+# unmounting /mnt + rebooting, so you can `chroot /mnt` to verify first.
 #   scripts/ansible-play.sh provision.yml -e provision_skip_reboot=true
 provision_skip_reboot: false
 
-# SSD discovery model pattern (matches lsblk MODEL field).
+# Matches the lsblk MODEL field.
 provision_ssd_model_pattern: "Micron_5100"
 
-# Sanity floor for SSD size, in GB. Pre-flight rejects any matching disk
-# below this size — catches "model string match but it's a 16GB USB stick"
-# scenarios. Real Ceph block.db SSDs should be >> 200GB anyway. Override
-# in host_vars / group_vars if you need a different floor.
+# SSD size sanity floor (GB): pre-flight rejects smaller matches (catches
+# "model matched but it's a 16GB USB stick").
 provision_ssd_min_size_gb: 200
 
-# Debian release + mirror for debootstrap.
 provision_debian_release: bookworm
 provision_debian_mirror: http://deb.debian.org/debian
 
-# LV sizing for Ceph block.db on each SSD partition 5 VG.
 provision_ceph_db_lv_size: 240G
 provision_ceph_db_lv_count_per_vg: 6   # 5 fixed-size + 1 remainder
 
-# Packages installed on the LIVE image before provisioning begins.
-# prerequisites_live.yml installs these via apt every run so the live
-# image has the debootstrap/partitioning/mdraid/LVM/rsync toolchain
-# regardless of which Debian live ISO was booted.
+# Installed on the LIVE image every run (prerequisites_live.yml) so the
+# provisioning toolchain exists regardless of which Debian live ISO was booted.
 provision_live_packages:
   - debootstrap
   - dosfstools
@@ -62,40 +45,32 @@ provision_live_packages:
   - lvm2
   - parted
 
-# Packages installed INSIDE the chroot — boot-essential only.
-# Diagnostic tools, podman ecosystem, and ops packages are installed
-# post-boot by the baseline role. This keeps the chroot minimal and
-# makes everything except boot infra convergeable.
+# Installed INSIDE the chroot — boot-essential only; everything else lands
+# post-boot via the baseline role (keeps all but boot infra convergeable).
 provision_chroot_packages:
-  # Boot / core OS
   - linux-image-amd64
   - grub-efi-amd64
   - efibootmgr
   - firmware-linux
-  # Storage / networking
   - mdadm
   - lvm2
   - ifenslave
   - dosfstools
   - cryptsetup
   - rsync
-  # Remote access (minimum for Ansible to connect post-reboot)
   - openssh-server
   - sudo
   - python3
-  # Time sync + TLS (needed at boot)
   - chrony
   - ca-certificates
   - gnupg
   - curl
   - dbus
 
-# Opt-in: auto-generate the ansible-iac deploy keypair on the controller
-# if it doesn't exist. Default: fail fast with a clear message.
+# false = fail fast when the controller keypair is missing.
 provision_create_iac_keypair: false
 
-# Post-reboot verification timing.
 provision_reboot_wait_timeout: 600
-provision_reboot_wait_delay: 60      # initial pause before SSH probing
-provision_verify_retries: 30         # max SSH probe attempts
-provision_verify_delay: 15           # seconds between probe attempts
+provision_reboot_wait_delay: 60      # seconds before the first SSH probe
+provision_verify_retries: 30
+provision_verify_delay: 15           # seconds between probes

--- a/ansible/ceph/roles/provision_host/tasks/admin_user.yml
+++ b/ansible/ceph/roles/provision_host/tasks/admin_user.yml
@@ -1,15 +1,8 @@
 ---
-# Phase 7: Create ansible-iac user inside chroot
-#
-# This is the minimum viable user for Ansible to connect after reboot:
-#   - uid 1000, locked password (key-only SSH)
-#   - SSH pubkey from {{ provision_iac_ssh_key_path }}.pub
-#   - NOPASSWD sudo
-#
-# The ops user and all other post-boot config are handled by the
-# baseline role, which runs after provisioning via the normal pipeline.
-
-# === ansible-iac (uid 1000, locked password, key-only) ================
+# The minimum viable user for Ansible to connect after reboot: uid 1000, locked
+# password (key-only SSH), pubkey from {{ provision_iac_ssh_key_path }}.pub,
+# NOPASSWD sudo. The ops user and all other post-boot config belong to the
+# baseline role.
 
 - name: Check if ansible-iac user exists inside chroot
   ansible.builtin.command: "chroot {{ provision_mnt }} id -u ansible-iac"
@@ -54,5 +47,3 @@
     mode: '0440'
     validate: "visudo -cf %s"
 
-    # ops user is created post-boot by the baseline role, not in chroot.
-    # Only ansible-iac is needed for Ansible to connect after reboot.

--- a/ansible/ceph/roles/provision_host/tasks/bootloader.yml
+++ b/ansible/ceph/roles/provision_host/tasks/bootloader.yml
@@ -1,12 +1,7 @@
 ---
-# Phase 8: Bootloader installation
-#
-# Builds the initramfs with mdraid/LVM support, installs GRUB to the
-# primary ESP, and creates a fallback efibootmgr entry pointing at
-# the backup ESP on SSD2. All three steps run inside chroot.
-#
-# initramfs and grub-install overwrite idempotently; efibootmgr is
-# guarded by a check for an existing "Debian (mirror)" entry.
+# All three steps run inside the chroot. initramfs and grub-install overwrite
+# idempotently; efibootmgr is guarded by a check for an existing
+# "Debian (mirror)" entry.
 
 - name: Rebuild initramfs inside chroot for all kernels
   ansible.builtin.command: "chroot {{ provision_mnt }} update-initramfs -u -k all"

--- a/ansible/ceph/roles/provision_host/tasks/chroot_packages.yml
+++ b/ansible/ceph/roles/provision_host/tasks/chroot_packages.yml
@@ -1,27 +1,11 @@
 ---
-# Phase 6: Install packages inside the chroot
-#
-# Sets up bind mounts for /dev, /dev/pts, /proc, /sys, and the EFI
-# variable store, then runs apt-get inside chroot to install the
-# baseline OS + diagnostic toolset. Also rotates the machine-id,
-# regenerates SSH host keys, and enables ssh + chrony services.
-#
-# Bind mounts use a probe-then-mount idempotency pattern (see the
-# comment block above the probe task) so crash-recovery re-runs don't
-# trip on binds that are already in place from a previous partial run.
-#
-# The bind mounts are NOT unmounted here — bootloader.yml needs them
-# for grub-install, and finalize.yml (via unmount.yml) will tear them
-# down at the end.
+# Bind mounts stay mounted -- bootloader.yml needs them for grub-install;
+# unmount.yml tears them down at the end.
 
-# --- Bind mounts for chroot --------------------------------------------
-#
-# Probe-then-mount pattern: ansible.posix.mount with state=ephemeral
-# fails if the mountpoint is already mounted (even with the same source)
-# because it reads /proc/mounts and compares the resolved source string
-# rather than recognizing the existing bind. Probe with mountpoint(1)
-# first and skip the mount if already present, so a partial-failure
-# crash-recovery rerun doesn't trip on the binds that already existed.
+# Probe-then-mount: ansible.posix.mount state=ephemeral fails when the
+# mountpoint is already mounted (compares resolved source strings, doesn't
+# recognize an existing bind), so probe with mountpoint(1) and skip -- a
+# crash-recovery rerun must not trip on binds from a previous partial run.
 
 - name: Probe existing chroot bind mounts
   ansible.builtin.command: "mountpoint -q {{ provision_mnt }}{{ item }}"
@@ -84,7 +68,6 @@
     state: ephemeral
   when: chroot_bind_probe.results[4].rc != 0
 
-# --- apt update/install inside chroot ----------------------------------
 
 - name: Check which required packages are already present in chroot
   ansible.builtin.shell: |
@@ -120,7 +103,6 @@
   async: 1800
   poll: 15
 
-# --- machine-id ---------------------------------------------------------
 
 - name: Check for existing machine-id
   ansible.builtin.stat:
@@ -139,7 +121,6 @@
     creates: "{{ provision_mnt }}/etc/machine-id"
   changed_when: true
 
-# --- SSH host keys ------------------------------------------------------
 
 - name: Check for existing SSH host keys in chroot
   ansible.builtin.find:
@@ -166,7 +147,6 @@
   ansible.builtin.command: "chroot {{ provision_mnt }} ssh-keygen -A"
   changed_when: true
 
-# --- Enable services ----------------------------------------------------
 
 - name: Check enabled state of key services in chroot
   ansible.builtin.command: "chroot {{ provision_mnt }} systemctl is-enabled {{ item }}"

--- a/ansible/ceph/roles/provision_host/tasks/configure.yml
+++ b/ansible/ceph/roles/provision_host/tasks/configure.yml
@@ -1,15 +1,7 @@
 ---
-# Phase 5: Configure the installed system
-#
-# All tasks write to /mnt (the installed system's root). No chroot
-# needed for file placement — ansible modules handle it fine because
-# /mnt is just a directory on the live image as far as the module
-# machinery is concerned.
-#
-# UUIDs are gathered at runtime from blkid so the fstab template
-# reflects reality. mdadm.conf is built from `mdadm --detail --scan`.
-
-# --- Gather filesystem UUIDs for fstab ---------------------------------
+# All tasks write to /mnt (the installed system's root); no chroot is needed for
+# file placement. UUIDs come from blkid at runtime and mdadm.conf from
+# `mdadm --detail --scan`, so both reflect the disks as actually built.
 
 - name: Gather UUID for md/root
   ansible.builtin.command: "blkid -s UUID -o value /dev/md/root"
@@ -44,8 +36,6 @@
     uuid_esp: "{{ blkid_esp.stdout | trim }}"
     backup_esp_partuuid: "{{ blkid_backup_esp_partuuid.stdout | trim }}"
 
-# --- Hostname and /etc/hosts -------------------------------------------
-
 - name: Write /mnt/etc/hostname
   ansible.builtin.copy:
     content: "{{ hostname_short }}\n"
@@ -61,8 +51,6 @@
     owner: root
     group: root
     mode: '0644'
-
-# --- Network interfaces (bond0 static) ---------------------------------
 
 - name: Ensure /mnt/etc/network directory exists
   ansible.builtin.file:
@@ -80,8 +68,7 @@
     group: root
     mode: '0644'
 
-# --- DNS resolver (so chroot apt works) --------------------------------
-
+# The chroot's apt needs a resolver.
 - name: Render /mnt/etc/resolv.conf
   ansible.builtin.template:
     src: resolv.conf.j2
@@ -90,8 +77,6 @@
     group: root
     mode: '0644'
 
-# --- apt sources list --------------------------------------------------
-
 - name: Render /mnt/etc/apt/sources.list
   ansible.builtin.template:
     src: apt-sources.list.j2
@@ -99,8 +84,6 @@
     owner: root
     group: root
     mode: '0644'
-
-# --- Timezone ----------------------------------------------------------
 
 - name: Symlink /etc/localtime to target timezone
   ansible.builtin.file:
@@ -118,8 +101,6 @@
     group: root
     mode: '0644'
 
-# --- fstab -------------------------------------------------------------
-
 - name: Render /mnt/etc/fstab
   ansible.builtin.template:
     src: fstab.j2
@@ -127,8 +108,6 @@
     owner: root
     group: root
     mode: '0644'
-
-# --- mdadm.conf --------------------------------------------------------
 
 - name: Gather mdadm --detail --scan output
   ansible.builtin.command: mdadm --detail --scan
@@ -155,7 +134,6 @@
     group: root
     mode: '0644'
 
-# --- ESP mirror kernel postinst hook -----------------------------------
 
 - name: Ensure /mnt/etc/kernel/postinst.d directory exists
   ansible.builtin.file:

--- a/ansible/ceph/roles/provision_host/tasks/detect.yml
+++ b/ansible/ceph/roles/provision_host/tasks/detect.yml
@@ -1,14 +1,7 @@
 ---
-# Phase 1: Detect state
-#
-# Confirms we're running on a Debian live image (not an installed OS)
-# and booted in UEFI mode, snapshots the current disk layout, then runs
-# the full SSD pre-flight: model-pattern discovery, rotational-flag
-# check, minimum-size floor, and capture of model/serial/size facts.
-# SSD pre-flight lives here (not in disks.yml) so that a bad hardware
-# configuration fails BEFORE any destructive disk work begins, and so
-# that ssd1_dev/ssd2_dev/ssd1_serial/ssd2_serial are available to every
-# later phase unconditionally (including the resume path in disks.yml).
+# The SSD pre-flight lives HERE, not in disks.yml, so bad hardware fails BEFORE
+# destructive work and the ssd*_dev/_serial facts exist for every later phase,
+# resume path included.
 
 - name: Verify host is booted from a Debian live image
   ansible.builtin.stat:
@@ -47,13 +40,7 @@
   ansible.builtin.debug:
     msg: "{{ pre_lsblk.stdout_lines }}"
 
-# --- SSD pre-flight ----------------------------------------------------
-#
-# This block validates the boot SSDs BEFORE the destructive disks phase
-# even gets a chance to run. Failing here means the role exits cleanly
-# with no state changes. The facts set here (ssd1_dev, ssd2_dev,
-# ssd1_serial, ssd2_serial) are consumed by disks.yml + the marker
-# template later in finalize.yml.
+# Failing here exits the role cleanly with no state changes.
 
 - name: Discover candidate SSDs by model pattern
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/provision_host/tasks/disks.yml
+++ b/ansible/ceph/roles/provision_host/tasks/disks.yml
@@ -1,36 +1,5 @@
 ---
-# Phase 3: Disk preparation
-#
-# SSD discovery and validation already happened in detect.yml — this
-# phase consumes ssd1_dev/ssd2_dev (plus serials/sizes/models) and does
-# the destructive work: partitions both SSDs identically with an
-# ESP/boot/root/swap/ceph-db/ceph-osd layout, creates RAID1 arrays for
-# boot/root/swap, creates filesystems, sets up LVM for Ceph block.db,
-# and mounts everything under /mnt.
-#
-# Resume semantics come in two flavors:
-#
-#   1. Fast path — /mnt is already mounted on /dev/md/root. The whole
-#      disks block is skipped and we move on to the install phase. This
-#      lets a post-disks crash (e.g. during debootstrap) be recovered by
-#      just re-running the playbook.
-#
-#   2. Opportunistic remount — /dev/md/root exists but nothing is
-#      mounted (happens after a skip_reboot canary inspection where the
-#      operator unmounted by hand, or after a rescue). We remount
-#      /dev/md/root, read the marker, and if the marker hostname matches
-#      inventory_hostname we finish mounting /mnt/boot + ESP and
-#      continue on the resume path. If the marker is missing or belongs
-#      to a different host, we unmount and fall through to a full wipe.
-#
-# The destructive subpath itself is also defensive about udev
-# re-assembling old mdraid: we stop arrays, then dd-zero the first 4 MB
-# (metadata 1.2) AND the last 4 MB (metadata 1.0) of every RAID member
-# partition before wipefs, so there is no superblock left for udev's
-# `mdadm --incremental` to latch onto during the tiny race window
-# between partprobe and mdadm --create.
-
-# --- State check --------------------------------------------------------
+# DESTRUCTIVE: wipes and repartitions both SSDs unless the resume marker matches this host.
 
 - name: Check if /dev/md/root exists
   ansible.builtin.stat:
@@ -43,18 +12,9 @@
   changed_when: false
   failed_when: false
 
-# --- Opportunistic remount + marker validation --------------------------
-#
-# If /dev/md/root exists but /mnt is not mounted (e.g. previous run was
-# rescued mid-flight, or a skip_reboot run was unmounted by hand), try
-# to remount and validate the on-disk marker. The marker has to match
-# inventory_hostname to be considered legitimate — otherwise we assume
-# this is an old install of a differently-named host and proceed with
-# the wipe.
-#
-# This is the keystone of the marker-driven resume path. Without it,
-# we'd re-wipe a perfectly provisioned system on every commit run after
-# a skip_reboot inspection.
+# Marker must match inventory_hostname or we treat it as a foreign install and
+# wipe. Keystone of the resume path: without it every commit run after a
+# skip_reboot inspection would re-wipe a provisioned system.
 
 - name: Opportunistic remount + marker validation
   when:
@@ -141,21 +101,12 @@
     msg: "Disks already prepared and {{ provision_mnt }} is mounted — skipping disk phase."
   when: disks_prepared
 
-# --- Disk preparation block --------------------------------------------
-
 - name: Prepare disks
   when: not disks_prepared
   block:
-    # SSD discovery + validation already happened in detect.yml. The
-    # facts ssd1_dev / ssd2_dev / ssd1_serial / ssd2_serial are set
-    # there and consumed throughout the rest of this file.
-
-    # ----- Stop any lingering mdraid arrays and clear PVs -----
-    #
-    # The previous install may have left arrays under any name (homehost
-    # prefix from a different hostname, /dev/md0..md127, etc.) that the
-    # live image's udev auto-assembled at boot. Walking /proc/mdstat and
-    # using --stop --scan catches them all, regardless of naming.
+    # A previous install may have arrays under any name (foreign homehost,
+    # md0..md127) auto-assembled by the live image's udev; --stop --scan plus a
+    # /proc/mdstat walk catches them all.
 
     - name: Stop all assembled mdraid arrays
       ansible.builtin.shell: |
@@ -169,13 +120,8 @@
         executable: /bin/bash
       changed_when: false
 
-    # ----- Deactivate and remove any lingering LVM state -----
-    #
-    # Same idea as the mdraid cleanup: a previous install left a VG with
-    # PVs at partition 5 of each SSD. The live image's lvmetad/udev will
-    # auto-activate it, holding the partition device, and the subsequent
-    # wipefs/sgdisk pass would otherwise fail to clear the PV signature.
-    # vgchange -an + vgremove + pvremove is the explicit teardown.
+    # lvmetad/udev auto-activates a leftover VG on partition 5, holding the
+    # device so wipefs/sgdisk could not clear the PV signature.
 
     - name: Deactivate any auto-activated VGs
       ansible.builtin.shell: |
@@ -196,8 +142,6 @@
         executable: /bin/bash
       changed_when: false
 
-    # ----- Full wipe of both SSDs -----
-
     - name: Wipe whole-disk signatures on SSDs
       ansible.builtin.command: "wipefs -af {{ item }}"
       loop:
@@ -211,8 +155,6 @@
         - "{{ ssd1_dev }}"
         - "{{ ssd2_dev }}"
       changed_when: true
-
-    # ----- Partition SSD1 -----
 
     - name: Partition SSD1 with six-partition layout
       ansible.builtin.command: >-
@@ -241,10 +183,8 @@
         - "{{ ssd2_dev }}"
       changed_when: false
 
-    # NOTE: partition-name concatenation assumes SAS-style device names
-    # (sda1, sdb2). R730xd rear SSDs use a SAS HBA, not NVMe. If this role
-    # is ever adapted for NVMe SSDs, add a part_sep fact ("" for SAS,
-    # "p" for NVMe) and interpose it in the paths below.
+    # Partition-name concatenation assumes SAS-style names (sda1); R730xd rear
+    # SSDs are SAS HBA. For NVMe, add a part_sep fact ("" SAS / "p" NVMe).
     - name: Wait for partition device nodes to appear
       ansible.builtin.wait_for:
         path: "{{ item }}"
@@ -264,16 +204,10 @@
         - "{{ ssd2_dev }}5"
         - "{{ ssd2_dev }}6"
 
-    # ----- Post-partprobe mdraid cleanup -----
-    #
-    # After partprobe, udev rescans the new partition table. Because we
-    # recreate identical partition layouts on a re-provision, mdraid
-    # superblocks from the previous install are still at the same byte
-    # offsets — udev runs `mdadm --incremental` on each partition and
-    # re-assembles the old md arrays. Unless we explicitly stop them
-    # again here AND destroy the on-disk superblocks, the partitions
-    # remain "device busy" and mdadm --create fails with
-    # "not suitable for this array".
+    # Identical re-provision layouts leave old superblocks at the same offsets,
+    # so post-partprobe udev `mdadm --incremental` re-assembles them; without
+    # stopping AND destroying superblocks, mdadm --create fails
+    # ("device busy" / "not suitable for this array").
 
     - name: Stop any mdraid arrays auto-assembled by udev after partprobe
       ansible.builtin.shell: |
@@ -285,12 +219,9 @@
         executable: /bin/bash
       changed_when: false
 
-    # Even with the stop above, there's a tiny race window where udev
-    # could re-assemble between the stop and the wipefs below. Destroy
-    # the on-disk superblock regions directly so re-assembly becomes
-    # impossible: zero the first 4 MB (catches mdraid metadata 1.2 at
-    # offset 4 KB) AND the last 4 MB (catches mdraid metadata 1.0 in
-    # the last 8 KB) of every RAID member partition.
+    # udev can re-assemble in the stop->wipefs race; zero first 4 MB (metadata
+    # 1.2 at 4 KB) AND last 4 MB (metadata 1.0 in the last 8 KB) of every RAID
+    # member so re-assembly is impossible.
     - name: Zero mdraid superblock regions on RAID member partitions
       ansible.builtin.shell: |
         set -e
@@ -305,11 +236,7 @@
         executable: /bin/bash
       changed_when: true
 
-    # ----- Clear partition-level stale signatures -----
-    #
-    # wipefs is the catch-all for any non-mdraid signatures (LVM PV
-    # labels on partition 5, vfat on partition 1, etc.) that weren't
-    # covered by the dd-zero above.
+    # wipefs catch-all for non-mdraid signatures (LVM PV on part 5, vfat on part 1).
 
     - name: Wipe partition signatures on SSD1
       ansible.builtin.command: "wipefs -af {{ ssd1_dev }}{{ item }}"
@@ -321,14 +248,9 @@
       loop: [1, 2, 3, 4, 5, 6]
       changed_when: true
 
-    # ----- Final mdraid cleanup before array creation -----
-    #
-    # wipefs and dd-zero removed the on-disk superblocks, but udev may
-    # have already re-assembled stale arrays from signatures it saw
-    # *before* the wipe. We must: (1) stop anything udev auto-assembled,
-    # (2) let udev finish processing the wipe events, (3) remove the
-    # mdadm assemble cache so nothing tries to re-appear. Without this,
-    # mdadm --create fails with "Device or resource busy".
+    # udev may have re-assembled from pre-wipe signatures: stop arrays, settle
+    # udev, remove the mdadm assemble cache (/run/mdadm/map), else mdadm --create
+    # fails "Device or resource busy".
 
     - name: Final mdraid stop + udev settle before array creation
       ansible.builtin.shell: |
@@ -344,8 +266,6 @@
       args:
         executable: /bin/bash
       changed_when: false
-
-    # ----- Create mdraid arrays -----
 
     - name: Create md/boot (RAID1, metadata 1.0 for GRUB compatibility)
       ansible.builtin.command: >-
@@ -367,8 +287,6 @@
         --run --force
         {{ ssd1_dev }}4 {{ ssd2_dev }}4
       changed_when: true
-
-    # ----- Filesystems -----
 
     - name: Create FAT32 ESP on SSD1 partition 1
       community.general.filesystem:
@@ -401,8 +319,6 @@
     - name: Create swap on /dev/md/swap
       ansible.builtin.command: "mkswap -L swap /dev/md/swap"
       changed_when: true
-
-    # ----- LVM for Ceph block.db -----
 
     - name: Create VG1 on SSD1 partition 5
       community.general.lvg:
@@ -446,8 +362,6 @@
         size: 100%FREE
         state: present
 
-    # ----- Mount new filesystems at /mnt (ephemeral, not in fstab) -----
-
     - name: Mount /dev/md/root at /mnt
       ansible.posix.mount:
         path: "{{ provision_mnt }}"
@@ -481,7 +395,3 @@
         fstype: vfat
         opts: umask=0077
         state: ephemeral
-
-# Resume-path SSD rediscovery removed: detect.yml now sets ssd1_dev /
-# ssd2_dev / ssd1_serial / ssd2_serial unconditionally on every run,
-# so the resume path inherits them automatically.

--- a/ansible/ceph/roles/provision_host/tasks/finalize.yml
+++ b/ansible/ceph/roles/provision_host/tasks/finalize.yml
@@ -1,28 +1,9 @@
 ---
-# Phase 9: Finalize
-#
-# 1. Write the provisioning marker to /mnt/etc/ceph-provisioned.json
-#    (skipped on marker-driven resume — provisioning_done guards it)
-# 2. Sync the primary ESP to the backup ESP on SSD2
-#    (also skipped on resume)
-# 3. If provision_skip_reboot is true, stop here — /mnt stays mounted
-#    with chroot bind mounts active for canary inspection. Operator
-#    can `chroot /mnt` to verify, unmount manually, reboot when ready.
-# 4. Otherwise include unmount.yml to tear down the chroot bind mounts
-#    and the /mnt hierarchy in reverse order (shared with the rescue
-#    path in main.yml).
-# 5. Trigger a reboot via systemd-run (fire-and-forget — the live
-#    image will disappear, so ansible cannot wait on SSH here).
-#
-# A separate post-reboot verification play runs from localhost after
-# this one completes.
+# Marker write + ESP mirror are skipped on resume via provisioning_done: an
+# existing marker must not get a bumped timestamp. The reboot is a systemd-run
+# fire-and-forget -- the live image disappears, so ansible cannot wait on SSH;
+# post-reboot verification is a separate localhost play.
 
-# --- Write marker + mirror ESP (skipped on resume via marker gate) -----
-#
-# Both of these tasks are gated on `not provisioning_done` because the
-# marker file IS the marker — if it already exists, we wrote it on a
-# previous run and don't want to bump the timestamp. The ESP mirror
-# is similarly idempotent on re-run and would just waste time.
 
 - name: Write marker and mirror ESP
   when: not provisioning_done
@@ -64,12 +45,8 @@
         path: /tmp/provision-backup-esp
         state: absent
 
-# --- Skip-reboot inspection mode ---------------------------------------
-#
-# When provision_skip_reboot is set, finalize stops here. Marker is
-# written, ESP is mirrored, but /mnt stays mounted (with the chroot
-# bind mounts still active). Operator can then `chroot /mnt` to verify,
-# unmount manually, and reboot when ready.
+# provision_skip_reboot leaves /mnt and the chroot binds mounted so the operator
+# can `chroot /mnt` to verify, then unmount and reboot by hand.
 
 - name: Report inspection-mode finalize (reboot skipped)
   ansible.builtin.debug:
@@ -86,7 +63,6 @@
   ansible.builtin.meta: end_host
   when: provision_skip_reboot | bool
 
-# --- Unmount chroot bind mounts and /mnt hierarchy ---------------------
 
 - name: Include unmount tasks (reverse order, best-effort)
   ansible.builtin.include_tasks: unmount.yml
@@ -95,7 +71,6 @@
   ansible.builtin.command: sync
   changed_when: false
 
-# --- Reboot ------------------------------------------------------------
 
 - name: Schedule async reboot via systemd-run
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/provision_host/tasks/install.yml
+++ b/ansible/ceph/roles/provision_host/tasks/install.yml
@@ -1,10 +1,6 @@
 ---
-# Phase 4: Base OS install via debootstrap
-#
-# Idempotent via stat check on /mnt/etc/debian_version. If that file
-# already exists we trust that a previous debootstrap run succeeded
-# and skip. A failed debootstrap leaves /mnt partially populated but
-# without /etc/debian_version, so re-runs will re-bootstrap.
+# Idempotent via /mnt/etc/debian_version: a failed debootstrap leaves /mnt
+# partially populated but without that file, so re-runs re-bootstrap.
 
 - name: Check for existing debootstrap result
   ansible.builtin.stat:
@@ -17,7 +13,6 @@
     {{ provision_mnt }} {{ provision_debian_mirror }}
   when: not debian_version_stat.stat.exists
   changed_when: true
-  # Debootstrap downloads a lot of packages — give it room to breathe.
   async: 1800
   poll: 15
 

--- a/ansible/ceph/roles/provision_host/tasks/main.yml
+++ b/ansible/ceph/roles/provision_host/tasks/main.yml
@@ -1,42 +1,9 @@
 ---
-# provision-host — idempotent fresh-install provisioning for sietch-ceph nodes.
-#
-# Flow:
-#   1. detect.yml             — live image + UEFI assertions, SSD pre-flight
-#                               discovery and validation
-#   2. prerequisites_live.yml — rewrite apt sources off the live medium and
-#                               install debootstrap/mdadm/lvm2/etc on the live image
-#   3. disks.yml              — opportunistic remount + marker probe, otherwise
-#                               wipe, partition, mdraid, LVM, mount at /mnt
-#   4. install.yml            — debootstrap Bookworm into /mnt
-#   5. configure.yml          — templates for hostname/hosts/network/fstab/mdadm
-#   6. chroot_packages.yml    — probe-then-mount bind mounts, apt install,
-#                               machine-id, SSH host keys, enable services
-#   7. admin_user.yml         — create ansible-iac (key-only, uid 1000)
-#                               inside chroot. The ops user is NOT created
-#                               here — it's created post-boot by the baseline
-#                               role (keeps fragile chroot work minimal,
-#                               separate from post-boot convergeable config).
-#   8. bootloader.yml         — initramfs, grub-install, efibootmgr fallback
-#   9. finalize.yml           — marker + ESP mirror, then unmount + reboot
-#                               (or stop short for skip-reboot canary mode)
-#  10. unmount.yml            — reverse-order best-effort cleanup, shared
-#                               between the successful finalize path and the
-#                               rescue block on failure
-#
-# Each phase has its own internal idempotency guards so the entire role
-# is safe to re-run after a partial failure. If a phase crashes, the
-# block/rescue unmounts /mnt so the next run starts from a clean state.
-#
-# Once the on-disk marker at /mnt/etc/ceph-provisioned.json is present
-# and matches inventory_hostname, chroot phases 4-8 plus the marker/ESP
-# block in phase 9 all short-circuit via `provisioning_done` and the role
-# goes straight to unmount + reboot. This is what makes the skip-reboot
-# canary path safe to commit on a follow-up run.
-#
-# To re-provision an already-installed host: reboot into the live image,
-# then re-run the playbook. If disks.yml can't find (or can't validate)
-# an existing marker it will wipe and start over.
+# Each phase guards its own idempotency; a crash unmounts /mnt via rescue so the
+# next run starts clean. A matching marker short-circuits the chroot phases via
+# `provisioning_done` straight to unmount + reboot -- what makes committing after
+# a skip-reboot canary safe. Re-provision an installed host by rebooting into the
+# live image and re-running; a missing/invalid marker wipes.
 
 - name: Detect provisioning state
   ansible.builtin.import_tasks: detect.yml
@@ -56,27 +23,16 @@
     - name: Prepare disks (partition, mdraid, LVM, mount)
       ansible.builtin.import_tasks: disks.yml
 
-    # Optional: wipe the OSD data HDDs too (default off). Needed on a clean
-    # rebuild from the live image, where destroy-ceph.yml never ran to tear
-    # OSDs down -- otherwise cephadm skips the still-signed HDDs. Opt in with
-    # -e provision_wipe_osd_disks=true (alongside confirm_wipe=true).
+    # Opt-in (-e provision_wipe_osd_disks=true, with confirm_wipe=true): on a
+    # clean rebuild destroy-ceph.yml never ran, and cephadm skips still-signed HDDs.
     - name: Wipe OSD data HDDs (opt-in)
       ansible.builtin.import_tasks: wipe-osds.yml
       when: provision_wipe_osd_disks | default(false) | bool
 
-    # ----- Marker-driven resume gate -------------------------------------
-    #
-    # If the chroot at /mnt already contains the provisioning marker, the
-    # whole install/configure/chroot/admin/bootloader/finalize-marker
-    # sequence is a no-op — they all wrote their final state on a previous
-    # run. The only thing left to do is unmount + reboot. Skipping all the
-    # chroot phases on resume avoids:
-    #   - re-binding bind mounts that are already in place
-    #   - re-rotating SSH host keys (would break known_hosts)
-    #   - re-hashing the ops password with a fresh salt
-    #   - re-running grub-install/update-grub for no reason
-    #   - re-rendering the marker with a stale provisioned_at timestamp
-
+    # Marker present in /mnt = all chroot phases already wrote their final state.
+    # Skipping avoids re-binding mounts, re-rotating SSH host keys (breaks
+    # known_hosts), re-salting the ops password, pointless grub-install, and a
+    # stale provisioned_at rewrite.
     - name: Check if provisioning marker is present in chroot
       ansible.builtin.stat:
         path: "{{ provision_mnt }}{{ provision_marker_path }}"

--- a/ansible/ceph/roles/provision_host/tasks/prerequisites_live.yml
+++ b/ansible/ceph/roles/provision_host/tasks/prerequisites_live.yml
@@ -1,10 +1,4 @@
 ---
-# Phase 2: Live-image prerequisites
-#
-# Installs the packages needed to run the rest of provisioning
-# (debootstrap, sgdisk, mdadm, lvm2, etc.) on the live image itself.
-# Idempotent — apt module only installs what's missing.
-
 # The Debian live image ships with a sources.list (and/or sources.list.d
 # entries) referencing `file:/run/live/medium`, which is NOT a real apt
 # repo and causes apt-get update to fail with "File not found". Replace

--- a/ansible/ceph/roles/provision_host/tasks/unmount.yml
+++ b/ansible/ceph/roles/provision_host/tasks/unmount.yml
@@ -1,10 +1,6 @@
 ---
-# Helper: unmount the chroot bind mounts and /mnt hierarchy in reverse
-# order. Called by finalize.yml at the end of a successful run and by
-# main.yml's rescue block on failure.
-#
-# Every unmount is best-effort (failed_when: false) — if a path isn't
-# mounted we just want to keep going.
+# Reverse order. Called by finalize.yml on success and by main.yml's rescue block
+# on failure, so every unmount is best-effort.
 
 - name: Unmount chroot bind mounts (reverse order)
   ansible.posix.mount:

--- a/ansible/ceph/roles/provision_host/tasks/wipe-osds.yml
+++ b/ansible/ceph/roles/provision_host/tasks/wipe-osds.yml
@@ -1,18 +1,10 @@
 ---
-# Zap the OSD data HDDs so cephadm sees them as available on a clean rebuild.
-#
-# WHY: disks.yml wipes only the two OS/block.db SSDs. The OSD HDDs keep the
-# previous cluster LVM (ceph-<uuid> VGs) plus bluestore signatures. cephadm
-# `ceph orch apply osd` only consumes disks it considers AVAILABLE, so leftover
-# signatures make it skip the HDDs and the OSD wait loop times out. In the
-# live-image reimage path destroy-ceph.yml never ran to tear OSDs down
-# gracefully, so we clear them here.
-#
-# Gated by provision_wipe_osd_disks (default false) on top of the role
-# confirm_wipe gate -- both must be set, since this is irreversible OSD data
-# loss. Targets exactly the ceph_hdd_osds devices (phy0..N), never the SSDs
-# (which are phy12/phy13 and handled by disks.yml). sietch-shape only
-# (sas_path_prefix); NVMe-RAID-shape hosts are out of scope here.
+# Zap the OSD data HDDs so cephadm sees them as AVAILABLE on a clean rebuild:
+# disks.yml wipes only the SSDs, and leftover ceph-<uuid> LVM + bluestore
+# signatures make `ceph orch apply osd` skip the HDDs until the wait loop times
+# out (the reimage path never ran destroy-ceph.yml). IRREVERSIBLE OSD data loss:
+# gated on provision_wipe_osd_disks AND confirm_wipe. Targets exactly the
+# ceph_hdd_osds devices, never the SSDs. sietch-shape (sas_path_prefix) only.
 
 - name: Zap OSD HDDs (remove LVM, wipe signatures, zero bluestore label)
   ansible.builtin.shell: |

--- a/ansible/ceph/roles/reprovision_hetzner/defaults/main.yml
+++ b/ansible/ceph/roles/reprovision_hetzner/defaults/main.yml
@@ -1,48 +1,38 @@
 ---
-# reprovision_hetzner - drive a Hetzner Robot installimage reprovision of an
-# SX295 ceph node: arm rescue + hw reset (Robot API via uri), wait for the real
-# rescue ramdisk, optionally zap the OSD HDDs, run installimage, reboot, verify.
-#
 # Everything that touches a node is delegate_to: localhost raw ssh/scp (no Python
 # on the rescue ramdisk; survives the reset/reboot connection boundary). This role
 # is ALWAYS destructive to the OS NVMes and must NEVER be folded into deploy/converge.
 
-# --- Robot API ---
-# Master switch for the Hetzner Robot portion (register rescue keys, arm rescue,
-# hw reset). Default true = the full remote path (reprovision.yml). Set false for
-# the manual rescue-first path (add-node.yml): the operator arms rescue + resets a
-# node by hand in the portal, and Ansible only runs the install/chroot/verify once
-# the node is ALREADY in rescue. False removes the Robot API from the loop entirely
-# -- no key registration, no arm, no reset -- so an errant run cannot flip a live
-# node into rescue (installimage exists only in the rescue ramdisk, so wait_rescue
-# refuses a node a human did not deliberately rescue).
+# Master switch for the Robot portion (register keys, arm rescue, hw reset).
+# true = full remote path (reprovision.yml). false = manual rescue-first path
+# (add-node.yml): operator arms rescue + resets in the portal, Ansible only runs
+# install/chroot/verify on a node ALREADY in rescue -- an errant run cannot flip
+# a live node (wait_rescue gates on the rescue-only installimage binary).
 reprovision_use_robot: true
 reprovision_robot_base_url: "https://robot-ws.your-server.de"
 reprovision_robot_username: "{{ lookup('ansible.builtin.env', 'HETZNER_ROBOT_USERNAME') }}"
 reprovision_robot_password: "{{ lookup('ansible.builtin.env', 'HETZNER_ROBOT_PASSWORD') }}"
 reprovision_rescue_os: linux
-reprovision_robot_retries: 5         # retry Robot API calls on 429/5xx/transient before failing the node
+reprovision_robot_retries: 5         # retries on Robot 429/5xx before failing the node
 reprovision_robot_delay: 10
 
-# --- installimage / hardware (SX295 painbox shape) ---
 reprovision_image: "/root/.oldroot/nfs/install/../images/Debian-bookworm-latest-amd64-base.tar.zst"
 # The Hetzner rescue installer is NOT on PATH; invoke + gate on its real path.
 # Its presence (executable) is also the reliable "am I in rescue?" signal.
 reprovision_installimage_bin: /root/.oldroot/nfs/install/installimage
 reprovision_boot_mode: bios          # bios|uefi - gates the ESP partition in autosetup.j2
-reprovision_expect_nvme: 2           # 2x NVMe (OS RAID-1)
-reprovision_expect_sata: 14          # 14x SATA HDD (OSDs) - baseline; some nodes carry more
+reprovision_expect_nvme: 2           # OS RAID-1 pair
+reprovision_expect_sata: 14          # OSD HDDs; baseline, some nodes carry more
 reprovision_disk_min_bytes: 1000000000000  # 1 TB floor for disk classification (drops the BMC 0-byte virtual disk)
 reprovision_installimage_timeout: 1800
 
-# --- SSH (one key only, no agent -> no MaxAuthTries; key authorized in BOTH rescue and installed OS) ---
+# One key only, no agent -> no MaxAuthTries; key authorized in BOTH rescue and installed OS.
 reprovision_ssh_user: root
-reprovision_ssh_key_path: "{{ provision_iac_ssh_key_path }}"   # ~/.ssh/id_ed25519_spice
+reprovision_ssh_key_path: "{{ provision_iac_ssh_key_path }}"
 reprovision_ssh_opts: >-
   -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=no
   -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o LogLevel=ERROR
 
-# --- gating + modes ---
 confirm_wipe: false                  # hard destructive gate (must pass -e confirm_wipe=true)
 reprovision_mode: install            # install | inspect (inspect = arm+reset+wait+inspect, NO wipe)
 reprovision_wipe_osd_disks: false    # opt-in: zap the 14 OSD HDDs in rescue (day-2 reimage; off for virgin bootstrap)
@@ -53,24 +43,23 @@ reprovision_ceph_safety: auto        # auto | strict | permissive (see tasks/cep
 # Resume-safe re-runs: skip a node whose INSTALLED-OS marker already matches inventory
 # (converge the not-yet-done nodes, leave the good ones alone). Off = always reimage.
 reprovision_skip_if_provisioned: false
-reprovision_force: false             # override skip_if_provisioned: reimage even if already provisioned
+reprovision_force: false
 reprovision_probe_retries: 3         # transport-only retries for the skip probe (don't re-wipe a healthy node on an ssh blip)
 reprovision_probe_delay: 5
 
-# --- timing / polling ---
-reprovision_reset_settle_delay: 25   # pause after hw-reset before first rescue probe
+reprovision_reset_settle_delay: 25
 reprovision_rescue_retries: 60       # 60 x 10s = 10 min to enter rescue
 reprovision_rescue_delay: 10
 reprovision_rescue_max_uptime: 1200  # this-boot guard: reject a stale already-up rescue (P1-4)
-reprovision_os_retries: 60           # 60 x 15s = 15 min for installed OS
+reprovision_os_retries: 60           # 60 x 15s = 15 min for the installed OS
 reprovision_os_delay: 15
 reprovision_marker_path: /etc/ceph-provisioned.json
 
-# --- canary gate (fan-out blocked until the canary is verified-booted) ---
+# Fan-out is blocked until the canary is verified-booted.
 reprovision_canary_host: spice-ceph-adelia
 reprovision_canary_marker: "{{ lookup('ansible.builtin.env', 'HOME') }}/.cache/{{ cluster_name | default('spice') }}-canary-verified"
 
-# --- keys authorized in RESCUE: operator break-glass keys; the iac pubkey is added from disk by register_keys ---
+# Authorized in RESCUE (break-glass); the iac pubkey is added from disk by register_keys.
 reprovision_operator_pubkeys:
   - { name: andy-futo, key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7XdW03gJKyABt5KCMxOLPb5sOGTXuZV0OHc1Ro46Nt andy@futo.org" }
   - { name: nutgood, key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOaH71qha6kLO2qRu+w6C5wPpWhkiBjEUeY1fAjAVApR nutgood" }

--- a/ansible/ceph/roles/reprovision_hetzner/files/prepare-os-disks.sh
+++ b/ansible/ceph/roles/reprovision_hetzner/files/prepare-os-disks.sh
@@ -1,29 +1,16 @@
 #!/bin/bash
-# Clear stale mdraid metadata (from a previous install, on ANY disk) and fully
-# wipe the OS NVMe disks, in the Hetzner rescue ramdisk BEFORE installimage.
-#
-# WHY: installimage's new NVMe RAID is auto-named rescue:0 / rescue:1. If a previous
-# install left mdraid superblocks with the SAME names on OTHER disks (the stor-test
-# boxes carried RAID across the SATA HDDs), the installed OS's initramfs sees
-# DUPLICATE array names, cannot assemble root at boot, and never comes back on the
-# network. So stale superblocks must be cleared on EVERY disk.
-#
-# HOW (robust): mdadm --zero-superblock is silently reverted while an array is still
-# assembled, so we (1) stop arrays in a loop until /proc/mdstat is empty, and
-# (2) zero the superblock regions with RAW dd at BOTH ends of each member (metadata
-# 1.2 at the front, 1.0 at the tail) - raw writes cannot be refused by a live array -
-# plus wipefs, re-stopping after each member in case a degraded array re-assembles.
-#
-# SAFETY: the mdraid-superblock clearing only touches devices that ACTUALLY carry a
-# superblock (a no-op on the bluestore OSD HDDs, which are LVM with no mdraid). The
-# extra destructive wipe (vgremove/pvremove/sgdisk/partprobe) is OS-NVMe-only.
-#
-# DO NOT read this as "a reimage preserves OSDs". On the NVMe-RAID shape (spice) the
-# HDD OSD block.db LVs AND the ssd-osd data LV live on the OS NVMe (vg0) this script
-# zeroes, so a reimage DESTROYS every OSD on the node even though the HDD data
-# devices themselves are untouched (an OSD is unusable once its block.db is gone).
-# The tasks/ceph_safety.yml gate must clear the node (ceph osd ok-to-stop) first.
-# Mirrors provision_host/tasks/disks.yml.
+# Clear stale mdraid metadata on ANY disk + fully wipe the OS NVMes, in rescue
+# BEFORE installimage. WHY: installimage names the new RAID rescue:0/1; stale
+# superblocks with the SAME names elsewhere (stor-test boxes carried RAID on the
+# SATA HDDs) give the initramfs duplicate array names -> root never assembles,
+# node never comes back. HOW: mdadm --zero-superblock is silently reverted while
+# an array is assembled, so stop-loop until /proc/mdstat is empty, then raw dd at
+# BOTH ends of each member (metadata 1.2 front, 1.0 tail) + wipefs, re-stopping
+# per member. SAFETY: superblock clearing only touches devices that carry one
+# (no-op on the LVM bluestore HDDs); the vgremove/pvremove/sgdisk wipe is
+# OS-NVMe-only. NOT data-preserving on the NVMe-RAID shape: vg0 holds every
+# block.db + the ssd-osd LV, so a reimage DESTROYS all OSDs on the node --
+# ceph_safety.yml (ok-to-stop) must clear it first. Mirrors provision_host/tasks/disks.yml.
 set -uo pipefail
 echo "=== prepare-os-disks: starting ==="
 

--- a/ansible/ceph/roles/reprovision_hetzner/files/zap-osd-hdds.sh
+++ b/ansible/ceph/roles/reprovision_hetzner/files/zap-osd-hdds.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
-# Zap the OSD data HDDs in the Hetzner RESCUE ramdisk, before installimage, so
-# cephadm sees them as AVAILABLE on a clean rebuild. Leftover ceph LVM / bluestore
-# / LUKS signatures otherwise make `ceph orch apply osd` skip the disks.
-#
-# Proven sequence distilled from yucca ceph_destroy/cleanup.yml +
-# provision_host/wipe-osds.yml. Targets ALL SATA disks (sd*); NEVER the NVMe OS
-# disks (installimage's SWRAID handles those). Idempotent and safe to re-run.
+# Runs in the Hetzner RESCUE ramdisk before installimage: leftover ceph LVM /
+# bluestore / LUKS signatures make `ceph orch apply osd` skip the disks.
+# Targets ALL SATA disks; NEVER the NVMe OS disks (installimage's SWRAID owns
+# those). Idempotent.
 #
 # Running in rescue (not a live node) sidesteps the LUKS-lock problem: a fresh
 # rescue never opens the dmcrypt mappings, so wipefs can clear the headers
@@ -30,8 +27,7 @@ for vg in $(vgs --noheadings -o vg_name 2>/dev/null | grep -i ceph | tr -d ' ');
   vgremove -ff "$vg" 2>/dev/null || true
 done
 
-# Per OSD HDD: drop any PV, wipe signatures, zap GPT, zero the bluestore label.
-# Select by rotational type + size (like sietch), NOT /dev/sdN - so the BMC 0-byte
+# Select by rotational type + size, NOT /dev/sdN, so the BMC 0-byte
 # "Virtual HDisk0" and the NVMe OS disks are excluded automatically.
 MIN_BYTES=1000000000000   # 1 TB floor
 mapfile -t DISKS < <(lsblk -dbn -o NAME,SIZE,ROTA,TYPE | awk -v m="$MIN_BYTES" '$4=="disk" && $3==1 && $2+0>=m+0 {print "/dev/"$1}')

--- a/ansible/ceph/roles/reprovision_hetzner/tasks/ceph_safety.yml
+++ b/ansible/ceph/roles/reprovision_hetzner/tasks/ceph_safety.yml
@@ -1,27 +1,14 @@
 ---
-# Day-2 safety gate for a live-cluster reimage.
-#
-# WHY THIS MATTERS ON SPICE: a reimage zeroes the OS NVMe (prepare-os-disks.sh),
-# and on the NVMe-RAID shape the 14 HDD OSD block.db LVs AND the ssd-osd data LV
-# all live on that NVMe (vg0). So reimaging a spice node DESTROYS every OSD on it
-# -- it is NOT a data-preserving operation. This gate refuses to proceed unless a
-# healthy cluster confirms the node's OSDs are safe to stop.
-#
+# Day-2 safety gate for a live-cluster reimage. On the NVMe-RAID shape a reimage
+# zeroes vg0 = all 14 block.db LVs + the ssd-osd LV, so it DESTROYS every OSD on
+# the node; a healthy cluster must confirm ok-to-stop first.
 # Modes (reprovision_ceph_safety):
-#   auto (default) - delegate to a peer admin/mon host and probe the cluster. If a
-#                    live cluster is reachable and this node has OSDs in it, enforce
-#                    the real checks; if no cluster answers (initial bootstrap),
-#                    permit. Default-on precisely when there is something to protect.
-#   strict         - always enforce; if the cluster cannot be reached to verify,
-#                    REFUSE (fail closed). Use for a deliberate day-2 reimage.
-#   permissive     - skip all checks. Explicit escape hatch for the initial
-#                    bootstrap, or a known-dead node when no peer can verify it.
-#
-# Enforced checks (auto-when-reachable and strict):
-#   - cluster is not HEALTH_ERR (no inactive/unavailable PGs)
-#   - `ceph osd ok-to-stop <this node's osd ids>` returns ok
-# On pass, noout is set on this node's OSDs so the reimage window does not trigger
-# a premature rebalance; it clears when the old OSDs are purged on re-add.
+#   auto (default) - probe via a peer mon; enforce when a live cluster holds this
+#                    node's OSDs, permit when nothing answers (initial bootstrap).
+#   strict         - always enforce; unverifiable = REFUSE (deliberate day-2 reimage).
+#   permissive     - skip all checks (bootstrap / known-dead-node escape hatch).
+# Enforced: not HEALTH_ERR + `ceph osd ok-to-stop <ids>`. On pass, noout is set on
+# this node's OSDs (no premature rebalance); clears when old OSDs purge on re-add.
 
 - name: Ceph-safety - resolve mode and admin delegate
   ansible.builtin.set_fact:
@@ -47,29 +34,26 @@
 - name: Ceph-safety - evaluate live-cluster reimage safety
   ansible.builtin.shell: |
     set -o pipefail
-    # 1. Is a cluster reachable from this admin peer?
     if ! ceph fsid >/dev/null 2>&1; then
       if [ "$CS_MODE" = strict ]; then
         echo "VERDICT=REFUSE reason=cluster-unreachable-in-strict"; exit 0
       fi
       echo "VERDICT=PERMIT reason=no-cluster-bootstrap"; exit 0
     fi
-    # 2. Does the target host still carry OSDs in this cluster?
     ids=$(ceph osd ls-tree "$CS_HOST" 2>/dev/null | awk 'NF' | tr '\n' ' ')
     ids=$(echo "$ids" | xargs || true)
     if [ -z "$ids" ]; then
       echo "VERDICT=PERMIT reason=no-osds-on-host host=$CS_HOST"; exit 0
     fi
-    # 3. Refuse on HEALTH_ERR (inactive / unavailable PGs - losing more is unsafe).
+    # HEALTH_ERR means PGs are already inactive/unavailable; losing more is unsafe.
     h=$(ceph health 2>/dev/null | cut -d' ' -f1)
     if [ "$h" = "HEALTH_ERR" ]; then
       echo "VERDICT=REFUSE reason=HEALTH_ERR host=$CS_HOST osds=[$ids]"; exit 0
     fi
-    # 4. Ask the cluster whether stopping the OSDs on this host keeps PGs available.
     if ! ceph osd ok-to-stop $ids >/dev/null 2>&1; then
       echo "VERDICT=REFUSE reason=not-ok-to-stop host=$CS_HOST osds=[$ids] health=$h"; exit 0
     fi
-    # 5. Passed - protect the reimage window from a premature rebalance.
+    # noout protects the reimage window from a premature rebalance.
     for id in $ids; do ceph osd add-noout "osd.$id" >/dev/null 2>&1 || true; done
     echo "VERDICT=PERMIT reason=ok-to-stop host=$CS_HOST osds=[$ids] health=$h noout=set"
   args:

--- a/ansible/ceph/roles/reprovision_hetzner/tasks/preflight.yml
+++ b/ansible/ceph/roles/reprovision_hetzner/tasks/preflight.yml
@@ -45,7 +45,6 @@
       (--limit {{ reprovision_canary_host }}); fan-out unlocks once its wait/verify
       succeeds, or override with -e allow_fanout=true.
 
-# --- Register rescue keys in the Robot (Robot path only) ----------------------
 # Skipped entirely on the manual add-node path (reprovision_use_robot=false): the
 # operator arms rescue by hand in the portal, so no API key registration is needed.
 - name: Register rescue keys + resolve fingerprints in the Robot

--- a/ansible/ceph/roles/s3_bench/defaults/main.yml
+++ b/ansible/ceph/roles/s3_bench/defaults/main.yml
@@ -1,11 +1,8 @@
 ---
-# S3 benchmark defaults
-#
-# Runs s3bench.py on each ceph_node against its local RGW endpoint.
-# Results land in {{ s3bench_log_dir }} on each node and are fetched
-# to {{ playbook_dir }}/bench/ on the controller.
+# Runs s3bench.py on each ceph_node against its local RGW endpoint. Results land
+# in {{ s3bench_log_dir }} on each node and are fetched to
+# {{ playbook_dir }}/bench/ on the controller.
 
-# Benchmark parameters
 s3bench_bucket: s3bench
 s3bench_object_size_mb: 16
 s3bench_num_objects: 1000
@@ -13,21 +10,15 @@ s3bench_concurrency: 8
 s3bench_ops: put             # put, get, delete, or mixed
 s3bench_key_prefix: "bench"
 
-# Per-node key offset spacing — ensures non-overlapping keys when
-# running in parallel across multiple nodes. Node N gets offset
-# N * s3bench_key_offset_stride.
+# Node N gets offset N * stride, so parallel nodes never share keys.
 s3bench_key_offset_stride: 100000
 
-# RGW endpoint (per-node, uses local RGW)
 s3bench_endpoint_scheme: "{{ ceph_rgw_scheme | default('https') }}"
 s3bench_endpoint_port: "{{ ceph_rgw_port | default(443) }}"
 s3bench_ssl_verify: false
 
-# S3 credentials — uses the svc-yucca-restic user by default.
-# Override with dedicated bench user if desired.
 s3bench_s3_user: "{{ ceph_rgw_s3_user_uid | default('svc-yucca-restic') }}"
 
-# Output
 s3bench_log_dir: /var/log/s3bench
 s3bench_fetch_results: true
 s3bench_local_results_dir: "{{ playbook_dir }}/bench"

--- a/ansible/ceph/roles/s3_bench/tasks/main.yml
+++ b/ansible/ceph/roles/s3_bench/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
-# S3 benchmark role — deploys s3bench.py to each node and runs a
-# parallel workload against each node's local RGW endpoint.
-#
-# Prerequisites: python3-boto3 (installed by the baseline role)
-# Results: JSONL logs on each node + fetched to controller bench/ dir
+# Requires python3-boto3 (installed by the baseline role). Results: JSONL logs on
+# each node, fetched to the controller's bench/ dir.
 
 - name: Create log directory
   ansible.builtin.file:

--- a/ansible/ceph/roles/security/defaults/main.yml
+++ b/ansible/ceph/roles/security/defaults/main.yml
@@ -1,10 +1,6 @@
 ---
-# Security hardening defaults for Ceph nodes
-
-# --- Firewall (nftables) ---
 ceph_firewall_enabled: true
 
-# Trusted source networks allowed to reach Ceph services.
 # RFC1918 + Tailscale CGNAT. Loopback is always allowed via iifname "lo".
 ceph_firewall_trusted_networks:
   - 10.0.0.0/8
@@ -12,28 +8,22 @@ ceph_firewall_trusted_networks:
   - 192.168.0.0/16
   - 100.64.0.0/10
 
-# Interfaces accepted WHOLESALE (no port filtering), e.g. the closed
-# replication VLAN (spice: bond0.122). Port rules only match daemon dports,
-# so return traffic of connections established BEFORE the firewall loaded
-# targets ephemeral ports and hits the drop policy (conntrack cannot adopt
-# mid-stream flows it did not see open). On a closed cluster L2, filtering
-# per-port adds nothing; accepting the interface keeps live replication
-# flowing through a firewall (re)activation. Default empty: flat-network
-# clusters (sietch) have no dedicated replication interface to trust.
+# Interfaces accepted WHOLESALE (e.g. spice's closed replication VLAN bond0.122).
+# Port rules match daemon dports only, so flows established BEFORE the firewall
+# loaded return on ephemeral ports and hit the drop policy (conntrack cannot
+# adopt mid-stream flows); accepting the closed L2 keeps live replication alive
+# through a firewall (re)activation. Empty default for flat clusters (sietch).
 ceph_firewall_trusted_ifaces: []
 
-# Ports to open (derived from Ceph service layout)
 ceph_firewall_mon_ports: [3300, 6789]
 # Full modern bind range (ms_bind_port_max default 7568; the historic docs
 # range 6800-7300 under-covers a restart-churned 15-OSD host).
 ceph_firewall_osd_port_range: "6800-7568"
 ceph_firewall_rgw_port: "{{ ceph_rgw_port | default(443) }}"
-# Allow RGW/S3 from any source (true) or restrict to trusted networks (false).
-# Mirrors ceph_firewall_ssh_any_source. Default true so a public S3 endpoint
-# keeps working out of the box. Set false in production once the client path is
-# confirmed to be inside ceph_firewall_trusted_networks (RFC1918 + NetBird
-# 100.64.0.0/10); on spice the fabric (10.40.20.0/23) and NetBird overlay both
-# already fall in those ranges, so restricting drops only public-internet reach.
+# RGW/S3 from any source (true) or trusted networks only (false). Default true
+# for a public S3 endpoint; set false once the client path is confirmed inside
+# ceph_firewall_trusted_networks (spice fabric + NetBird overlay both are, so
+# restricting drops only public-internet reach).
 ceph_firewall_rgw_any_source: true
 ceph_firewall_dashboard_port: 8443
 ceph_firewall_prometheus_port: "{{ ceph_prometheus_port | default(9095) }}"
@@ -42,34 +32,24 @@ ceph_firewall_alertmanager_port: "{{ ceph_alertmanager_port | default(9093) }}"
 ceph_firewall_node_exporter_port: 9100
 ceph_firewall_mgr_exporter_port: 9283
 ceph_firewall_ceph_exporter_port: 9926
-# Fluent Bit's own metrics (roles/fluentbit). Bound to the fabric public address
-# so vmagent reaches it the same way as the exporters above. Opening the port
-# where the agent is not enabled is inert: nothing listens.
 ceph_firewall_fluentbit_port: 2020
-# cephadm service discovery (mgr). Prometheus fetches its scrape target list
-# from this endpoint on the active mgr via http_sd. If it is not reachable from
-# the Prometheus host, Prometheus discovers zero targets and Grafana shows no
-# data. The active mgr can be any node, so this must be open on all of them.
+# cephadm service discovery: Prometheus http_sd fetches its target list from the
+# active mgr -- unreachable = zero targets, Grafana empty. Active mgr can be any
+# node, so open on all.
 ceph_firewall_service_discovery_port: 8765
 
-# --- Optional service gateways (disabled by default) ---
-
-# iSCSI gateway - block storage for non-native clients
 ceph_firewall_iscsi_enabled: false
 ceph_firewall_iscsi_port: 3260
 ceph_firewall_iscsi_api_port: 5000
 
-# NFS-Ganesha - CephFS export for NFS clients
 ceph_firewall_nfs_enabled: false
 ceph_firewall_nfs_port: 2049
 ceph_firewall_nfs_mgmt_port: 12049
 
-# Allow SSH from any source (true) or restrict to trusted networks (false).
-# Default true for dev/bootstrapping. Set false in production once
-# management networks are confirmed.
+# SSH from any source (true) or trusted networks only (false). Default true for
+# dev/bootstrapping; false in prod once management networks are confirmed.
 ceph_firewall_ssh_any_source: true
 
-# --- SSH hardening ---
 ceph_ssh_max_auth_tries: 3
 ceph_ssh_permit_root_login: prohibit-password
 ceph_ssh_allowed_users: "ansible-iac ops root"

--- a/ansible/ceph/roles/security/molecule/fabric-only/verify.yml
+++ b/ansible/ceph/roles/security/molecule/fabric-only/verify.yml
@@ -25,7 +25,6 @@
   tasks:
     - name: Select the fabric-only (closed) firewall branch
       ansible.builtin.set_fact:
-        # No any-source exposure for RGW or SSH.
         ceph_firewall_rgw_any_source: false
         ceph_firewall_ssh_any_source: false
         # spice fabric (10.40.20.0/23) + NetBird overlay (100.64.0.0/10).

--- a/ansible/ceph/roles/security/tasks/main.yml
+++ b/ansible/ceph/roles/security/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
-# Security hardening for Ceph nodes.
-# Firewall (nftables) + SSH hardening.
-# Run AFTER ceph_deploy so cephadm orchestrator can freely deploy daemons.
-
-# --- nftables firewall ---
+# Run AFTER ceph_deploy so the cephadm orchestrator can deploy daemons freely.
 
 - name: Install nftables
   ansible.builtin.apt:
@@ -20,17 +16,13 @@
     validate: "nft -c -f %s"
   when: ceph_firewall_enabled | bool
 
-# Reload the firewall only when the LIVE filter table actually differs from the
-# desired one -- not merely when the rendered file changed. On DIFF we `reload`
-# (ExecReload = nft -f /etc/nftables.conf), which with the table-scoped config
-# atomically replaces ONLY table inet filter and leaves the podman/docker tables
-# alone -- unlike a `restart`, whose ExecStop flushes the whole ruleset (that
-# momentary flush can stall OSD peering and drop podman's rules). The desired
-# state is normalized by loading the config into a throwaway network namespace --
-# fully isolated, it never touches the live firewall -- then its table inet filter
-# is compared to the live one. Both sides go through nft's own output formatting,
-# so the match is on effective rules, not file text. Anything inconclusive falls
-# back to reloading (DIFF), so the firewall is never left stale or drifted.
+# Reload only when the LIVE filter table differs from desired, and always
+# `reload` (nft -f), never `restart`: restart's ExecStop flushes the whole
+# ruleset, which can stall OSD peering and drops podman's tables; reload
+# atomically replaces ONLY table inet filter. Desired state is normalized by
+# loading the config in a throwaway netns (never touches the live firewall) and
+# comparing its inet filter to the live one via nft's own formatting (effective
+# rules, not file text). Inconclusive -> DIFF -> reload, never left stale.
 - name: Compare the live nftables ruleset against the desired one
   ansible.builtin.shell: |
     set -o pipefail
@@ -93,8 +85,6 @@
   ansible.builtin.debug:
     msg: "{{ nft_rules.stdout_lines | default(['Firewall disabled']) }}"
 
-# --- SSH hardening ---
-
 - name: Deploy SSH hardening config
   ansible.builtin.template:
     src: sshd-hardening.conf.j2
@@ -107,8 +97,6 @@
 - name: Verify full SSH config is valid after drop-in
   ansible.builtin.command: sshd -t
   changed_when: false
-
-# --- Summary ---
 
 - name: Report security state
   ansible.builtin.debug:

--- a/ansible/ceph/rotate-certs.yml
+++ b/ansible/ceph/rotate-certs.yml
@@ -1,14 +1,8 @@
 ---
-# Rotate the self-signed RGW TLS certificate.
-#
-# Deletes the existing cert/key on the bootstrap node, re-generates via
-# the ceph_deploy RGW role, and restarts RGW daemons to pick up the new cert.
-#
-# Usage:
-#   scripts/ansible-play.sh rotate-certs.yml
-#
-# The new cert inherits all SANs (DNS names, IPs, wildcard) from
-# group_vars/all/vars.yml. Validity period: ceph_rgw_ssl_cert_days (default 3650).
+# Deletes the cert/key on the bootstrap node, re-generates via the ceph_deploy
+# RGW role, and restarts the RGW daemons. The new cert inherits all SANs (DNS
+# names, IPs, wildcard) from group_vars/all/vars.yml; validity is
+# ceph_rgw_ssl_cert_days.
 
 - name: Rotate RGW TLS certificate
   hosts: ceph_nodes

--- a/ansible/ceph/rotate-ssh-key.yml
+++ b/ansible/ceph/rotate-ssh-key.yml
@@ -1,19 +1,9 @@
 ---
-# Distribute the current ansible-iac public key to every node in the cluster.
-#
-# Non-destructive — adds the key if absent, does NOT remove any others.
-# Run this after generating a new key in 1P to make it usable before you
-# rotate off the old one. Old keys are removed manually (or by a separate
-# cleanup playbook) once the new key is verified working.
-#
-# Usage:
-#   scripts/ansible-play.sh rotate-ssh-key.yml
-#
-# The current public key is sourced from:
-#   op://{{ cluster_secrets_vault }}/{{ cluster_name | upper }}_CEPH_ANSIBLE_IAC_SSH_KEY/public_key
-#
-# which for sietch is op://yucca_tf_dev/SIETCH_CEPH_ANSIBLE_IAC_SSH_KEY/public_key
-# (cluster_secrets_vault + cluster_name both set per-cluster in group_vars/all/vars.yml).
+# Distribute the current ansible-iac public key to every node. Non-destructive:
+# adds if absent, never removes others -- run after minting a new 1P key, before
+# rotating off the old one; old keys are removed manually once the new one works.
+# Key source: op://{{ cluster_secrets_vault }}/<CLUSTER>_CEPH_ANSIBLE_IAC_SSH_KEY/public_key
+# (both vars per-cluster in group_vars/all/vars.yml).
 
 - name: Rotate ansible-iac SSH authorized_keys
   hosts: ceph_nodes

--- a/ansible/ceph/scripts/ansible-play.sh
+++ b/ansible/ceph/scripts/ansible-play.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# ansible-play.sh — secrets-resolving wrapper around ansible-playbook.
-#
 # Renders the cluster's TF-generated secrets.yml.tpl via `op inject` into a
 # short-lived tmpfile, then execs ansible-playbook with --extra-vars @tmpfile.
 # Fails closed: if op inject exits non-zero or auth is unavailable, ansible

--- a/ansible/ceph/scripts/install-ssh-keys.sh
+++ b/ansible/ceph/scripts/install-ssh-keys.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
-# install-ssh-keys.sh — pull ansible-iac SSH keys from 1P into ~/.ssh/
-#
-# For new operators setting up a fresh workstation, or existing operators
-# after a key rotation. Idempotent — skips keys that already exist on disk
-# with matching fingerprints.
+# Pull ansible-iac SSH keys from 1P into ~/.ssh/. Skips keys already on disk
+# whose fingerprint matches.
 #
 # Prereq: `op` CLI signed in (desktop session unlocked or
-# OP_SERVICE_ACCOUNT_TOKEN set). Read-only access to the cluster's vault
-# (see VAULTS below) is enough.
+# OP_SERVICE_ACCOUNT_TOKEN set). Read-only access to the cluster's vault suffices.
 #
 # Usage:
 #   scripts/install-ssh-keys.sh                  # all keys
@@ -15,16 +11,13 @@
 #   OP_VAULT=yucca_tf_staging scripts/install-ssh-keys.sh sietch   # override vault
 set -euo pipefail
 
-# Map: short cluster name -> target filename under ~/.ssh/
 declare -A KEYS=(
   [sietch]="id_ed25519_sietch"
   [spice]="id_ed25519_spice"
 )
 
-# Map: short cluster name -> 1P vault holding its
-# <CLUSTER>_CEPH_ANSIBLE_IAC_SSH_KEY item. Per-cluster so clusters can live in
-# different env vaults (e.g. sietch moves to yucca_tf_staging on promotion).
-# Override any lookup with OP_VAULT=<vault>.
+# Vault holding each cluster's <CLUSTER>_CEPH_ANSIBLE_IAC_SSH_KEY item; override
+# with OP_VAULT=<vault>.
 declare -A VAULTS=(
   [sietch]="yucca_tf_staging"
   [spice]="yucca_tf_prod"
@@ -50,7 +43,6 @@ for cluster in "${targets[@]}"; do
 
   echo "=== $cluster → $priv (vault: $vault) ==="
 
-  # Compare fingerprints if the key is already on disk
   if [ -f "$priv" ]; then
     disk_fp=$(ssh-keygen -l -f "$priv" 2>/dev/null | awk '{print $2}' || echo "?")
     onep_fp=$(op read "op://$vault/$item/public_key" | ssh-keygen -l -f /dev/stdin 2>/dev/null | awk '{print $2}' || echo "?")
@@ -66,12 +58,9 @@ for cluster in "${targets[@]}"; do
     fi
   fi
 
-  # Write private + public side by side.
-  # ?ssh-format=openssh is REQUIRED: the 1P item is an SSH_KEY whose private-key
-  # field otherwise reads back as PKCS#8 (-----BEGIN PRIVATE KEY-----), which
-  # macOS ssh tolerates for ed25519 but Ubuntu's OpenSSH (e.g. CI runners)
-  # rejects with "Load key: invalid format". OpenSSH format is accepted
-  # everywhere.
+  # ?ssh-format=openssh is REQUIRED: the SSH_KEY item otherwise reads back as
+  # PKCS#8, which macOS ssh tolerates for ed25519 but Ubuntu OpenSSH (CI
+  # runners) rejects with "Load key: invalid format".
   umask 077
   op read "op://$vault/$item/private_key?ssh-format=openssh" > "$priv"
   op read "op://$vault/$item/public_key"  > "$pub"

--- a/ansible/ceph/scripts/preflight.sh
+++ b/ansible/ceph/scripts/preflight.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# Pre-flight checks before running destructive playbooks.
-# Verifies: TF-rendered artifacts present, 1P session live, secrets template
-# resolves via op inject, SSH connectivity, Python on targets.
+# Verifies TF-rendered artifacts are present, the 1P session is live, the secrets
+# template resolves via op inject, SSH connectivity, and Python on targets.
 #
-# Target inventory + secrets template are located via CEPH_ENV (path to
-# the TF-rendered inventory file; TF is the authoritative source of
-# cluster identity, declared in tf/deployment/<partition>/<region>/ceph/clusters.auto.tfvars).
+# Inventory + secrets template are located via CEPH_ENV; cluster identity is
+# declared in tf/deployment/<partition>/<region>/ceph/clusters.auto.tfvars.
 set -euo pipefail
 
 : "${CEPH_ENV:?CEPH_ENV must be set to the target cluster inventory.ini}"
@@ -14,7 +12,6 @@ INV="$CEPH_ENV"
 INV_DIR="$(dirname "$CEPH_ENV")"
 TEMPLATE="${INV_DIR}/secrets.yml.tpl"
 
-# Read SSH key path from inventory vars (preferred) or group_vars fallback
 SSH_KEY="$(sed -n 's/^ansible_ssh_private_key_file=\(.*\)/\1/p' "$INV" 2>/dev/null | head -1)"
 if [ -z "$SSH_KEY" ]; then
   SSH_KEY="$(sed -n 's/^provision_iac_ssh_key_path:[[:space:]]*//p' \
@@ -55,7 +52,6 @@ echo "Inventory: $INV"
 echo "Template:  $TEMPLATE"
 echo ""
 
-# Controller checks
 echo "--- Controller ---"
 check "ansible-play.sh wrapper executable" test -x scripts/ansible-play.sh
 check "Inventory file (TF-rendered) present" test -f "$INV"
@@ -68,7 +64,6 @@ check "op CLI installed" op --version
 check "1Password session live" op account get
 echo ""
 
-# Secrets resolve
 echo "--- Secrets ---"
 SECRETS_TEST="$(mktemp --suffix=-secrets-test.yml)"
 trap 'rm -f "$SECRETS_TEST"' EXIT INT TERM
@@ -77,7 +72,6 @@ check "Resolved file has non-empty vault_ops_password" \
   grep -qE '^vault_ops_password: \S+' "$SECRETS_TEST"
 echo ""
 
-# Target connectivity
 echo "--- Target connectivity ---"
 for host in $(ansible-inventory -i "$INV" --list 2>/dev/null \
   | python3 -c "
@@ -104,7 +98,6 @@ for h in hosts:
 done
 echo ""
 
-# Summary
 echo "=== Results ==="
 echo "  Passed: $PASS  Failed: $FAIL  Warnings: $WARN"
 if [ "$FAIL" -gt 0 ]; then

--- a/ansible/ceph/scripts/render-inventories.sh
+++ b/ansible/ceph/scripts/render-inventories.sh
@@ -1,32 +1,20 @@
 #!/usr/bin/env bash
-# render-inventories.sh — write the TF-rendered Ansible inventories + secrets
-# templates into THIS checkout, from the dev/ceph stack's `render` output.
-#
-# WHY a wrapper instead of tofu `local_file`: local_file records the destination
-# path in state. With a shared remote backend that path is checkout-specific, so
-# it coupled state to whichever git worktree last applied (get_repo_root()
-# resolves per-worktree) — every apply elsewhere then force-replaced the files
-# and rebound state. Reading the content from a TF *output* and writing it here,
-# with the path derived from THIS script's own location, keeps checkout-specific
-# paths out of shared state entirely.
-#
-# Prereq: `terragrunt apply` has been run for the stack (so the `render` output
-# reflects the current cluster spec). This script is read-only against state.
-#
-# Usage (from anywhere):
-#   ansible/ceph/scripts/render-inventories.sh [partition] [region]
-#     # partition defaults to staging, region defaults to austin (sietch's home)
-#
-# The TF `render` output carries each cluster's own `dirname` (region-scoped,
-# friendly-cluster leaf — e.g. `staging-austin/sietch`), so this wrapper does
-# not derive the inventory layout; it only locates the partition/region stack.
+# Write the TF-rendered Ansible inventories + secrets templates into THIS
+# checkout from the ceph stack's `render` output. A wrapper, not tofu
+# `local_file`: local_file stores the checkout-specific path in shared state, so
+# every apply from another worktree force-replaced the files and rebound state;
+# reading the output and deriving the path from this script's location keeps
+# checkout paths out of state. Read-only against state; requires a prior
+# terragrunt apply. Layout comes from each cluster's `dirname` in the output
+# (e.g. staging-austin/sietch); this only locates the partition/region stack.
+# Usage: ansible/ceph/scripts/render-inventories.sh [partition=staging] [region=austin]
 set -euo pipefail
 
 PARTITION="${1:-staging}"
 REGION="${2:-austin}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ANSIBLE_CEPH="$(cd "$SCRIPT_DIR/.." && pwd)"   # ansible/ceph
+ANSIBLE_CEPH="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$ANSIBLE_CEPH/../.." && pwd)" # repo root of THIS checkout
 STACK_DIR="$REPO_ROOT/tf/deployment/${PARTITION}/${REGION}/ceph"
 INV_ROOT="$ANSIBLE_CEPH/inventories"
@@ -36,12 +24,10 @@ INV_ROOT="$ANSIBLE_CEPH/inventories"
   exit 1
 }
 
-# The `render` output is non-sensitive (inventory text + op:// references — no
-# raw secrets). Reading state needs the S3 backend creds, so go through the
-# op-run wrapper which injects them from the partition's env file: prod refs
-# live in tf/.env.prod, everything else in tf/.env (the same split infra.yml
-# makes). op run resolves every ref up front, so a mismatched file fails on the
-# wrong vault under the prod service-account token.
+# `render` output is non-sensitive (op:// refs, no raw secrets), but reading
+# state needs the S3 backend creds: go through op-run with the partition's env
+# file (prod -> tf/.env.prod, else tf/.env, same split as infra.yml). op run
+# resolves refs up front, so a mismatched file fails on the wrong vault.
 ENV_FILE="$REPO_ROOT/tf/.env"
 if [ "$PARTITION" = "prod" ]; then ENV_FILE="$REPO_ROOT/tf/.env.prod"; fi
 JSON="$(cd "$STACK_DIR" && OP_ENV_FILE="$ENV_FILE" "$REPO_ROOT/tf/op-run.sh" terragrunt output -json render)"

--- a/ansible/ceph/site.yml
+++ b/ansible/ceph/site.yml
@@ -1,17 +1,8 @@
 ---
-# Full site playbook: tune -> deploy -> tune ceph -> harden -> ship logs
-#
-# Runs all post-provision steps in the correct dependency order.
-# Provisioning is a separate concern; run provision.yml first.
-#
-# Workflow:
-#   1. Boot nodes from Debian live image
-#   2. CEPH_ENV=inventories/<cluster>/inventory-provision.ini \
-#        scripts/ansible-play.sh provision.yml -e confirm_wipe=true
-#   3. Nodes reboot into installed OS
-#   4. scripts/ansible-play.sh site.yml
-#
-# Or use: mise run deploy  (wraps scripts/ansible-play.sh per sub-playbook)
+# Full site playbook: tune -> deploy -> tune ceph -> harden -> ship logs, in
+# dependency order. Provisioning is separate: run provision.yml (live image,
+# -e confirm_wipe=true) first, then `scripts/ansible-play.sh site.yml` or
+# `mise run deploy` (wraps ansible-play.sh per sub-playbook).
 
 - name: OS baseline (ops user, packages, /etc/hosts)
   import_playbook: baseline.yml

--- a/ansible/ceph/status.yml
+++ b/ansible/ceph/status.yml
@@ -1,8 +1,5 @@
 ---
-# Quick cluster health check — no changes, read-only.
-#
-# Usage:
-#   scripts/ansible-play.sh status.yml
+# Read-only.
 
 - name: Ceph cluster status
   hosts: ceph_nodes

--- a/ansible/ceph/tasks/ceph_upgrade.yml
+++ b/ansible/ceph/tasks/ceph_upgrade.yml
@@ -1,18 +1,6 @@
 ---
-# cephadm-orchestrated Ceph upgrade: preflight gate, record-for-rollback,
-# start, bounded poll, and post-convergence assertions. Imported by
-# upgrade-ceph.yml. Every task here is a cluster op: run_once and delegated to
-# the bootstrap node (groups['ceph_bootstrap'][0]), matching the repo idiom
-# (deploy-ceph.yml / tune-ceph.yml / roles/ceph_deploy). Read-only probes are
-# changed_when:false; only `ceph orch upgrade start` reports changed.
-#
-# Target selection (one is REQUIRED, asserted in the playbook, no default):
-#   ceph_upgrade_target_image  -- full image ref, e.g.
-#                                 quay.io/ceph/ceph:v20.2.2 (preferred: exact,
-#                                 digest-pinnable, and what rollback consumes)
-#   ceph_upgrade_version       -- e.g. 20.2.2 (cephadm resolves the image)
-
-# --- Resolve the upgrade target into a single `ceph orch upgrade start` arg ---
+# Target (one REQUIRED, asserted in the playbook): ceph_upgrade_target_image
+# (preferred -- exact, what rollback consumes) or ceph_upgrade_version.
 - name: Resolve upgrade target argument
   ansible.builtin.set_fact:
     _ceph_upgrade_arg: >-
@@ -26,7 +14,6 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Preflight: health ---------------------------------------------------
 - name: Preflight -- probe Ceph health
   ansible.builtin.command: ceph health --format json
   register: _ceph_up_health_pre
@@ -52,7 +39,6 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Preflight: no upgrade already running -------------------------------
 - name: Preflight -- probe orchestrator upgrade status
   ansible.builtin.command: ceph orch upgrade status --format json
   register: _ceph_up_status_pre
@@ -72,7 +58,6 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Preflight: all OSDs up and in ---------------------------------------
 - name: Preflight -- probe OSD stat
   ansible.builtin.command: ceph osd stat --format json
   register: _ceph_up_osd_pre
@@ -99,11 +84,8 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Record current state for rollback -----------------------------------
-# The exact rollback target is the image the daemons are running NOW. Capture
-# the distinct container image refs across all daemons plus the daemon-version
-# map, print them, and stash to a fact so an operator can copy the prior image
-# into `ceph orch upgrade start --image <prior>` (see runbook header).
+# Rollback target = the image running NOW. Capture + print so an operator can
+# feed it to `ceph orch upgrade start --image <prior>` (see runbook header).
 - name: Record -- current daemon versions
   ansible.builtin.command: ceph versions --format json
   register: _ceph_up_versions_pre
@@ -146,9 +128,8 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# Idempotency: if the target image is already the sole running image and the
-# cluster is version-converged, there is nothing to do. Skip start + poll so a
-# re-run is a clean no-op instead of a spurious upgrade cycle.
+# Skip start + poll when the target is already the sole image and versions are
+# converged, so a re-run is a clean no-op.
 - name: Decide whether an upgrade is needed
   ansible.builtin.set_fact:
     _ceph_upgrade_needed: >-
@@ -169,7 +150,6 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Start the upgrade ----------------------------------------------------
 - name: Start orchestrator upgrade
   ansible.builtin.command: "ceph orch upgrade start {{ _ceph_upgrade_arg }}"
   register: _ceph_up_start
@@ -185,11 +165,8 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Poll to completion (bounded) ----------------------------------------
-# ceph_upgrade_poll_retries * ceph_upgrade_poll_delay bounds the wait
-# (default 120 * 30s = 60 min). We stop polling when the orchestrator reports
-# in_progress=false (done) OR is_paused=true (cephadm auto-pauses on a failed
-# step), then assert-not-paused below so a stall fails the play loudly.
+# Stop on in_progress=false (done) OR is_paused=true (cephadm auto-pauses on a
+# failed step); the assert below turns a pause/stall into a loud failure.
 - name: Poll orchestrator upgrade status until complete or paused
   ansible.builtin.command: ceph orch upgrade status --format json
   register: _ceph_up_poll
@@ -221,7 +198,6 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Post: health + version convergence ----------------------------------
 - name: Post -- probe Ceph health
   ansible.builtin.command: ceph health --format json
   register: _ceph_up_health_post
@@ -265,7 +241,6 @@
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
 
-# --- Summary --------------------------------------------------------------
 - name: Upgrade summary
   ansible.builtin.debug:
     msg:

--- a/ansible/ceph/tasks/health_gate.yml
+++ b/ansible/ceph/tasks/health_gate.yml
@@ -1,19 +1,11 @@
 ---
-# Reusable Ceph-health checkpoint for the rolling converge plays. Imported as a
-# pre_task and post_task on each serial converge play (baseline / tune-os /
-# tune-hardware / tune-ceph / harden).
-#
-# It probes the cluster via the bootstrap node and, ONLY when a live cluster
-# answers, halts the roll if the cluster is HEALTH_ERR (inactive / unavailable
-# PGs). It is a deliberate no-op during the initial bootstrap ordering
-# (baseline -> tune -> deploy-ceph), where `ceph health` cannot run yet: the
-# probe is failed_when:false and the assert is gated on the probe having
-# succeeded, so a not-yet-Ceph node just skips the gate.
-#
-# Combined with serial + max_fail_percentage:0 on the play, a batch that takes
-# data offline (a bad ruleset, a wrong sysctl, a firewall that fences the fabric)
-# halts the rollout at the next checkpoint instead of propagating to all nodes.
-# run_once makes it one check per serial batch, delegated to the bootstrap host.
+# Reusable Ceph-health checkpoint, imported pre+post on each serial converge
+# play (baseline / tune-* / harden). Halts the roll on HEALTH_ERR, but ONLY when
+# a live cluster answers -- during initial bootstrap `ceph health` cannot run, so
+# the probe is failed_when:false and the assert is gated on it succeeding.
+# With serial + max_fail_percentage:0, a batch that takes data offline halts at
+# the next checkpoint instead of propagating fleet-wide. One check per batch
+# (run_once, delegated to the bootstrap host).
 
 - name: Probe Ceph health (no-op until the cluster is live)
   ansible.builtin.command: ceph health --format json

--- a/ansible/ceph/tune-ceph.yml
+++ b/ansible/ceph/tune-ceph.yml
@@ -1,9 +1,5 @@
 ---
-# Apply post-deploy Ceph cluster tuning.
-# Requires a running cluster — run AFTER deploy-ceph.yml.
-#
-# Usage:
-#   scripts/ansible-play.sh tune-ceph.yml
+# Requires a running cluster: run AFTER deploy-ceph.yml.
 
 - name: Ceph cluster tuning
   hosts: ceph_nodes

--- a/ansible/ceph/tune-hardware.yml
+++ b/ansible/ceph/tune-hardware.yml
@@ -1,9 +1,5 @@
 ---
-# Apply hardware-level disk tuning to Ceph nodes.
-# Run BEFORE deploy-ceph.yml so OSDs use optimal I/O settings from the start.
-#
-# Usage:
-#   scripts/ansible-play.sh tune-hardware.yml
+# Run BEFORE deploy-ceph.yml so OSDs use these I/O settings from the start.
 
 - name: Hardware tuning for Ceph nodes
   hosts: ceph_nodes

--- a/ansible/ceph/tune-os.yml
+++ b/ansible/ceph/tune-os.yml
@@ -1,9 +1,5 @@
 ---
-# Apply OS-level kernel tuning to Ceph nodes.
-# Run BEFORE deploy-ceph.yml so OSD daemons start with correct limits.
-#
-# Usage:
-#   scripts/ansible-play.sh tune-os.yml
+# Run BEFORE deploy-ceph.yml so OSD daemons start with the correct limits.
 
 - name: OS tuning for Ceph nodes
   hosts: ceph_nodes

--- a/ansible/ceph/upgrade-ceph.yml
+++ b/ansible/ceph/upgrade-ceph.yml
@@ -1,79 +1,14 @@
 ---
-# Health-gated, cephadm-orchestrated Ceph upgrade (Tentacle 20.2.x train).
+# DELIBERATE, MANUALLY-INVOKED day-2 op -- intentionally NOT in site.yml; converge
+# must never trigger an upgrade.
 #
-# This is a DELIBERATE, MANUALLY-INVOKED day-2 operation. It is intentionally
-# NOT wired into site.yml -- converge must never trigger a cluster upgrade.
+# REQUIRED target (no default): -e ceph_upgrade_target_image=quay.io/ceph/ceph:v20.2.2
+#   (preferred) or -e ceph_upgrade_version=20.2.2. `--check` dry-runs the preflight.
 #
-# What it does (all cluster ops run_once on groups['ceph_bootstrap'][0]):
-#   1. Preflight gate: HEALTH_OK (or an explicit allow-HEALTH_WARN toggle),
-#      no upgrade already in progress, and all OSDs up+in. Refuses otherwise.
-#   2. Records the rollback anchor (current running image(s) + versions) and
-#      prints it BEFORE touching anything.
-#   3. `ceph orch upgrade start` to the REQUIRED, explicit target (below).
-#   4. Polls `ceph orch upgrade status` with a bounded timeout; fails loudly
-#      if cephadm pauses/stalls the upgrade.
-#   5. Post: asserts HEALTH_OK (or WARN toggle) and that all daemons converged
-#      on one version; prints a summary.
-#
-# ---------------------------------------------------------------------------
-# REQUIRED TARGET (no default -- the play refuses to run without one):
-#   -e ceph_upgrade_target_image=quay.io/ceph/ceph:v20.2.2    (preferred)
-#     or
-#   -e ceph_upgrade_version=20.2.2
-#
-# OPTIONAL TOGGLES:
-#   -e ceph_upgrade_allow_health_warn=true   # proceed on a benign HEALTH_WARN
-#   -e ceph_upgrade_poll_retries=120         # poll attempts   (default 120)
-#   -e ceph_upgrade_poll_delay=30            # seconds/attempt (default 30)
-#   # -> default bound = 120 * 30s = 60 minutes
-#
-# USAGE:
-#   scripts/ansible-play.sh upgrade-ceph.yml \
-#     -e ceph_upgrade_target_image=quay.io/ceph/ceph:v20.2.2
-#
-#   # dry run of the preflight/plan (no start; poll/start are skipped in check):
-#   scripts/ansible-play.sh upgrade-ceph.yml \
-#     -e ceph_upgrade_target_image=quay.io/ceph/ceph:v20.2.2 --check
-#
-# ===========================================================================
-# ROLLBACK RUNBOOK (read before you start; see docs/runbooks/upgrade-ceph.md)
-# ===========================================================================
-# cephadm upgrades roll one daemon type at a time (mgr -> mon -> ... -> osd)
-# and auto-PAUSE on the first failure rather than tearing the cluster down.
-# There is no destructive cutover, so rollback = point the orchestrator back
-# at the PRIOR image and let it converge.
-#
-# 0. Capture the prior image. This play PRINTS it ("ROLLBACK ANCHOR ...")
-#    before starting; otherwise read the running image now:
-#      ceph orch ps --format json | \
-#        python3 -c 'import sys,json;print(sorted({d["container_image_name"] for d in json.load(sys.stdin)}))'
-#
-# 1. Stop / pause the in-flight upgrade:
-#      ceph orch upgrade stop            # abandons the current target
-#      # (or `ceph orch upgrade pause` / `resume` to hold and inspect)
-#
-# 2. Roll back to the prior image (only daemons ahead of it move):
-#      ceph orch upgrade start --image <PRIOR_IMAGE>
-#
-# 3. Watch it converge:
-#      ceph orch upgrade status
-#      ceph -W cephadm                   # live cephadm event log
-#      watch ceph versions
-#
-# 4. Health checks once status shows not in_progress:
-#      ceph health detail                # expect HEALTH_OK
-#      ceph versions                     # expect ONE overall version
-#      ceph osd stat                     # all OSDs up + in
-#
-# Notes / gotchas:
-#   - Ceph does NOT support downgrading across a major release. Rollback is
-#     only safe WITHIN the pinned 20.2.x train (patch level). Do not use this
-#     to cross 20.x -> 19.x.
-#   - If a mon/osd is stuck mid-step, `ceph orch upgrade stop` then re-target;
-#     cephadm reconciles idempotently.
-#   - Re-running THIS play with the prior image as the target performs the
-#     same health-gated rollback with all the same checks.
-# ===========================================================================
+# ROLLBACK: full runbook in docs/runbooks/upgrade-ceph.md. cephadm rolls one
+# daemon type at a time and auto-pauses on failure; rollback = re-run this play
+# targeting the printed PRIOR image (or `ceph orch upgrade stop` then re-target).
+# NEVER cross a major release downward -- rollback is safe only within 20.2.x.
 
 - name: Upgrade Ceph (cephadm-orchestrated, health-gated)
   hosts: ceph_nodes
@@ -81,7 +16,6 @@
   gather_facts: false
 
   vars:
-    # Poll bound for the orchestrated upgrade (retries * delay seconds).
     ceph_upgrade_poll_retries: 120
     ceph_upgrade_poll_delay: 30
     # Preflight/postflight normally demand HEALTH_OK. Flip to true (on the CLI)

--- a/ansible/mgmt/ansible.cfg
+++ b/ansible/mgmt/ansible.cfg
@@ -4,14 +4,12 @@
 inventory = inventories/htz-fsn1/hosts.yml
 log_path = ansible.log
 
-# Performance
 forks = 20
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = .ansible_facts_cache
 fact_caching_timeout = 3600
 
-# Output
 stdout_callback = default
 result_format = yaml
 callbacks_enabled = ansible.posix.timer, ansible.posix.profile_tasks
@@ -21,7 +19,6 @@ deprecation_warnings = False
 retry_files_enabled = False
 display_skipped_hosts = False
 
-# Security
 host_key_checking = False
 timeout = 30
 

--- a/ansible/mgmt/inventories/htz-fsn1/group_vars/all/main.yml
+++ b/ansible/mgmt/inventories/htz-fsn1/group_vars/all/main.yml
@@ -1,6 +1,4 @@
 ---
-# Static shared vars for the htz-fsn1 mgmt hosts.
-#
 # Host/user/addressing data is TF-GENERATED at run time (hosts.yml,
 # host_vars/*.yml, users.generated.yml) by tf/render/ansible-mgmt from the
 # Terraform sources (mgmt-hosts.yaml, fabric-addressing, identity). Edit those,

--- a/ansible/mgmt/roles/netbird/defaults/main.yml
+++ b/ansible/mgmt/roles/netbird/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# NetBird defaults.
 mgmt_netbird_management_url: "https://api.netbird.io"
 
 # Setup key — NEVER hardcoded. Passed at run time (op:// ref, see README). The

--- a/ansible/mgmt/roles/netbird/tasks/main.yml
+++ b/ansible/mgmt/roles/netbird/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
-# Install NetBird and join the overlay. The mgmt nodes are the NetBird route
-# peers for the site subnets (the routed network is declared in TF, not here), so
-# enable IP forwarding. Convergeable: `netbird up` is skipped when already
-# connected.
+# The mgmt nodes are the NetBird route peers for the site subnets (the routed
+# network is declared in TF, not here), hence IP forwarding.
 
 - name: Install NetBird (official script — adds the apt repo + installs)
   ansible.builtin.shell:

--- a/ansible/mgmt/roles/networkd/defaults/main.yml
+++ b/ansible/mgmt/roles/networkd/defaults/main.yml
@@ -13,8 +13,7 @@
 # NICs are verified per host in mgmt-hosts.yaml; correct there if `ip link` differs.
 mgmt_networkd_enabled: true
 
-# OOB management interface { nic, address } — empty disables just the OOB part.
+# { nic, address }; empty disables just the OOB part.
 mgmt_oob: {}
 
-# --- Paths ---
 mgmt_networkd_config_dir: /etc/systemd/network

--- a/ansible/mgmt/roles/networkd/tasks/deploy.yml
+++ b/ansible/mgmt/roles/networkd/tasks/deploy.yml
@@ -1,7 +1,6 @@
 ---
-# Write systemd-networkd config for the OOB management NIC + the 25G fabric
-# VLANs, and make sure networkd is running. Safe to re-run. Only the NICs matched
-# below are managed; the primary public NIC is left to its own manager.
+# Only the NICs matched below are managed; the primary public NIC is left to its
+# own manager.
 
 - name: Ensure systemd-networkd is enabled and running
   ansible.builtin.systemd:
@@ -9,7 +8,7 @@
     enabled: true
     state: started
 
-# ── OOB management LAN (1G; the switch vme lives here) ──────────────────────
+# OOB management LAN (1G); the switch vme lives here.
 - name: Deploy OOB management .network
   ansible.builtin.template:
     src: oob.network.j2
@@ -20,7 +19,6 @@
   when: mgmt_oob.nic is defined
   notify: Restart systemd-networkd
 
-# ── 25G fabric VLAN sub-interfaces ──────────────────────────────────────────
 - name: Deploy fabric parent .network (declares VLANs, no L3 of its own)
   ansible.builtin.template:
     src: fabric.network.j2

--- a/ansible/mgmt/roles/security/defaults/main.yml
+++ b/ansible/mgmt/roles/security/defaults/main.yml
@@ -1,13 +1,9 @@
 ---
-# Security hardening defaults for management hosts.
-
-# --- Firewall (nftables) ---
 mgmt_firewall_enabled: true
 
-# Trusted source networks allowed to reach management services beyond SSH.
 # RFC1918 + the NetBird overlay range (this tailnet uses 10.254.0.0/15) + CGNAT.
 # Loopback is always allowed via "lo"; overlay traffic is also accepted by iface
-# (iifname "wt0") in the nftables template — this list is the belt-and-braces.
+# (iifname "wt0") in the nftables template -- this list is belt-and-braces.
 mgmt_firewall_trusted_networks:
   - 10.0.0.0/8
   - 172.16.0.0/12
@@ -15,12 +11,10 @@ mgmt_firewall_trusted_networks:
   - 10.254.0.0/15
   - 100.64.0.0/10
 
-# Allow SSH from any source (true) or restrict to trusted networks (false).
-# Default true: these hosts are reached over the public IP for bootstrapping
-# and NetBird admin. Tighten once NetBird access is confirmed.
+# true = any source, false = trusted networks only. True while these hosts are
+# reached over the public IP for bootstrapping; tighten once NetBird is confirmed.
 mgmt_firewall_ssh_any_source: true
 
-# --- SSH hardening ---
 mgmt_ssh_max_auth_tries: 3
 # Key-based root is required for the initial Ansible run (TF provisioning key).
 # prohibit-password keeps password root login off while allowing key auth.

--- a/ansible/mgmt/roles/security/tasks/main.yml
+++ b/ansible/mgmt/roles/security/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-# Security hardening for management hosts.
-# nftables firewall + SSH hardening + unattended-upgrades.
-
-# --- nftables firewall ---
 
 - name: Install nftables
   ansible.builtin.apt:
@@ -27,7 +23,6 @@
     state: "{{ 'restarted' if nftables_config is changed else 'started' }}"
   when: mgmt_firewall_enabled | bool
 
-# --- SSH hardening ---
 
 - name: Deploy SSH hardening config
   ansible.builtin.template:
@@ -42,7 +37,6 @@
   ansible.builtin.command: sshd -t
   changed_when: false
 
-# --- unattended-upgrades ---
 
 - name: Install unattended-upgrades
   ansible.builtin.apt:
@@ -59,7 +53,6 @@
     group: root
     mode: '0644'
 
-# --- Summary ---
 
 - name: Report security state
   ansible.builtin.debug:

--- a/ansible/mgmt/roles/users/tasks/main.yml
+++ b/ansible/mgmt/roles/users/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
-# Login users for members of the identity registry's `server`-mapped groups.
-# Sourced from mgmt_users (group_vars/all.yml). Convergeable: re-running fixes
-# drift in group membership, sudo, and authorized_keys.
+# Login users for members of the identity registry's `server`-mapped groups,
+# sourced from mgmt_users (group_vars/all.yml).
 
 - name: Ensure login users exist
   ansible.builtin.user:

--- a/ansible/mgmt/site.yml
+++ b/ansible/mgmt/site.yml
@@ -1,23 +1,14 @@
 ---
-# Configure the Hetzner FSN1 management hosts after they are reprovisioned
-# to Debian 13 ("trixie") via Hetzner robot auto-install.
-#
-# Connection: freshly-reprovisioned hosts are reached over their PUBLIC IP
-# (bootstrap); once a host has joined the NetBird overlay (the netbird role),
-# later runs reconnect over its NetBird IP automatically — see the first play.
-#
-# Canonical entrypoint is `mise run mgmt:ansible` (renders the inventory from
-# Terraform, then runs this). It passes the provisioning key + the NetBird
-# "mgmt" setup key (op://yucca_tf_prod/NETBIRD_YUCCA_PROD_<REGION>_MGMT_SETUP_KEY).
-#
-# NOTE: the networkd role (25G VLAN sub-interfaces) is gated on
-# mgmt_networkd_enabled (default false) because the 25G fabric link is
-# currently unreliable. Enable it once the fabric is up.
+# Configure the FSN1 mgmt hosts after Robot auto-install of Debian 13 (trixie).
+# Fresh hosts are reached over their PUBLIC IP (bootstrap); once NetBird-joined,
+# later runs reconnect over the NetBird IP (first play). Canonical entrypoint:
+# `mise run mgmt:ansible` (renders inventory from TF; passes the provisioning key
+# + op://yucca_tf_prod/NETBIRD_YUCCA_PROD_<REGION>_MGMT_SETUP_KEY).
+# networkd role (25G VLANs) gated on mgmt_networkd_enabled (default false: the
+# 25G fabric link is currently unreliable).
 
-# ── Prefer NetBird, fall back to the public IP ───────────────────────────────
-# Runs entirely on the control node (no target connection), so it's safe before
-# a host is reachable at all. If the host is a connected NetBird peer, switch the
-# connection to its NetBird IP; otherwise keep the public IP (bootstrap).
+# Runs entirely on the control node (no target connection), so it is safe before
+# a host is reachable at all.
 - name: Select connection address
   hosts: mgmt
   gather_facts: false

--- a/ansible/talos/.mise.toml
+++ b/ansible/talos/.mise.toml
@@ -2,12 +2,11 @@
 python = "3.12"
 
 [env]
-# Project-local virtualenv for all Python tooling
 VIRTUAL_ENV = "{{config_root}}/.venv"
 PATH = "{{config_root}}/.venv/bin:{{env.PATH}}"
-# Note: TALOS_ENV is intentionally NOT declared here. mise's [env] block
-# overrides shell-exported values, which silently sends operators to the
-# wrong cluster. Operators must export TALOS_ENV once per shell session:
+# TALOS_ENV is deliberately NOT declared here: mise's [env] block overrides
+# shell-exported values, silently sending operators to the wrong cluster. Export
+# it once per shell session:
 #   export TALOS_ENV=inventories/staging-austin/inventory.ini
 # Inventory file is TF-rendered — `TF_STACK_DIR=tf/deployment/staging/austin/talos mise run tf:apply`
 # (from yucca root) if missing.

--- a/ansible/talos/ansible.cfg
+++ b/ansible/talos/ansible.cfg
@@ -5,14 +5,12 @@
 # skips op inject if secrets.yml.tpl is absent.
 log_path = ansible.log
 
-# Performance
 forks = 20
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = .ansible_facts_cache
 fact_caching_timeout = 3600
 
-# Output
 stdout_callback = default
 result_format = yaml
 callbacks_enabled = ansible.posix.timer, ansible.posix.profile_tasks
@@ -22,7 +20,6 @@ deprecation_warnings = False
 retry_files_enabled = False
 display_skipped_hosts = False
 
-# Security
 host_key_checking = False
 timeout = 30
 

--- a/ansible/talos/destroy-vms.yml
+++ b/ansible/talos/destroy-vms.yml
@@ -1,20 +1,9 @@
 ---
-# Tear down all Talos VMs and their qcow2 overlays for lab repeatability.
-# Does NOT touch:
-#   - networkd bridges (br-vlan50, br-vlan51) — reusable infrastructure
-#   - libvirt itself or the storage pool definition
-#   - the base raw image (re-fetching is slow; keep)
-#   - Ceph or its OSDs (entirely out of scope here)
-#
-# Filtering: matches VMs by regex `^(sietch-)?talos-` so we never touch
-# unrelated libvirt domains a host might host. The transitional regex
-# catches both the legacy `talos-cp1` shape (from pre-monorepo sietch-talos
-# stock VMs that need destroying once) AND the current `sietch-talos-cp1`
-# shape that this subtree produces. Drop the `(sietch-)?` once no legacy
-# names remain in the lab.
-#
-# Usage: scripts/ansible-play.sh destroy-vms.yml
-# Or:    mise run destroy-vms
+# Does NOT touch: networkd bridges, libvirt/storage pool, the base raw image
+# (slow re-fetch), or Ceph/OSDs. VM filter `^(sietch-)?talos-` never matches
+# unrelated domains; the transitional `(sietch-)?` catches legacy pre-monorepo
+# `talos-cp1` names -- drop it once no legacy VMs remain.
+# Usage: scripts/ansible-play.sh destroy-vms.yml | mise run destroy-vms
 
 - name: Destroy Talos VMs (lab cleanup)
   hosts: hypervisors

--- a/ansible/talos/preflight.yml
+++ b/ansible/talos/preflight.yml
@@ -1,10 +1,8 @@
 ---
-# Read-only pre-flight. Verifies the hypervisors are ready to receive
-# Talos work. Touches no state. Refuses to greenlight if Ceph cluster
-# health degrades — cluster health is non-negotiable.
+# Read-only; touches no state. Refuses to greenlight if Ceph cluster health is
+# degraded.
 #
-# Usage: scripts/ansible-play.sh preflight.yml
-# Or:    mise run preflight
+# Usage: scripts/ansible-play.sh preflight.yml  (or: mise run preflight)
 
 - name: Pre-flight — sietch-talos prerequisites (read-only)
   hosts: hypervisors
@@ -13,14 +11,12 @@
   tags: [preflight]
 
   tasks:
-    # ─── Reachability ─────────────────────────────────────────────────
     - name: Confirm SSH + sudo reachability
       ansible.builtin.ping:
       become: false  # ping doesn't need root; keep blast radius minimal
 
-    # ─── Ceph cluster health ──────────────────────────────────────────
-    # Runs on every host; redundant per node but surfaces per-host
-    # failures (ceph not callable on this node = node-local issue).
+    # Runs on every host: redundant per node, but ceph not being callable on one
+    # node is itself a node-local failure worth surfacing.
     - name: Query Ceph cluster status
       ansible.builtin.command: ceph -s --format=json
       register: _ceph_status
@@ -50,7 +46,6 @@
             ' (HEALTH_WARN explicitly allowed via -e allow_ceph_warn=true)'
             if _ceph_health == 'HEALTH_WARN' else '' }}
 
-    # ─── Network prerequisites ────────────────────────────────────────
     - name: Confirm systemd-networkd is active
       ansible.builtin.systemd_service:
         name: systemd-networkd
@@ -78,7 +73,6 @@
           bond0 not present on {{ inventory_hostname }}.
           The Ceph deployment is expected to bring it up.
 
-    # ─── Virtualization capability ────────────────────────────────────
     - name: /dev/kvm exists
       ansible.builtin.stat:
         path: /dev/kvm
@@ -93,10 +87,8 @@
           module not loaded or virtualization extensions disabled in
           BIOS/UEFI. Cannot run Talos VMs on this host.
 
-    # ─── Optional state-of-deployment (informational) ─────────────────
-    # These pass through with debug output rather than asserting; on
-    # a fresh host they'll be missing. preflight is run BEFORE
-    # prepare-hypervisors, so absence is normal.
+    # Debug output rather than asserts: preflight runs BEFORE
+    # prepare-hypervisors, so absence on a fresh host is normal.
     - name: Check if br-vlan50 already exists (informational)
       ansible.builtin.stat:
         path: "/sys/class/net/{{ vlan_compute_bridge }}"

--- a/ansible/talos/prepare-hypervisors.yml
+++ b/ansible/talos/prepare-hypervisors.yml
@@ -1,22 +1,10 @@
 ---
-# Idempotent hypervisor preparation. Order matters:
-#   0. preflight        — read-only Ceph + bond0 + /dev/kvm gate.
-#      Imported (not opted-in) so HEALTH_OK enforcement is automatic
-#      regardless of whether the operator remembered `mise run
-#      preflight` first. Bypass with `-e allow_ceph_warn=true` if
-#      HEALTH_WARN is sanctioned for this run.
-#   1. networkd_bridges — bridges in place before libvirt tries to
-#      attach VMs to them (handler is flushed inline by the role).
-#   2. libvirt_host     — qemu/libvirt installed before image fetch
-#      sets ownership to libvirt-qemu.
-#   3. talos_image      — base image staged before talos_vms makes
-#      overlays.
-#
-# Each role's enabled-flag is set true here. Defaults stay false so
-# accidental imports / unrelated playbooks don't reconfigure live state.
-#
-# Usage: scripts/ansible-play.sh prepare-hypervisors.yml
-# Or:    mise run prepare-hypervisors
+# Idempotent hypervisor prep. ORDER MATTERS: preflight (imported, automatic
+# HEALTH_OK gate; bypass HEALTH_WARN with -e allow_ceph_warn=true) ->
+# networkd_bridges (before libvirt attaches VMs; handler flushed inline) ->
+# libvirt_host (before image fetch chowns to libvirt-qemu) -> talos_image
+# (before talos_vms makes overlays). Role enabled-flags are set true HERE;
+# defaults stay false so accidental imports never reconfigure live network.
 
 - name: Pre-flight gate (imported)
   ansible.builtin.import_playbook: preflight.yml
@@ -38,10 +26,8 @@
         libvirt_host_enabled: true
       tags: [libvirt_host]
 
-    # Disables bridge-nf-call-iptables/-ip6tables so VM traffic on
-    # br-vlan50/51 bypasses Ceph's inet filter forward DROP. Runs
-    # before talos_image is fetched so the host is fully prepped
-    # for VM bring-up by the time provision-vms runs.
+    # Disables bridge-nf-call-iptables/-ip6tables so VM traffic on br-vlan50/51
+    # bypasses Ceph's inet filter forward DROP.
     - role: nftables_bridges
       vars:
         nftables_bridges_enabled: true

--- a/ansible/talos/provision-vms.yml
+++ b/ansible/talos/provision-vms.yml
@@ -1,16 +1,9 @@
 ---
-# Provision Talos VMs per profile. Assumes prepare-hypervisors has
-# already run (bridges + libvirt + base image present on each host);
-# the talos_vms role's pre-flight will refuse otherwise.
-#
-# preflight.yml is imported (not opt-in) so the Ceph health gate is
-# enforced automatically. Bypass HEALTH_WARN block with
-# `-e allow_ceph_warn=true` if sanctioned.
-#
-# Usage: scripts/ansible-play.sh provision-vms.yml
-# Default is full (production: 3 CP + 3 workers, one CP + one worker per
-# hypervisor). For single-host validation, select smoke explicitly:
-#   scripts/ansible-play.sh provision-vms.yml -e profile=smoke
+# Provision Talos VMs per profile; requires prepare-hypervisors first (the
+# talos_vms pre-flight refuses otherwise). preflight.yml is imported, so the
+# Ceph health gate is automatic (bypass HEALTH_WARN: -e allow_ceph_warn=true).
+# Default profile full = 3 CP + 3 workers; single-host validation:
+# -e profile=smoke
 
 - name: Pre-flight gate (imported)
   ansible.builtin.import_playbook: preflight.yml
@@ -20,8 +13,8 @@
   become: true
   gather_facts: true
   vars:
-    # Default to full (matches the TF-side default). A play var outranks
-    # group_vars, so set it explicitly here. Override with `-e profile=smoke`.
+    # Matches the TF-side default; a play var outranks group_vars, so it is set
+    # explicitly here.
     talos_profile: "{{ profile | default('full') }}"
   tags: [provision]
 

--- a/ansible/talos/roles/libvirt_host/defaults/main.yml
+++ b/ansible/talos/roles/libvirt_host/defaults/main.yml
@@ -1,32 +1,22 @@
 ---
-# Master toggle — role is a no-op when false. Default false; opt-in
-# only, matching the project-wide lab posture.
 libvirt_host_enabled: false
 
-# Packages installed via apt. Debian 12 Bookworm names. Ordered for
-# readable apt output rather than dependency reasons (apt resolves
-# the dependency graph itself).
+# Debian 12 Bookworm package names.
 libvirt_host_packages:
-  - qemu-system-x86       # KVM via qemu (x86_64 target)
-  - qemu-utils            # qemu-img for qcow2 overlay creation
-  - libvirt-daemon-system # libvirtd + default systemd units
+  - qemu-system-x86
+  - qemu-utils            # qemu-img, for qcow2 overlays
+  - libvirt-daemon-system
   - libvirt-clients       # virsh, virt-host-validate
-  - virtinst              # virt-install (used by talos_vms role)
-  - ovmf                  # UEFI firmware images for EFI boot
-  - dnsmasq-base          # libvirt uses pieces of this for some networks
-  - python3-lxml          # required by community.libvirt.virt_pool /
-                          # virt modules to parse libvirt XML state
+  - virtinst              # virt-install, used by the talos_vms role
+  - ovmf                  # UEFI firmware images
+  - dnsmasq-base          # libvirt uses pieces of it for some networks
+  - python3-lxml          # community.libvirt modules parse libvirt XML with it
                           # (target-side dep, not controller-side)
 
-# Storage pool — name + path are read from group_vars (single source
-# of truth across roles). Defaults below are fallbacks for standalone
-# role use.
+# Read from group_vars across roles; these are standalone-use fallbacks.
 libvirt_host_pool_name: "{{ libvirt_storage_pool_name | default('talos') }}"
 libvirt_host_pool_path: "{{ libvirt_storage_pool_path | default('/var/lib/libvirt/images') }}"
 
-# Whether to disable libvirt's default NAT network. The default
-# network is virbr0 + dnsmasq, autostarted on every libvirtd start.
-# We don't use it (Talos VMs sit on br-vlan50). Setting autostart=no
-# tidies host startup without removing the network — operators can
-# still bring it up manually if they ever want a one-off NAT VM.
+# Talos VMs sit on br-vlan50, so libvirt's virbr0 + dnsmasq are unused;
+# autostart=no leaves the network defined for a one-off NAT VM.
 libvirt_host_disable_default_network_autostart: true

--- a/ansible/talos/roles/libvirt_host/tasks/main.yml
+++ b/ansible/talos/roles/libvirt_host/tasks/main.yml
@@ -1,13 +1,7 @@
 ---
-# Install libvirt + qemu, enable libvirtd, define the Talos storage
-# pool. Idempotent on re-run; package installs are apt-cache-aware so
-# a recent run skips the index update.
-#
-# Pre-flight refuses to proceed if KVM isn't available — running qemu
-# under TCG (software emulation) is too slow for actual Talos workloads
-# and almost certainly indicates a misconfigured host (BIOS virt
-# extensions disabled, kernel module missing, or container with no
-# /dev/kvm passthrough).
+# Pre-flight refuses to proceed without KVM: qemu under TCG is too slow for Talos
+# workloads, and its absence means BIOS virt extensions off, kernel module
+# missing, or a container with no /dev/kvm passthrough.
 
 - name: Pre-flight — role enabled
   ansible.builtin.assert:
@@ -49,10 +43,6 @@
     state: started
   tags: [libvirt_host]
 
-# Storage pool — define, set autostart, activate. The community.libvirt
-# module is idempotent for each phase: define is a no-op if the pool
-# already exists with matching XML; autostart and active flips only
-# fire when the current state differs.
 
 - name: Define Talos storage pool
   community.libvirt.virt_pool:
@@ -73,9 +63,8 @@
     name: "{{ libvirt_host_pool_name }}"
   tags: [libvirt_host, pool]
 
-# Default NAT network — keep defined (we're not in the business of
-# tearing down libvirt's defaults), but disable autostart so it's not
-# constantly bringing virbr0 + dnsmasq up at every libvirtd start.
+# libvirt's default network stays defined, but autostart off so virbr0 + dnsmasq
+# do not come up at every libvirtd start.
 - name: Set default network autostart=no
   community.libvirt.virt_net:
     autostart: false

--- a/ansible/talos/roles/networkd_bridges/defaults/main.yml
+++ b/ansible/talos/roles/networkd_bridges/defaults/main.yml
@@ -1,40 +1,30 @@
 ---
-# Master toggle — role is a no-op when false. Default false so a loose
-# import or accidental include never reconfigures live network.
+# false by default so a loose import never reconfigures live network.
 networkd_bridges_enabled: false
 
-# Physical parent for the VLAN sub-interfaces. The existing bond0 (set
-# up by the Ceph deployment for the storage VLAN) is the only sane
-# choice on Sietch; any other value is a misconfiguration.
+# bond0 is the Ceph deployment's storage-VLAN bond; any other parent on sietch is
+# a misconfiguration.
 networkd_bridges_parent: bond0
 
-# Where systemd-networkd reads its config. Must be a directory that
-# overrides /lib/systemd/network. Standard Debian/Arch path is /etc/.
+# Must override /lib/systemd/network.
 networkd_bridges_config_dir: /etc/systemd/network
 
-# Filename prefix. Numeric prefix orders unit-file processing —
-# parent bond0 is set up by the Ceph deployment with prefix 20-, so
-# 50- here lands AFTER bond0 exists, before any 70-* anyone may add.
+# Numeric prefix orders unit-file processing: the Ceph deployment sets bond0 up
+# with prefix 20-, so 50- lands after bond0 exists and before any 70-*.
 networkd_bridges_prefix: "50"
 
-# Drop-in directory for the parent (bond0) .network file. systemd-
-# networkd reads `<basename>.d/*.conf` automatically when present.
-# We render `<dropin_dir>/10-talos-vlans.conf` containing the
-# `[Network] VLAN=bond0.50 / VLAN=bond0.51` directives — without
-# these, networkd never instantiates the kernel sub-interfaces from
-# the .netdev files alone (a key gotcha). The default tracks the Ceph
-# deployment's `20-bond0.network` basename; override if the prefix
-# changes upstream.
+# Parent (bond0) .network drop-in dir. We render 10-talos-vlans.conf with
+# `[Network] VLAN=bond0.50/.51` -- KEY GOTCHA: networkd never instantiates VLAN
+# sub-interfaces from .netdev files alone; they must be declared on the parent.
+# Default tracks the Ceph deployment's `20-bond0.network` basename.
 networkd_bridges_parent_dropin_dir: "/etc/systemd/network/20-bond0.network.d"
 networkd_bridges_parent_dropin_filename: "10-talos-vlans.conf"
 
-# STP on the L2-only bridges. Off by default — only one path exists
-# (bond0 → VLAN sub-interface → bridge → VMs); STP convergence churn
-# would just slow VM port-up without preventing any loop.
+# Only one path exists (bond0 -> VLAN sub-interface -> bridge -> VMs), so STP
+# convergence churn would slow VM port-up without preventing any loop.
 networkd_bridges_stp: false
 
-# List of VLANs to configure as bridges. Built from group_vars so a
-# new VLAN added there shows up here without touching role code.
+# Built from group_vars so a new VLAN needs no role edit.
 networkd_bridges_list:
   - id: "{{ vlan_compute_id }}"
     name: "{{ vlan_compute_name }}"

--- a/ansible/talos/roles/networkd_bridges/tasks/main.yml
+++ b/ansible/talos/roles/networkd_bridges/tasks/main.yml
@@ -1,18 +1,8 @@
 ---
-# Create VLAN-tagged sub-interfaces on bond0 and L2 bridges for VM
-# attachment. Idempotent (template module compares content); the
-# `networkctl reload` handler fires only if any unit file actually
-# changed.
-#
-# Pre-conditions:
-#   - bond0 exists and is up (Ceph storage cluster brought it up)
-#   - systemd-networkd is the active link manager
-#   - VLANs 50/51 are tagged on the upstream switch port
-#
-# Failure modes intentionally NOT handled:
-#   - Switch not tagging VLANs → bridges come up but VMs see no
-#     traffic. Caught by post-deploy verification, not by this role.
-#   - bond0 missing → role refuses to render (pre-flight below).
+# Pre-conditions: bond0 up (Ceph brought it up), networkd active, VLANs 50/51
+# tagged on the switch port. Untagged switch VLANs are NOT detected here (bridges
+# come up, VMs see no traffic -- caught by post-deploy verification); missing
+# bond0 refuses to render.
 
 - name: Pre-flight — role enabled
   ansible.builtin.assert:
@@ -56,11 +46,10 @@
       networkd deployment finished on this host?
   tags: [networkd_bridges, preflight]
 
-# Parent .network drop-in: declares VLAN= per sub-interface. Without
-# this, our .netdev files alone never instantiate kernel devices —
-# networkd only attaches VLAN sub-interfaces it sees declared on the
-# parent's [Network]. Drop-in path is parent-filename-prefix-sensitive;
-# default tracks the Ceph deployment's 20-bond0.network basename.
+# networkd only instantiates VLAN sub-interfaces declared on the parent's
+# [Network], never from .netdev files alone. The drop-in path is sensitive to the
+# parent filename prefix; the default tracks the Ceph deployment's
+# 20-bond0.network basename.
 - name: Ensure parent .network drop-in directory exists
   ansible.builtin.file:
     path: "{{ networkd_bridges_parent_dropin_dir }}"
@@ -132,9 +121,8 @@
   notify: Networkd reload
   tags: [networkd_bridges]
 
-# Run handlers explicitly here (not after the play) so a downstream
-# role like libvirt_host can rely on bridges being up by the time it
-# tries to attach VMs to them.
+# Flush here, not after the play, so libvirt_host can rely on the bridges being
+# up before it attaches VMs.
 - name: Flush handlers — apply networkd reload now if files changed
   ansible.builtin.meta: flush_handlers
   tags: [networkd_bridges]

--- a/ansible/talos/roles/nftables_bridges/defaults/main.yml
+++ b/ansible/talos/roles/nftables_bridges/defaults/main.yml
@@ -1,22 +1,17 @@
 ---
-# Master toggle — role is a no-op when false. Default false; opt-in only.
 nftables_bridges_enabled: false
 
-# Sysctl drop-in path. A dedicated file (not /etc/sysctl.conf) so
-# rollback is a clean `state: absent` on this single path. Numeric
-# prefix `50-` orders us after distro defaults.
+# A dedicated file (not /etc/sysctl.conf) so rollback is a clean `state: absent`;
+# the `50-` prefix orders it after distro defaults.
 nftables_bridges_sysctl_file: /etc/sysctl.d/50-talos-bridges.conf
 
-# br_netfilter must be loaded for these sysctls to exist (the
-# /proc/sys/net/bridge/* keys only appear once the module is in).
-# We set persistent: present so a reboot re-loads it.
+# The /proc/sys/net/bridge/* keys only appear once br_netfilter is loaded, hence
+# persistent: present so a reboot re-loads it.
 nftables_bridges_module: br_netfilter
 
-# Sysctls managed by this role. Both default to 1 in stock kernels;
-# we set them to 0 so bridge-forwarded frames bypass the netfilter
-# IP layer entirely. This matters because Ceph's existing inet
-# filter table has a default-DROP forward chain — without bypass,
-# Talos VM↔VM traffic on br-vlan50 would be silently dropped.
+# Both default to 1 in stock kernels; 0 makes bridge-forwarded frames bypass the
+# netfilter IP layer. Ceph's inet filter table has a default-DROP forward chain,
+# so without the bypass Talos VM<->VM traffic on br-vlan50 is silently dropped.
 nftables_bridges_sysctls:
   net.bridge.bridge-nf-call-iptables: "0"
   net.bridge.bridge-nf-call-ip6tables: "0"

--- a/ansible/talos/roles/nftables_bridges/tasks/main.yml
+++ b/ansible/talos/roles/nftables_bridges/tasks/main.yml
@@ -1,17 +1,10 @@
 ---
-# Make Talos VM traffic on br-vlan50/51 bypass the Ceph nftables
-# inet filter table. Without this, br_netfilter (loaded by libvirt
-# on first VM start) hooks bridge frames into the netfilter IP layer,
-# where Ceph's default-DROP forward chain silently kills them.
-#
-# We don't add nftables rules — we keep our state DISJOINT from the
-# Ceph-owned ruleset. The sysctl bypass is local to the kernel's
-# bridge module and has zero overlap with Ceph's existing inet filter
-# table or its DROP policy.
-#
-# Pre-conditions:
-#   - br_netfilter module loadable (always true on Debian Bookworm)
-#   - Ceph cluster HEALTH_OK (asserted by preflight.yml import upstream)
+# Make Talos VM traffic on br-vlan50/51 bypass the Ceph nftables inet filter:
+# br_netfilter (loaded by libvirt on first VM start) hooks bridge frames into
+# the netfilter IP layer, where Ceph's default-DROP forward chain silently kills
+# them. Deliberately NO nftables rules -- the sysctl bypass keeps our state
+# disjoint from the Ceph-owned ruleset. Pre-conditions: br_netfilter loadable;
+# Ceph HEALTH_OK (asserted by the upstream preflight.yml import).
 
 - name: Pre-flight — role enabled
   ansible.builtin.assert:

--- a/ansible/talos/roles/talos_image/defaults/main.yml
+++ b/ansible/talos/roles/talos_image/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# Master toggle — role is a no-op when false. Default false.
 talos_image_enabled: false
 
 # All other settings inherited from group_vars/all.yml:
@@ -8,12 +7,8 @@ talos_image_enabled: false
 #   talos_kernel_url, talos_kernel_sha256, talos_kernel_path,
 #   talos_initramfs_url, talos_initramfs_sha256, talos_initramfs_path
 
-# Where the compressed image lands during fetch. Removed after
-# successful decompression to save disk on the operator's pool.
 talos_image_compressed_path: "{{ talos_base_image_path }}.zst"
 
-# Whether to delete the .zst after a successful decompression. Off
-# by default for re-fetch resilience — keeping the verified .zst
-# means we can re-decompress without a re-download if the .raw is
-# ever clobbered.
+# Off by default: keeping the verified .zst allows a re-decompress without a
+# re-download if the .raw is ever clobbered.
 talos_image_delete_compressed: false

--- a/ansible/talos/roles/talos_image/tasks/main.yml
+++ b/ansible/talos/roles/talos_image/tasks/main.yml
@@ -1,17 +1,8 @@
 ---
-# Stage the Talos base image on each hypervisor. The base raw image
-# is immutable and shared by every VM — each VM gets a thin qcow2
-# overlay (talos_vms role) backed by this single file.
-#
-# Idempotency model:
-#   - .raw exists  → role is a no-op (no download, no decompress).
-#   - .raw missing, .zst exists with matching checksum → decompress only.
-#   - neither → download (checksum-verified) + decompress.
-#
-# Why pin the .zst checksum (not the .raw): verifying the compressed
-# artifact at download time fails fast (no wasted decompress CPU).
-# Image Factory publishes no checksum sidecar on the free tier —
-# compute it yourself: `curl -sL <talos_image_url> | sha256sum`.
+# Idempotency: .raw exists -> no-op; .zst with matching checksum -> decompress
+# only; neither -> checksum-verified download + decompress. The checksum is
+# pinned on the .zst so a bad download fails before decompress; Image Factory
+# publishes no sidecar -- compute via `curl -sL <talos_image_url> | sha256sum`.
 
 - name: Pre-flight — role enabled
   ansible.builtin.assert:
@@ -71,8 +62,6 @@
   register: _raw_image
   tags: [talos_image]
 
-# zstd is in Debian Bookworm's base archive. Install only when we
-# actually need it (image not already present).
 - name: Install zstd (only if image not yet decompressed)
   ansible.builtin.apt:
     name: zstd
@@ -112,15 +101,9 @@
     path: "{{ talos_image_compressed_path }}"
     state: absent
   when: talos_image_delete_compressed | bool
-  # Reaching this task means decompression completed — either the
-  # creates:-guarded decompress ran successfully, or the .raw was
-  # already present (in which case the .zst probably doesn't exist
-  # either, and state=absent is a no-op).
   tags: [talos_image]
 
-# ─── Boot assets for libvirt direct kernel boot ──────────────────────────
 # Kernel + initramfs referenced by the domain XML's <kernel>/<initrd>.
-# get_url is idempotent (skips when dest matches the checksum).
 
 - name: Fetch Talos kernel (checksum-verified)
   ansible.builtin.get_url:

--- a/ansible/talos/roles/talos_vms/defaults/main.yml
+++ b/ansible/talos/roles/talos_vms/defaults/main.yml
@@ -1,48 +1,29 @@
 ---
-# Master toggle — role is a no-op when false.
 talos_vms_enabled: false
 
-# Libvirt domain + qcow2 + NVRAM file name prefix.
-# Default scopes to "sietch-talos" so VMs end up as sietch-talos-cp1,
-# sietch-talos-worker1, etc. — aligns with the monorepo FQDN scheme
-# `<cluster>-<role>-<name>.<domain>` (e.g. sietch-talos-cp1.staging.austin.int.futo.cloud)
-# and matches the *_TALOS_* 1P secret-prefix convention. Read from
-# group_vars `talos_domain_prefix` when present so a future second
-# cluster can override without role edits.
+# Names domains/qcow2/NVRAM, matching the <cluster>-<role>-<name> FQDN scheme and
+# the *_TALOS_* 1P prefixes.
 talos_vms_domain_prefix: "{{ talos_domain_prefix | default('sietch-talos') }}"
 
-# Active profile selector. Full = 3 CP + 3 workers (1 CP + 1 worker per
-# hypervisor); smoke = 1 CP + 1 worker (laurel).
-# Read from group_vars (single source); local default falls through to
-# `full` to match the playbook + group_vars + TF default.
+# full = 3 CP + 3 workers (1 CP + 1 worker per hypervisor); smoke = 1 CP + 1
+# worker (laurel).
 talos_vms_profile: "{{ talos_profile | default('full') }}"
 
-# Computed inside tasks/main.yml from per-host talos_vms list filtered
-# by the active profile. Surfaced here as a default of [] so the
-# profile-filter task can append idempotently.
+# Computed in tasks/main.yml; [] here so the profile-filter task can append
+# idempotently.
 talos_vms_filtered: []
 
-# Bridge attachment for the primary NIC (VLAN 50 Compute).
-# All Talos VMs sit here; VLAN 51 Services attachment is a follow-up
-# (cluster ingress / LB workloads, not infra bring-up).
+# VLAN 50 Compute; every Talos VM sits here.
 talos_vms_primary_bridge: "{{ vlan_compute_bridge | default('br-vlan50') }}"
 
-# Secondary NIC for workers — attaches to the Services VLAN bridge so
-# LB / ingress controllers can announce service VIPs on VLAN 51 without
-# their traffic touching the cluster's compute network. Rendered by the
-# template only when item.role == 'worker'; CPs stay single-NIC.
+# VLAN 51 Services, workers only (item.role == 'worker'): lets LB/ingress
+# announce service VIPs without that traffic touching the compute network.
 talos_vms_secondary_bridge: "{{ vlan_services_bridge | default('br-vlan51') }}"
 
-# UEFI / OVMF paths. Pinned explicitly (not via `<os firmware='efi'>`
-# shorthand) because libvirt's expansion of that shorthand into stored
-# XML differs from the template every run, triggering re-define on
-# every provision-vms run; a re-define on a stopped VM wipes per-VM
-# NVRAM state.
-#
-# Defaults track Debian Bookworm's `ovmf` package layout. Verify on
-# the actual hypervisor with `dpkg -L ovmf | grep -E 'CODE|VARS'` if
-# upstream changes the filename. The 4M variant (vs legacy 2M) is
-# Bookworm's default for ovmf 2022.11+.
+# OVMF paths pinned explicitly, NOT `<os firmware='efi'>`: libvirt's shorthand
+# expansion differs from the template every run, forcing a re-define each
+# provision-vms -- and a re-define on a stopped VM wipes its NVRAM. Tracks
+# Bookworm's ovmf layout (4M variant); verify with `dpkg -L ovmf | grep -E 'CODE|VARS'`.
 talos_vms_ovmf_code_path: "/usr/share/OVMF/OVMF_CODE_4M.fd"
 talos_vms_ovmf_vars_template: "/usr/share/OVMF/OVMF_VARS_4M.fd"
 talos_vms_nvram_dir: "/var/lib/libvirt/qemu/nvram"

--- a/ansible/talos/roles/talos_vms/tasks/main.yml
+++ b/ansible/talos/roles/talos_vms/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
-# Create per-VM qcow2 overlays, render libvirt domain XML, define +
-# start each VM. Three phases (overlay, define, start) so progress
-# fans out across all VMs at each phase rather than fully provisioning
-# one VM before starting the next — easier to debug if a phase fails
-# for a single VM.
-#
-# Idempotency:
-#   - qcow2 overlays use `creates:` (qemu-img is not idempotent on its
-#     own; -F + creates: gives us the right semantics).
-#   - community.libvirt.virt define is a no-op if the active XML matches.
-#   - state=running is a no-op when the VM is already running.
+# Idempotency: overlays via `creates:` (qemu-img is not idempotent alone), virt
+# define no-ops on matching XML, state=running no-ops when already running.
 
 - name: Pre-flight — role enabled
   ansible.builtin.assert:
@@ -69,9 +60,7 @@
       networkd_bridges role first.
   tags: [talos_vms, preflight]
 
-# ─── Profile filter ─────────────────────────────────────────────────
-# Build the filtered VM list with an explicit accumulator loop —
-# verbose but unambiguous and ansible-lint clean.
+# Explicit accumulator loop: verbose, but unambiguous and ansible-lint clean.
 
 - name: Reset filtered VM list
   ansible.builtin.set_fact:
@@ -94,7 +83,6 @@
       VM(s) selected for profile={{ talos_vms_profile }}.
   tags: [talos_vms]
 
-# ─── Overlays: per-VM qcow2 ─────────────────────────────────────────
 
 - name: Create per-VM qcow2 overlay backed by the Talos base image
   ansible.builtin.command:
@@ -122,7 +110,6 @@
     label: "{{ talos_vms_domain_prefix }}-{{ item.name }}.qcow2"
   tags: [talos_vms, overlays]
 
-# ─── Define: libvirt domains ────────────────────────────────────────
 
 - name: Define libvirt domain for each VM
   community.libvirt.virt:
@@ -133,7 +120,6 @@
     label: "{{ talos_vms_domain_prefix }}-{{ item.name }}"
   tags: [talos_vms, define]
 
-# ─── Start: boot the VMs ────────────────────────────────────────────
 
 - name: Start each VM (idempotent — no-op when already running)
   community.libvirt.virt:
@@ -145,7 +131,6 @@
     label: "{{ talos_vms_domain_prefix }}-{{ item.name }}"
   tags: [talos_vms, start]
 
-# ─── Verify ─────────────────────────────────────────────────────────
 
 - name: Confirm each VM is in 'running' state
   community.libvirt.virt:
@@ -158,9 +143,8 @@
     label: "{{ talos_vms_domain_prefix }}-{{ item.name }}"
   tags: [talos_vms, verify]
 
-# Show the MAC table so the operator can identify VMs at the switch /
-# bridge level (and correlate workers' VLAN-51 DHCP leases). Recomputes
-# the same MAC the template embedded.
+# Recomputes the MAC the template embedded, so VMs can be identified at the
+# switch/bridge level and workers' VLAN-51 DHCP leases correlated.
 - name: Display VM MAC table for operator handoff
   ansible.builtin.debug:
     msg: >-

--- a/ansible/talos/rollback-nftables-bridges.yml
+++ b/ansible/talos/rollback-nftables-bridges.yml
@@ -1,19 +1,9 @@
 ---
-# Rollback for the nftables_bridges role: restore the kernel defaults
-# for br_netfilter call-iptables/-ip6tables, remove the sysctl drop-in
-# file, leave br_netfilter loaded (it's harmless when the call-*
-# sysctls are 1, and removing the module would risk disrupting any
-# bridge in use). After this runs, bridge traffic is back under the
-# kernel default behavior — which means Ceph's inet filter forward
-# chain DROP applies, and Talos VM traffic on br-vlan50 will be
-# dropped again.
-#
-# Use after destroy-vms.yml when fully reverting the Talos lab,
-# OR if the operator decides to take a different approach to bridge
-# filtering (e.g. explicit allow rules in the Ceph security role).
-#
-# Usage: scripts/ansible-play.sh rollback-nftables-bridges.yml
-# Or:    mise run rollback-nftables-bridges
+# Rollback for nftables_bridges: restore br_netfilter call-iptables/-ip6tables
+# defaults, remove the sysctl drop-in, leave br_netfilter loaded (unloading could
+# disrupt in-use bridges). Afterwards Ceph's inet filter forward DROP applies
+# again and Talos VM traffic on br-vlan50 is dropped. Use after destroy-vms.yml
+# or when switching to explicit allow rules in the Ceph security role.
 
 - name: Pre-flight gate (imported)
   ansible.builtin.import_playbook: preflight.yml

--- a/ansible/talos/scripts/ansible-play.sh
+++ b/ansible/talos/scripts/ansible-play.sh
@@ -1,25 +1,10 @@
 #!/usr/bin/env bash
-# ansible-play.sh — secrets-resolving wrapper around ansible-playbook for
-# the talos subtree. Mirrors ansible/ceph/scripts/ansible-play.sh but
-# treats the secrets.yml.tpl file as optional — present when TF has
-# rendered it (with `op://` references), absent otherwise.
-#
-# When secrets.yml.tpl is present:
-#   - Fails fast if no 1P session is available
-#   - Renders the template via `op inject` into a short-lived tmpfile
-#     (mode 600, trap-cleaned on EXIT/INT/TERM)
-#   - Execs ansible-playbook with --extra-vars @tmpfile
-#
-# When secrets.yml.tpl is absent:
-#   - Skips the op-inject step entirely
-#   - Execs ansible-playbook directly (no --extra-vars injection)
-#
-# Usage:
-#   TALOS_ENV=inventories/<cluster>/inventory.ini scripts/ansible-play.sh <playbook.yml> [ansible args...]
-#
-# Environment:
-#   TALOS_ENV                     required — path to inventory.ini for the target cluster
-#   OP_SERVICE_ACCOUNT_TOKEN      optional — CI headless auth (else op desktop session)
+# Secrets-resolving ansible-playbook wrapper for the talos subtree. Mirrors
+# ansible/ceph/scripts/ansible-play.sh but secrets.yml.tpl is OPTIONAL: when
+# present, fail fast without a 1P session, `op inject` into a trap-cleaned 0600
+# tmpfile, exec with --extra-vars @tmpfile; when absent, exec directly.
+# Usage: TALOS_ENV=inventories/<cluster>/inventory.ini scripts/ansible-play.sh <playbook.yml> [args...]
+#   TALOS_ENV required; OP_SERVICE_ACCOUNT_TOKEN optional (CI headless auth).
 set -euo pipefail
 
 : "${TALOS_ENV:?TALOS_ENV must be set to the target cluster inventory.ini}"
@@ -34,7 +19,6 @@ TALOS_ENV_DIR="$(dirname "$TALOS_ENV")"
 TEMPLATE="$TALOS_ENV_DIR/secrets.yml.tpl"
 
 if [ -f "$TEMPLATE" ]; then
-  # Secrets path: render template via op inject.
   if ! op account get >/dev/null 2>&1; then
     echo "ansible-play.sh: 1Password session unavailable (secrets template present)." >&2
     echo "  Unlock 1Password desktop, or set OP_SERVICE_ACCOUNT_TOKEN for CI." >&2
@@ -52,6 +36,5 @@ if [ -f "$TEMPLATE" ]; then
 
   exec ansible-playbook -i "$TALOS_ENV" --extra-vars "@$TMPFILE" "$@"
 else
-  # No-secrets path: skip op inject entirely.
   exec ansible-playbook -i "$TALOS_ENV" "$@"
 fi


### PR DESCRIPTION
Comment-only pass over `ansible/`. Comment lines 2,484 -> 1,889 in the final sweep.

**Deleted:** `# --- Step N ---` / `# Phase N` dividers, `# === Naming/Network/Storage ===` group headers in the cluster `vars.yml` files, `# Performance`/`# Output`/`# Security` labels in the three `ansible.cfg`, file headers re-listing the phases below, and self-evident package/sysctl labels (`tcpdump # packet capture`, `kernel_dmesg_restrict: 1 # restrict dmesg`).

**Kept -- every dated incident:** the sntrup761 kex hang (2026-07-16..20, four-day outage), RGW period-commit segfaults and `period update --commit` non-idempotence (2026-07-27), the conntrack INVALID wedge that took out 9 OSDs and 7 RGWs (2026-07-20), the silent `orch apply -i` no-op and alertmanager route-tree bug (2026-07-31), grafana `disable_initial_admin_creation` (2026-07-21), ALPM slow-op on osd.155 (2026-07-24), Ceph tracker #68436, the reversed db-slot pairing, the miguel by-path exception, and the `reprovision_hetzner` ALWAYS-DESTRUCTIVE header.

**Note -- a correction is included.** An earlier sweep stripped trailing annotations that carried non-derivable facts; 29 were restored: the VLAN 120/122/124 mappings and their CIDRs, `bond0.120`, `ceph_rgw_ingress_vip_prefix: 23 # matches public_network`, the `baseline_ops_sudo` value contract, `56623104 # ~54 MB`, `3650 # 10 years`, `\"20.2.*\" # patch range`, and the opaque-package decodes (`mstflint`, `ledmon`, `sg3-utils`). A CIDR-to-VLAN mapping exists nowhere else in the tree.

**Verification:** all 106 changed YAML files compared structurally (`safe_load_all`, HEAD vs worktree) -- identical, so no values moved. `bash -n` clean on edited scripts; `.mise.toml` and `ansible.cfg` parse. `.j2` templates untouched (their comments render into deployed configs). No ansible was run.

- `main` <!-- branch-stack -->
  - \#453 :point\_left:
