### PR TITLE
chore(k8s): trim narration from comments

### DIFF
--- a/charts/apps/meta/Chart.yaml
+++ b/charts/apps/meta/Chart.yaml
@@ -3,9 +3,8 @@ name: meta
 description: Yucca .well-known discovery pointer (static nginx)
 type: application
 version: 0.1.0
-# Upstream nginx, not a yucca image — this chart is deliberately OUT of the
-# release-please single-version scheme (release-please-config.json lists the
-# other apps' Chart.yaml, not this one). The tag in values.yaml is what ships.
+# Deliberately OUT of the release-please single-version scheme (upstream nginx,
+# not a yucca image); the tag in values.yaml is what ships.
 appVersion: "1.29"
 dependencies:
   - name: yucca-common

--- a/charts/apps/meta/values.yaml
+++ b/charts/apps/meta/values.yaml
@@ -1,19 +1,11 @@
-# The discovery pointer: a static nginx serving exactly
-# /.well-known/yucca.json — the one URL a client can hard-code. The JSON names
-# the API root, and yucca-api's /meta serves everything else (sites, rest_url,
-# config). Deliberately a separate pod from yucca-api: the pointer must stay
-# reachable on a stable vendor host (meta.futo.cloud) independent of whichever
-# domain the API currently lives on.
+# Deliberately separate from yucca-api so the stable vendor host (meta.futo.cloud)
+# outlives the API's domain.
 
-# 2 replicas + a PDB (templates/pdb.yaml): the pointer is the first thing every
-# client touches, and it costs ~nothing to run two.
 replicas: 2
 
-# Tiny: nginx serving one 60-byte file. The limit looks oversized for that
-# because nginx's stock `worker_processes auto` forks one worker per HOST cpu
-# (~48 on the father workers, measured ~0.6MiB private each) — the image's
-# autotune entrypoint can't help, it bails on a read-only rootfs since it
-# rewrites /etc/nginx/nginx.conf. Headroom is cheaper than a custom nginx.conf.
+# Limit looks oversized because `worker_processes auto` forks per HOST cpu (~48 on
+# father, ~0.6MiB each); the image's autotune entrypoint bails on read-only rootfs
+# (rewrites nginx.conf). Headroom is cheaper than a custom nginx.conf.
 resources:
   requests: { cpu: 10m, memory: 32Mi }
   limits: { memory: 256Mi }
@@ -21,9 +13,7 @@ resources:
 # Stable in-cluster name, independent of the Helm release name (dev == prod).
 fullnameOverride: yucca-meta
 
-# Unprivileged upstream nginx: listens on 8080 as uid 101 and relocates every
-# runtime path (pid, *_temp) under /tmp, so it runs unchanged with the chart's
-# read-only rootfs. Pinned to the 1.29 minor — patch releases roll in on pull.
+# Image runs 8080 as uid 101, runtime paths under /tmp → works with read-only rootfs.
 image:
   repository: docker.io/nginxinc/nginx-unprivileged
   tag: 1.29-alpine
@@ -45,10 +35,7 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Serialized verbatim (as JSON) into the ConfigMap that becomes
-# /.well-known/yucca.json. The real clusters override meta_url from the
-# HelmRelease (https://${APP_DOMAIN}/api/meta); this default points at the dev
-# port-forward, which is where a browser-side client reaches yucca-api in k3d.
+# Default = dev port-forward; real clusters override meta_url from the HelmRelease.
 wellKnown:
   meta_url: http://localhost:3020/api/meta
 
@@ -58,9 +45,7 @@ volumes:
   - name: well-known
     configMap:
       name: yucca-meta
-  # nginx-unprivileged keeps its temp paths in /tmp (already an emptyDir from
-  # the library chart), but the image still creates /var/cache/nginx and the
-  # rootfs is read-only. A tmpfs here keeps startup quiet.
+  # Image still creates /var/cache/nginx on the read-only rootfs; tmpfs keeps startup quiet.
   - name: cache
     emptyDir: {}
 

--- a/charts/apps/michael/values.yaml
+++ b/charts/apps/michael/values.yaml
@@ -1,9 +1,7 @@
-# 2 replicas + a PDB (templates/pdb.yaml): michael is the production restic
-# gateway — a single replica turns every node drain into interrupted backups.
-# Stateless S3 proxy, safe to run N-way.
+# A single replica turns every node drain into interrupted backups; stateless, safe N-way.
 replicas: 2
 
-# Generous requests, deliberately huge memory limits (never CPU-limit).
+# No CPU limit on purpose (CFS throttling hurts tail latency).
 resources:
   requests: { cpu: 250m, memory: 256Mi }
   limits: { memory: 4Gi }
@@ -23,8 +21,8 @@ ports:
 service:
   type: ClusterIP
 
-# Michael reads the same topology as the API. Every declared storage cluster
-# is therefore routable before the API can mint a token for it.
+# Same topology as the API: every declared storage cluster is routable before
+# the API can mint a token for it.
 volumes:
   - name: topology
     configMap:
@@ -34,12 +32,8 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
-# OPT-IN dev verification key — the public half of the project's well-known
-# local-dev keypair (see charts/yucca-api/values.yaml + .mise/tasks/*/env).
-# Renders into the Secret ONLY when useDevKeypair is true (dev/local overlay).
-# Default false: with no key provided the Secret doesn't render and the pod
-# fails loudly, instead of silently trusting tokens anyone can mint with the
-# committed private half. Prod provides the real key via ExternalSecret.
+# Public half of the local-dev keypair (.mise/tasks/*/env). Default false: pod fails
+# loudly rather than trusting tokens anyone can mint with the committed private half.
 useDevKeypair: false
 devJwtPublicKey: |
   -----BEGIN PUBLIC KEY-----
@@ -52,14 +46,9 @@ env:
     value: "3010"
   - name: LOG_LEVEL
     value: debug
-  # S3 object store = Rook-Ceph RGW. michael creates one bucket per restic
-  # repository, so it needs a full RGW user (CephObjectStoreUser via
-  # charts/ceph-objectuser), NOT a bucket-scoped ObjectBucketClaim. Rook writes
-  # the user's keys into this namespace as rook-ceph-object-user-<store>-<user>.
-  # Must match the dev topology's cluster code (ConfigMap yucca-topology /
-  # topology.dev.json): yucca-api mints restic tokens with
-  # storageCluster=local-dev,
-  # and michael fails closed on cluster codes it does not front.
+  # One bucket per restic repo → needs a full RGW user, NOT a bucket-scoped OBC.
+  # S3_DEFAULT_CLUSTER must match the topology cluster code — michael fails closed
+  # on cluster codes it does not front.
   - name: S3_DEFAULT_CLUSTER
     value: local-dev
   - name: SITE_CODE
@@ -82,11 +71,9 @@ env:
     value: us-east-1
   - name: S3_FORCE_PATH_STYLE
     value: "true"
-  # Built-in S3 load balancing. Dev has a single RGW behind a ClusterIP, so the
-  # DNS source resolves to one backend (kube-proxy still spreads behind the
-  # VIP) — this exercises the pool/health-probe/per-backend-metrics path in
-  # dev. Plain HTTP to Rook RGW, which accepts any signing host, so no
-  # host-pinning or TLS skip is needed (unlike staging's bare-metal RGW).
+  # Dev's DNS source resolves to the single RGW ClusterIP — still exercises the
+  # pool/health-probe/per-backend-metrics path. Rook RGW accepts any signing host,
+  # so no host-pinning/TLS skip (unlike staging's bare-metal RGW).
   - name: S3_BACKEND_SOURCE
     value: dns
   - name: S3_BACKEND_DNS_HOST

--- a/charts/apps/web/values.yaml
+++ b/charts/apps/web/values.yaml
@@ -1,8 +1,6 @@
-# 2 replicas + a PDB (templates/pdb.yaml): the user-facing frontend survives
-# single-node drains/reboots.
 replicas: 2
 
-# Generous requests, deliberately huge memory limits (never CPU-limit).
+# No CPU limit on purpose (CFS throttling hurts tail latency).
 resources:
   requests: { cpu: 100m, memory: 256Mi }
   limits: { memory: 4Gi }

--- a/charts/apps/yucca-admin-api/values.yaml
+++ b/charts/apps/yucca-admin-api/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 
-# Generous requests, deliberately huge memory limits (never CPU-limit).
+# No CPU limit on purpose (CFS throttling hurts tail latency).
 resources:
   requests: { cpu: 100m, memory: 512Mi }
   limits: { memory: 4Gi }
@@ -20,8 +20,6 @@ ports:
 service:
   type: ClusterIP
 
-# The GitOps-owned topology document (sites + storage clusters), validated and
-# hot-reloaded on access. Same ConfigMap and mount as yucca-api.
 volumes:
   - name: topology
     configMap:
@@ -31,25 +29,20 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
-# CNPG-managed postgres Cluster name (shares yucca-api's database)
 postgresClusterName: yucca-db
 
-# OIDC provider in-cluster service (must match the issuer mock-oidc advertises)
+# Must match the issuer mock-oidc advertises.
 oidcIssuer: http://yucca-mock-oidc:8092
 oidcRedirectUri: http://localhost:3030/api/auth/oidc/callback
 oidcLogoutRedirectUri: http://localhost:3030
 
-# Static dev secrets (overridden in prod via ExternalSecret)
+# Dev fixtures; prod replaces via ExternalSecret.
 secretData:
   OIDC_ADMIN_CLIENT_ID: "client ID"
   OIDC_ADMIN_CLIENT_SECRET: "client secret"
 
-# OPT-IN dev signing key for CLI session JWTs. The project's well-known
-# local-dev ES256 keypair (the same one committed in .mise/tasks/*/env and the
-# yucca-api chart) renders into the Secret ONLY when useDevKeypair is true —
-# set by the dev/local overlay. Default false: an overlay that forgets to
-# provide a real key gets a loud missing-JWT_PRIVATE_KEY crash instead of
-# silently signing admin tokens with a public fixture.
+# Local-dev ES256 keypair (.mise/tasks/*/env). Default false so a forgetful overlay
+# crashes on missing JWT_PRIVATE_KEY instead of signing admin tokens with a public fixture.
 useDevKeypair: false
 devJwtPrivateKey: |
   -----BEGIN PRIVATE KEY-----
@@ -67,8 +60,6 @@ env:
     value: debug
   - name: OIDC_ADMIN_ALLOW_INSECURE
     value: "true"
-  # Fleet topology — replaces the old single RESTIC_ENDPOINT: the restic
-  # gateway is now a per-site field in this file (rest_url), not one global URL.
   - name: TOPOLOGY_FILE
     value: /etc/yucca/topology.json
   - name: LEGACY_SITE_CODE

--- a/charts/apps/yucca-api/templates/migration-job.yaml
+++ b/charts/apps/yucca-api/templates/migration-job.yaml
@@ -18,7 +18,6 @@ spec:
         job: migrate
     spec:
       restartPolicy: OnFailure
-      # Restricted-PSS-compliant (the yucca namespace enforces `restricted`).
       # No readOnlyRootFilesystem: the migrate step writes to /app (pnpm).
       securityContext:
         runAsNonRoot: true

--- a/charts/apps/yucca-api/values.yaml
+++ b/charts/apps/yucca-api/values.yaml
@@ -1,16 +1,11 @@
-# 2 replicas + a PDB (templates/pdb.yaml, rendered when replicas > 1): the API
-# survives single-node drains/reboots.
 replicas: 2
 
-# Generous requests, deliberately huge memory limits (never CPU-limit — CFS
-# throttling hurts tail latency more than contention does).
+# No CPU limit on purpose (CFS throttling hurts tail latency more than contention).
 resources:
   requests: { cpu: 250m, memory: 512Mi }
   limits: { memory: 4Gi }
 
-# Stable in-cluster name, independent of the Helm release name. This keeps
-# service DNS identical whether rendered by Tilt (dev) or Flux (prod, per-app
-# release names).
+# Stable in-cluster DNS regardless of release name — identical under Tilt (dev) and Flux (prod).
 fullnameOverride: yucca-api
 
 image:
@@ -25,11 +20,8 @@ ports:
 service:
   type: ClusterIP
 
-# The GitOps-owned topology document (sites + storage clusters), validated and
-# hot-reloaded on access — see TOPOLOGY_FILE below. Rendered per cluster by
-# kubernetes/apps/base/topology; dev/k3d gets the literal copy from
-# kubernetes/apps/dev/local/yucca/topology. Same mount in yucca-admin-api and
-# yucca-metrics-worker.
+# Hot-reloaded. Rendered by kubernetes/apps/base/topology (dev/k3d: literal copy
+# under apps/dev/local/yucca/topology).
 volumes:
   - name: topology
     configMap:
@@ -39,26 +31,19 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
-# CNPG-managed postgres Cluster name (see umbrella chart)
 postgresClusterName: yucca-db
 
-# OIDC provider in-cluster service
 oidcIssuer: http://yucca-mock-oidc:8092
 oidcRedirectUri: http://localhost:5173/api/auth/oidc/callback
 oidcLogoutRedirectUri: http://localhost:5173
 
-# DEV FIXTURES — not secrets (mock-oidc placeholder client). Prod replaces
-# this whole block with ExternalSecrets (1Password) — see kubernetes/README.md.
+# Dev fixtures, not secrets; prod replaces the whole block via ExternalSecrets.
 secretData:
   OIDC_CLIENT_ID: "client ID"
   OIDC_CLIENT_SECRET: "client secret"
 
-# OPT-IN dev signing key. The project's well-known local-dev ES256 keypair
-# (the same one committed in .mise/tasks/*/env; michael verifies with the
-# matching public half) renders into the Secret ONLY when useDevKeypair is
-# true — set by the dev/local overlay. Default false: an overlay that forgets
-# to provide a real key gets a loud missing-JWT_PRIVATE_KEY crash instead of
-# silently signing production tokens with a public fixture.
+# Local-dev ES256 keypair (.mise/tasks/*/env; michael holds the public half). Default
+# false so an overlay missing a real key crashes instead of signing with a public fixture.
 useDevKeypair: false
 devJwtPrivateKey: |
   -----BEGIN PRIVATE KEY-----
@@ -67,12 +52,9 @@ devJwtPrivateKey: |
   Ls1C0ncCcmRhqKA7UxLknn0ji5FcKaku1zBOhxQYcxFVmsYtAxZ1ljgN
   -----END PRIVATE KEY-----
 
-# Extra envFrom sources appended AFTER the chart's own secret — for duplicate
-# keys the last source wins, so this is the override hook. Tilt points it at
-# the yucca-dev-env Secret (built from a gitignored root .env, op:// refs
-# resolved via the 1Password CLI); prod can point it at an ExternalSecret.
-# NB: explicit `env` entries below always beat envFrom — env vars the chart
-# pins there (OIDC_ISSUER & co) are overridden via their Helm values instead.
+# Appended AFTER the chart's own secret — last envFrom source wins, so this is the
+# override hook (Tilt: yucca-dev-env Secret from gitignored .env; prod: ExternalSecret).
+# NB: explicit `env` entries below always beat envFrom — override those via Helm values.
 extraEnvFrom: []
 
 env:
@@ -84,16 +66,12 @@ env:
     value: debug
   - name: OIDC_ALLOW_INSECURE
     value: "true"
-  # Device-flow OIDC (required by yucca-api env schema; points at mock-oidc's
-  # registered device client).
   - name: OIDC_DEVICE_ISSUER
     value: http://yucca-mock-oidc:8092
   - name: OIDC_DEVICE_CLIENT_ID
     value: "device client ID"
   - name: OIDC_DEVICE_ALLOW_INSECURE
     value: "true"
-  # Fleet topology — replaces the old single RESTIC_ENDPOINT: the restic
-  # gateway is now a per-site field in this file (rest_url), not one global URL.
   - name: TOPOLOGY_FILE
     value: /etc/yucca/topology.json
   - name: LEGACY_SITE_CODE

--- a/charts/apps/yucca-metrics-worker/values.yaml
+++ b/charts/apps/yucca-metrics-worker/values.yaml
@@ -1,8 +1,7 @@
-# Single replica ON PURPOSE: a cron-style meter worker — two replicas would
-# double-count usage.
+# Single replica ON PURPOSE: two replicas would double-count usage.
 replicas: 1
 
-# Generous requests, deliberately huge memory limits (never CPU-limit).
+# No CPU limit on purpose (CFS throttling hurts tail latency).
 resources:
   requests: { cpu: 100m, memory: 512Mi }
   limits: { memory: 4Gi }
@@ -19,17 +18,11 @@ ports:
   - name: http
     containerPort: 3040
 
-# CNPG-managed postgres Cluster name (shares yucca-api's database)
 postgresClusterName: yucca-db
 
-# RGW admin endpoints come from the hot-reloaded topology file (ConfigMap
-# yucca-topology, rgw_admin_endpoint per storage cluster). The object-user Secret holds the
-# fallback AccessKey/SecretKey pair — a dedicated RGW user (charts/ceph-objectuser
-# via the yucca-metrics-object-user release) with admin read caps, so the worker
-# can pull per-bucket stats from the RGW admin API — michael is a plain S3 user
-# without those caps. Per-cluster creds override via
-# RADOS_ACCESS_KEY_ID_<CODE>/RADOS_SECRET_ACCESS_KEY_<CODE> keys in that same
-# Secret (envFrom exposes them under those exact names).
+# Fallback AccessKey/SecretKey of a dedicated RGW user with admin read caps for per-bucket
+# stats (michael's plain S3 user lacks them). Per-cluster overrides:
+# RADOS_ACCESS_KEY_ID_<CODE>/RADOS_SECRET_ACCESS_KEY_<CODE> in the same Secret (envFrom).
 radosSecretName: rook-ceph-object-user-yucca-metrics
 
 volumes:
@@ -41,8 +34,7 @@ volumeMounts:
     mountPath: /etc/yucca
     readOnly: true
 
-# Static dev secrets (overridden in dev via the yucca-dev-env extraEnvFrom
-# layer, in prod via ExternalSecret)
+# Dev fixtures; overridden via the yucca-dev-env extraEnvFrom layer (dev) / ExternalSecret (prod).
 secretData:
   POLAR_ACCESS_TOKEN: "polar access token"
   POLAR_WEBHOOK_SECRET: "polar webhook secret"

--- a/charts/dev/mock-oidc/values.yaml
+++ b/charts/dev/mock-oidc/values.yaml
@@ -1,7 +1,6 @@
 replicas: 1
 
 # Stable in-cluster name, independent of the Helm release name (dev == prod).
-# yucca-api/admin-api reference this as their OIDC issuer host.
 fullnameOverride: yucca-mock-oidc
 
 image:
@@ -9,8 +8,6 @@ image:
   tag: dev
   pullPolicy: IfNotPresent
 
-# Container listens on 80 (see packages/mock-oidc-provider); exposed in-cluster
-# and via port-forward as 8092 to match yucca-api's oidcIssuer.
 ports:
   - name: http
     containerPort: 80
@@ -22,8 +19,7 @@ service:
 env:
   - name: PORT
     value: "80"
-  # iss claim / discovery base — must match yucca-api's OIDC_ISSUER
-  # (http://yucca-mock-oidc:8092) so issued tokens validate in-cluster.
+  # Must match yucca-api's OIDC_ISSUER or issued tokens fail validation in-cluster.
   - name: ISSUER
     value: http://yucca-mock-oidc:8092
   - name: CLIENT_ID
@@ -32,7 +28,6 @@ env:
     value: "client secret"
   - name: DEVICE_CLIENT_ID
     value: "device client ID"
-  # Browser-facing callbacks resolve via the Tilt port-forwards.
   - name: REDIRECT_URI
     value: http://localhost:5173/api/auth/oidc/callback
   - name: POST_LOGOUT_REDIRECT_URI
@@ -42,8 +37,6 @@ env:
   - name: ADMIN_POST_LOGOUT_REDIRECT_URI
     value: http://localhost:3030
 
-# Probe the discovery document — it's what every consumer (yucca-api, the e2e,
-# browsers) needs working.
 startupProbe:
   httpGet: { path: /.well-known/openid-configuration, port: http }
   periodSeconds: 2

--- a/charts/lib/yucca-common/templates/_deployment.tpl
+++ b/charts/lib/yucca-common/templates/_deployment.tpl
@@ -26,11 +26,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # Restricted-PSS-compliant defaults (the yucca namespace enforces
-      # `restricted`). uid/gid 1000 matches every service Dockerfile (USER
-      # node/michael, both 1000) — set explicitly because kubelet can't verify
-      # runAsNonRoot against a NAMED image user. Override wholesale via
-      # .Values.podSecurityContext when a chart needs something else.
+      # Restricted-PSS defaults (yucca ns enforces `restricted`). uid/gid 1000 matches
+      # every service Dockerfile; explicit because kubelet can't verify runAsNonRoot
+      # against a NAMED image user. Override wholesale via .Values.podSecurityContext.
       securityContext:
         {{- if .Values.podSecurityContext }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -91,9 +89,7 @@ spec:
           {{- with .Values.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          # /tmp is always a writable emptyDir: the root filesystem is
-          # read-only by default (securityContext above) and the Node runtimes
-          # expect a writable tmpdir.
+          # /tmp always writable: rootfs is read-only by default and Node runtimes need a tmpdir.
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/charts/platform/ceph-objectuser/values.yaml
+++ b/charts/platform/ceph-objectuser/values.yaml
@@ -1,13 +1,10 @@
-# RGW user for michael. Rook writes a Secret named
-# "rook-ceph-object-user-<store>-<userName>" into THIS namespace with keys
-# AccessKey / SecretKey. michael (charts/michael) consumes them.
+# Rook writes a Secret named "rook-ceph-object-user-<store>-<userName>" into THIS
+# namespace with keys AccessKey / SecretKey.
 userName: michael
-# CephObjectStore name + the namespace where the Rook cluster/objectstore lives.
 store: yucca
 clusterNamespace: rook-ceph
 
-# RGW admin capabilities (radosgw-admin caps). Empty = a plain S3 user that can
-# only manage its own buckets (michael's case). Grant read caps to a user that
-# needs the RGW admin API — e.g. the metrics worker reading per-bucket usage.
-# See https://rook.io/docs/rook/latest/CRDs/Object-Storage/ceph-object-store-user-crd/
+# radosgw-admin caps. Empty = plain S3 user (own buckets only); read caps unlock the
+# RGW admin API (e.g. per-bucket usage for the metrics worker).
+# https://rook.io/docs/rook/latest/CRDs/Object-Storage/ceph-object-store-user-crd/
 capabilities: {}

--- a/charts/platform/cnpg-cluster/values.yaml
+++ b/charts/platform/cnpg-cluster/values.yaml
@@ -1,12 +1,9 @@
-# CNPG Cluster. The name is the stable in-cluster identifier; yucca-api and
-# yucca-admin-api derive their POSTGRES_* env from the "<clusterName>-app" secret
-# that CNPG generates, so keep this consistent across dev and prod.
+# Consumers derive POSTGRES_* from the CNPG-generated "<clusterName>-app" secret —
+# keep the name consistent across dev and prod.
 clusterName: yucca-db
 instances: 1
 storage: 1Gi
 storageClass: ""
 database: yucca
 owner: yucca
-# Per-instance postgres pod resources (CNPG spec.resources). Empty = BestEffort
-# (dev default); real clusters set this via the HelmRelease.
 resources: {}

--- a/charts/platform/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/charts/platform/rook-ceph-cluster/templates/cephcluster.yaml
@@ -16,28 +16,23 @@ spec:
     allowMultiplePerNode: true
   dashboard:
     enabled: {{ .Values.dashboard.enabled }}
-  # Trim the footprint for a laptop-sized dev cluster.
   crashCollector:
     disable: true
   cephConfig:
     global:
-      # no redundancy on a single OSD
       osd_pool_default_size: "1"
       osd_pool_default_min_size: "1"
       mon_warn_on_pool_no_redundancy: "false"
       mon_allow_pool_size_one: "true"
-      # Single-OSD dev fix: the PG autoscaler starts pools at pg_num=1, but Rook
-      # sets pg_num_min=8 on the RGW system pools (e.g. .rgw.root) -> EINVAL
-      # "pg_num_min 8 > pg_num 1". Disable autoscaling and default new pools to
-      # 8 PGs so the object store's pools are created at pg_num=8.
+      # The PG autoscaler starts pools at pg_num=1, but Rook sets pg_num_min=8 on the
+      # RGW system pools -> EINVAL "pg_num_min 8 > pg_num 1"; default new pools to 8 PGs.
       osd_pool_default_pg_autoscale_mode: "off"
       osd_pool_default_pg_num: "8"
       osd_pool_default_pgp_num: "8"
   storage:
     useAllNodes: true
     useAllDevices: false
-    # Loop devices must be named explicitly (see values.yaml). Requires
-    # allowLoopDevices=true on the operator.
+    # Loop devices must be named explicitly; requires allowLoopDevices=true on the operator.
     devices:
       - name: {{ .Values.storage.device }}
   healthCheck:

--- a/charts/platform/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/charts/platform/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -17,8 +17,7 @@ spec:
   gateway:
     port: {{ .Values.objectStore.gateway.port }}
     instances: {{ .Values.objectStore.gateway.instances }}
-  # Allow CephObjectStoreUser CRs in the app namespace (so the user's S3 secret
-  # is written there for michael to consume). See charts/ceph-objectuser.
+  # So user CRs live in the app namespace and their S3 secrets are written there.
   allowUsersInNamespaces:
     {{- range .Values.objectStore.allowUsersInNamespaces }}
     - {{ . }}

--- a/charts/platform/rook-ceph-cluster/templates/loop-device.yaml
+++ b/charts/platform/rook-ceph-cluster/templates/loop-device.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.loopDevice.enabled }}
-# DEV ONLY. k3d nodes have no spare block device, and Rook OSDs need raw block
-# storage (k3d's local-path provisioner is filesystem-only). This privileged
-# DaemonSet creates a sparse image on the node and losetup-attaches it to a
-# FIXED loop device (storage.device / loopDevice.device) that the CephCluster
-# names explicitly. The container stays alive so the attachment persists.
+# DEV ONLY. Rook OSDs need raw block storage and k3d has none (local-path is filesystem-only).
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -34,12 +30,10 @@ spec:
               DEV="{{ .Values.loopDevice.device }}"
               mkdir -p "$(dirname "$IMG")"
               [ -f "$IMG" ] || truncate -s {{ .Values.loopDevice.sizeGiB }}G "$IMG"
-              # Attach the image to the FIXED device the CephCluster references.
-              # Loop attachments live in the HOST kernel (shared by every k3d
-              # node), so they survive cluster re-creation: after a k3d:reset,
-              # DEV is typically still bound to the PREVIOUS cluster's now-
-              # deleted image — which also makes Rook skip it (stale bluestore
-              # signature). Clean all stale state before attaching:
+              # Loop attachments live in the HOST kernel (shared by all k3d nodes) and
+              # survive cluster re-creation: after k3d:reset DEV is typically bound to the
+              # previous cluster's deleted image (stale bluestore signature — Rook skips
+              # it). Clean stale state before attaching:
               if losetup "$DEV" >/dev/null 2>&1; then
                 back="$(losetup --noheadings --output BACK-FILE "$DEV" 2>/dev/null | xargs || true)"
                 # detach unless it's a live attachment of exactly our image

--- a/charts/platform/rook-ceph-cluster/values.yaml
+++ b/charts/platform/rook-ceph-cluster/values.yaml
@@ -12,33 +12,27 @@ dashboard:
   enabled: false
 
 storage:
-  # Rook does NOT auto-select loop devices via useAllDevices (even with
-  # allowLoopDevices on the operator) — they must be named explicitly. This is
-  # the loop device attached by the DaemonSet below. A HIGH minor number: the
-  # kernel hands out the lowest free loop devices, so k3s/containerd will have
-  # claimed loop0..N on a fresh node — loop100 is reliably ours.
+  # Rook does NOT auto-select loop devices via useAllDevices (even with allowLoopDevices)
+  # — must be named explicitly; attached by the DaemonSet below. High minor on purpose:
+  # k3s/containerd claim the lowest free loop0..N, so loop100 is reliably ours.
   device: /dev/loop100
 
-# S3 object store (CephObjectStore + RGW).
 objectStore:
   name: yucca
   region: us-east-1
   gateway:
     port: 80
     instances: 1
-  # Namespaces allowed to host CephObjectStoreUser CRs (michael's S3 user lives
-  # in the yucca namespace so its secret is written there).
+  # So user CRs live in the app namespace and Rook writes their S3 secrets there.
   allowUsersInNamespaces:
     - yucca
 
-# k3d has no spare block device, so synthesize one with a loopback file. This
-# privileged DaemonSet truncates a sparse image on the node and losetup-attaches
-# it; Rook's OSD then consumes it. Disable if your nodes have real disks.
+# k3d has no spare block device — a privileged DaemonSet losetup-attaches a sparse
+# image for the OSD. Disable if your nodes have real disks.
 loopDevice:
   enabled: true
   image: alpine:3.21
   sizeGiB: 20
-  # where the backing image file lives on the node (under dataDirHostPath)
   path: /var/lib/rook/osd-loop.img
-  # fixed device the image is attached to (must match storage.device above)
+  # must match storage.device above
   device: /dev/loop100

--- a/kubernetes/apps/base/envoy-proxy/certificate.yaml
+++ b/kubernetes/apps/base/envoy-proxy/certificate.yaml
@@ -1,9 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cert-manager.io/certificate_v1.json
-# Wildcard + apex for the cluster's APP_DOMAIN — covers web (apex), api.
-# (and admin. when it's exposed; prod's restic host is two labels down and has
-# its own gw-public cert). cert-manager writes app-domain-tls into this
-# namespace (envoy-system) for the Gateway(s) to terminate with.
+# Prod's restic host is two labels down — outside this wildcard; it has its own gw-public cert.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/kubernetes/apps/base/envoy-proxy/envoyproxy.yaml
+++ b/kubernetes/apps/base/envoy-proxy/envoyproxy.yaml
@@ -1,8 +1,5 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
-# Bare-metal exposure: the Envoy data-plane Service is a LoadBalancer pinned to
-# the internal ingress VIP via Cilium LB-IPAM (the public IP NATs to it). Unlike
-# o11y's cloud NodePort, this serves :443 directly.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -20,9 +17,8 @@ spec:
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
-              # DoNotSchedule: with ScheduleAnyway both replicas could co-locate
-              # and one node reboot takes all ingress down. Both real clusters
-              # have 3+ schedulable nodes, so this is always satisfiable.
+              # ScheduleAnyway could co-locate both replicas → one node reboot takes all
+              # ingress down. Both real clusters have 3+ nodes, so always satisfiable.
               whenUnsatisfiable: DoNotSchedule
               labelSelector:
                 matchLabels:
@@ -35,12 +31,10 @@ spec:
           value:
             metadata:
               labels:
-                # Pool selection where pools use a serviceSelector (father:
-                # internal → lb-internal, public → lb-public-a); ignored where
-                # the pool matches by IP annotation (staging).
+                # Pool selection where pools use a serviceSelector (father); ignored
+                # where the pool matches by IP annotation (staging).
                 lb: ${INGRESS_LB_LABEL}
               annotations:
-                # Cilium LB-IPAM assigns this specific VIP to the Service.
                 lbipam.cilium.io/ips: "${INGRESS_VIP}"
   telemetry:
     metrics:

--- a/kubernetes/apps/base/envoy-proxy/gateway.yaml
+++ b/kubernetes/apps/base/envoy-proxy/gateway.yaml
@@ -1,10 +1,7 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/gateway_v1.json
-# HTTPS on 443 (the wildcard cert covers the apex + every subdomain: web/api/gw)
-# plus a bare HTTP listener on 80 that exists ONLY to serve the 301 redirect
-# (redirect.yaml in httproutes) — without it, plain-http requests to the VIP get
-# connection-refused. Per-host routing is in the HTTPRoutes (which live with the
-# app services). Routes may attach from any namespace.
+# The :80 listener exists ONLY for the 301 redirect (redirect.yaml) — without it
+# plain-http hits connection-refused.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/kubernetes/apps/base/httproutes/gw.yaml
+++ b/kubernetes/apps/base/httproutes/gw.yaml
@@ -1,8 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
-# michael — the restic gateway. Exposed at gw.<domain>. The parent is
-# per-cluster: staging's single app gateway (envoy) vs father's dedicated
-# high-throughput gateway (gw) — see GW_PARENT_GATEWAY in cluster-settings.
+# GW_PARENT_GATEWAY: staging shares the app gateway (envoy); father has a dedicated gw.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/base/httproutes/meta.yaml
+++ b/kubernetes/apps/base/httproutes/meta.yaml
@@ -1,11 +1,7 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
-# The discovery pointer at ${META_HOST} — a host that deliberately does NOT
-# move with the product domain, so shipped clients can hard-code it. Only
-# /.well-known/ is routed: everything else on this host (including nginx's
-# stock welcome page) falls through to the gateway's 404.
-#
-# The :80 half is covered by redirect.yaml's catch-all 301 (no hostname filter).
+# Only /.well-known/ is routed on purpose — everything else (incl. nginx's stock
+# welcome page) falls through to the gateway's 404.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/base/httproutes/redirect.yaml
+++ b/kubernetes/apps/base/httproutes/redirect.yaml
@@ -1,7 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
-# Catch-all on the :80 listener: permanent-redirect everything to HTTPS. No
-# hostnames filter — any plain-http hit on the VIP gets the 301.
+# No hostnames filter: intentional catch-all.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/base/meta/helmrelease.yaml
+++ b/kubernetes/apps/base/meta/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/apps/meta
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -24,11 +23,6 @@ spec:
     remediation:
       retries: 3
   values:
-    # Stock upstream nginx — no image override here (nothing to stamp with
-    # ${YUCCA_IMAGE_TAG}); the chart pins the tag.
-    #
-    # The whole point of the pod: hand a client the API root it should ask for
-    # everything else. Rendered into the chart's ConfigMap and served at
-    # /.well-known/yucca.json.
+    # No ${YUCCA_IMAGE_TAG} override — the chart pins the upstream nginx tag.
     wellKnown:
       meta_url: https://${APP_DOMAIN}/api/meta

--- a/kubernetes/apps/base/michael/helmrelease.yaml
+++ b/kubernetes/apps/base/michael/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/apps/michael
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -24,18 +23,14 @@ spec:
     remediation:
       retries: 3
   values:
-    # Per-cluster fleet size (staging 2, father 12 — the 60+ Gbps data plane).
     replicas: ${MICHAEL_REPLICAS}
     image:
       repository: ghcr.io/immich-app/yucca/michael
-      # Substituted from the image-versions ConfigMap: staging's is rewritten
-      # in-cluster to the latest CI build (flux-operator ResourceSet), prod's is
-      # release-please-stamped in git. If unset, the empty default lets the
-      # chart fall back to v<appVersion> — the matching release image.
+      # From the image-versions ConfigMap (staging: rewritten in-cluster by the flux-operator
+      # ResourceSet to latest CI build; prod: release-please-stamped in git). Empty default →
+      # chart falls back to v<appVersion>, the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
-    # secretData nulled: the chart's dev JWT_PUBLIC_KEY fixture is replaced by
-    # the TF-provisioned `yucca-michael` Secret (JWT_PUBLIC_KEY + S3 creds),
-    # which the chart's `envFrom: secretRef: yucca-michael` picks up unchanged.
+    # Real values come from the TF-provisioned `yucca-michael` Secret (envFrom).
     secretData: null
     env:
       - name: RESTIC_API_PORT
@@ -57,7 +52,6 @@ spec:
         value: us-east-1
       - name: S3_FORCE_PATH_STYLE
         value: "true"
-      # --- built-in RGW load balancing (replaces rgw-haproxy) ---
       - name: S3_BACKEND_SOURCE
         value: dns
       - name: S3_BACKEND_DNS_HOST
@@ -70,10 +64,8 @@ spec:
         value: "true"
       - name: S3_PROBE_BUCKET
         value: michael-rgw-healthcheck
-      # Ejection / health tuning (these are michael's defaults, surfaced here so
-      # they're tunable per-env): eject a gateway after this many consecutive
-      # transport failures, and re-resolve DNS + probe every interval (also how
-      # fast an ejected gateway is reinstated).
+      # Eject a gateway after N consecutive transport failures; re-resolve DNS + probe
+      # every interval (which is also the reinstatement speed).
       - name: S3_EJECT_THRESHOLD
         value: "3"
       - name: S3_RECONCILE_INTERVAL_MS

--- a/kubernetes/apps/base/netbird-operator/helmrelease.yaml
+++ b/kubernetes/apps/base/netbird-operator/helmrelease.yaml
@@ -19,34 +19,24 @@ spec:
   rollback:
     cleanupOnFail: true
   values:
-    # Webhook certs via cert-manager (deployed in this env; the Flux
-    # Kustomization dependsOn it). The operator's admission webhooks validate
-    # SetupKey/SidecarProfile/NetworkResource resources.
     webhook:
       enableCertManager: true
-    # NetBird-side naming for networks/resources the operator creates.
+    # NetBird-side naming for what the operator creates.
     cluster:
       name: yucca-staging
-    # Management API auth: the netbird-mgmt-api-key Secret (key NB_API_KEY) is
-    # bootstrapped by the staging/talos Terraform stack. These are the chart
-    # defaults, set explicitly so the contract is visible here.
+    # Secret bootstrapped by the staging/talos TF stack; chart defaults, set
+    # explicitly so the contract is visible.
     netbirdAPI:
       keyFromSecret:
         name: netbird-mgmt-api-key
         key: NB_API_KEY
-    # Gateway API exposure is off for now (envoy-gateway is present; can enable
-    # later to route Services onto the overlay via the operator).
     gatewayAPI:
       enabled: false
-  # The chart ships the pod-mutator webhook (mpod-v1.netbird.io) with
-  # failurePolicy: Fail and an EMPTY namespaceSelector, so it gates *every* pod
-  # CREATE cluster-wide. When the operator pod is unreachable that blocks all
-  # pod scheduling — once this cascaded into a cluster-wide outage (cilium agents
-  # couldn't be recreated, which broke pod routing, which broke flux/cnpg…).
-  # Keep failurePolicy: Fail (app pods still get guaranteed netbird injection)
-  # but exclude the control-plane/infra namespaces so core self-healing can never
-  # be gated by this webhook. The chart exposes no knob for this, so patch the
-  # rendered MutatingWebhookConfiguration via a postRenderer.
+  # The chart's pod-mutator webhook (mpod-v1.netbird.io) has failurePolicy: Fail with an
+  # EMPTY namespaceSelector — it gates every pod CREATE cluster-wide, and an unreachable
+  # operator once cascaded into a full outage (cilium agents unschedulable → pod routing
+  # → flux/cnpg). Keep Fail (guaranteed injection for app pods) but exclude control-plane/
+  # infra namespaces; chart has no knob, so patch the MutatingWebhookConfiguration via postRenderer.
   postRenderers:
     - kustomize:
         patches:
@@ -68,9 +58,8 @@ spec:
                         - openebs # father's openebs namespace name
                         - cert-manager
                         - netbird
-                        # Ingress data plane: envoy-gateway recreates proxy pods
-                        # dynamically (node drains included) — gating them here
-                        # is the exact outage shape documented above.
+                        # envoy-gateway recreates proxy pods dynamically (incl. node
+                        # drains) — gating them is the exact outage shape above.
                         - envoy-system
                         # Monitoring agents must be schedulable while the
                         # operator is down, or an incident blinds itself.

--- a/kubernetes/apps/base/openebs/helmrelease.yaml
+++ b/kubernetes/apps/base/openebs/helmrelease.yaml
@@ -23,17 +23,11 @@ spec:
     remediation:
       remediateLastFailure: true
       retries: 2
-  # OpenEBS LocalPV hostpath + (optionally) Mayastor replicated block storage.
-  # Shared by every cluster via postBuild substitutions (cluster-settings):
-  #   OPENEBS_MAYASTOR_ENABLED        default false (staging: PG replicates at the
-  #                                   app layer; father: true — VictoriaMetrics
-  #                                   rides repl=2 volumes on the DiskPools)
-  #   OPENEBS_LOCALPV_BASEPATH        default /var/mnt/hostpath (a UserVolume)
-  #   OPENEBS_HOSTPATH_CLASS_ENABLED  default false (staging uses per-disk SCs in
-  #                                   its overlay; father uses the chart class)
-  #   OPENEBS_MAYASTOR_ETCD_BASEPATH  mayastor's own etcd (localpv) — only read
-  #                                   when mayastor is enabled
-  # lvm/zfs/loki/alloy/minio stay off everywhere.
+  # Per-cluster via cluster-settings:
+  #   OPENEBS_MAYASTOR_ENABLED       default false (staging: PG replicates app-side;
+  #                                  father true — VictoriaMetrics on repl=2 DiskPools)
+  #   OPENEBS_LOCALPV_BASEPATH       default /var/mnt/hostpath (a UserVolume)
+  #   OPENEBS_HOSTPATH_CLASS_ENABLED default false (staging: per-disk SCs in overlay)
   values:
     preUpgradeHook:
       enabled: false
@@ -43,16 +37,10 @@ spec:
       localpv:
         image:
           registry: quay.io/
-        # Fallback basePath for the chart's default class. We disable that class
-        # below (the 240GB BOSS install disk holds no PVs), so this is unused —
-        # all PVs land on the NVMe StorageClasses (storageclass-spare-disk*.yaml),
-        # which set their own BasePath. Kept pointing at a UserVolume mount to
-        # avoid any drift onto EPHEMERAL.
+        # Kept on a UserVolume mount to avoid drift onto EPHEMERAL.
         basePath: ${OPENEBS_LOCALPV_BASEPATH:=/var/mnt/hostpath}
-      # No openebs-system-disk default class: unlike o11y's large system disks,
-      # these nodes install to a small 240GB DELLBOSS. Persistent storage lives
-      # on the two 1.6TB NVMes via openebs-spare-disk / -2 (one of which is the
-      # cluster-default class). Disabling this stops PVs landing on the BOSS.
+      # Disabled so PVs never land on the small 240GB DELLBOSS install disk;
+      # storage lives on the two 1.6TB NVMes via openebs-spare-disk / -2.
       hostpathClass:
         enabled: ${OPENEBS_HOSTPATH_CLASS_ENABLED:=false}
       helperPod:

--- a/kubernetes/apps/base/topology/configmap.yaml
+++ b/kubernetes/apps/base/topology/configmap.yaml
@@ -1,17 +1,6 @@
 ---
-# The fleet topology, GitOps-owned: which sites exist, the restic gateway that
-# fronts each one, and the Ceph clusters behind it. yucca-api, yucca-admin-api,
-# yucca-metrics-worker and michael all mount this at /etc/yucca, validate it at
-# boot, and are rolled on change by their charts' topology checksum annotation.
-#
-# Today every cluster is single-site: the site IS this region, and its one
-# storage cluster is the active one. A second Ceph cluster in a region means a
-# second `clusters` entry (active: false until it takes writes); a second REGION
-# means a second `sites` entry, which is a cross-cluster edit and doesn't belong
-# in a per-cluster substitution — expect this file to grow a real template then.
-#
-# NB: the ${VAR} tokens are Flux postBuild substitutions, not shell/JSON — the
-# literal JSON braces around them pass through untouched.
+# Consumers validate at boot and roll on change via the charts' topology checksum annotation.
+# ${VAR} tokens are Flux postBuild substitutions; the JSON braces pass through untouched.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
@@ -19,13 +19,10 @@ spec:
     remediation:
       retries: 2
   values:
-    # DaemonSet that tails every pod's stdout node-side and forwards to o11y's
-    # VictoriaLogs. Replaces the OTLP-push vlagent: captures all pods (not just
-    # apps) and parses their JSON logs into fields.
     fullnameOverride: victoria-logs-collector
 
-    # Ship to o11y's vmauth (native VictoriaLogs ingest -> vlinsert), authed with
-    # the shared bearer token (TF-provisioned `vmagent-remote-write` Secret).
+    # o11y's vmauth (native VictoriaLogs ingest -> vlinsert); bearer token from the
+    # TF-provisioned `vmagent-remote-write` Secret.
     remoteWrite:
       - url: ${VLOGS_REMOTE_URL}
         maxDiskUsagePerURL: 10GB
@@ -49,12 +46,10 @@ spec:
         - kubernetes.pod_namespace
         - kubernetes.container_name
         - kubernetes.pod_labels.app.kubernetes.io/name
-      # Stamp the remote-cluster identity on every log line (cluster/site/env,
-      # same tags as the metrics pipeline).
+      # Same tags as the metrics pipeline.
       extraFields: '{"cluster":"${METRICS_CLUSTER_LABEL}","site":"${METRICS_SITE_LABEL}","env":"${METRICS_ENV_LABEL}"}'
 
-    # All staging nodes are control-plane; tolerate the taint so the DaemonSet
-    # lands everywhere.
+    # All staging nodes are control-plane.
     tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists

--- a/kubernetes/apps/base/vmagent/helmrelease.yaml
+++ b/kubernetes/apps/base/vmagent/helmrelease.yaml
@@ -17,14 +17,11 @@ spec:
     remediation:
       retries: 2
   values:
-    # `vmagent-<name>` Service => vmagent-yucca (matches VMAGENT_OTLP). The
-    # k8s-stack chart bundles the VM operator, so this one release gives us the
-    # CRDs + operator + a VMAgent. yucca_staging is a METRICS REMOTE CLUSTER:
-    # only the agent runs here; storage/query/alerting live at o11y.
+    # `vmagent-<name>` Service => vmagent-yucca (must match VMAGENT_OTLP). Only the
+    # agent runs here; storage/query/alerting live at o11y.
     fullnameOverride: yucca
     global:
       clusterLabel: cluster
-    # Server-side components are disabled — they run in the o11y cluster.
     vmcluster:
       enabled: false
     vmsingle:
@@ -48,10 +45,8 @@ spec:
     vmagent:
       enabled: true
       spec:
-        # Stamp the remote-cluster identity on EVERY series: cluster (short
-        # cluster name), site, env. Relabel (not externalLabels): externalLabels
-        # only tags scraped data, leaving OTLP-pushed app metrics untagged. This
-        # applies to all data (scraped + ingested) before remote-write.
+        # Relabel, not externalLabels: externalLabels only tags scraped data, leaving
+        # OTLP-pushed app metrics untagged; relabel covers both before remote-write.
         inlineRelabelConfig:
           - target_label: cluster
             replacement: ${METRICS_CLUSTER_LABEL}
@@ -59,9 +54,8 @@ spec:
             replacement: ${METRICS_SITE_LABEL}
           - target_label: env
             replacement: ${METRICS_ENV_LABEL}
-        # Ship to o11y's vmauth (the `remote-clusters` VMUser proxies
-        # /insert/0/.* -> vminsert), authenticating with the shared bearer token
-        # (TF-provisioned `vmagent-remote-write` Secret from o11y_tf_staging).
+        # o11y's vmauth (the `remote-clusters` VMUser proxies /insert/0/.* -> vminsert);
+        # bearer token TF-provisioned from o11y_tf_staging.
         remoteWrite:
           - url: https://vmauth.staging.futostatus.com/insert/0/prometheus/api/v1/write
             bearerTokenSecret:

--- a/kubernetes/apps/base/web/helmrelease.yaml
+++ b/kubernetes/apps/base/web/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/apps/web
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -26,10 +25,9 @@ spec:
   values:
     image:
       repository: ghcr.io/immich-app/yucca/web
-      # Substituted from the image-versions ConfigMap: staging's is rewritten
-      # in-cluster to the latest CI build (flux-operator ResourceSet), prod's is
-      # release-please-stamped in git. If unset, the empty default lets the
-      # chart fall back to v<appVersion> — the matching release image.
+      # From the image-versions ConfigMap (staging: rewritten in-cluster by the flux-operator
+      # ResourceSet to latest CI build; prod: release-please-stamped in git). Empty default →
+      # chart falls back to v<appVersion>, the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
     env:
       - name: NODE_ENV
@@ -37,10 +35,8 @@ spec:
       # Prod server (adapter-node) defaults to :3000; pin to the chart's port.
       - name: PORT
         value: "5173"
-      # Browser-facing API base (served at the staging ingress domain).
       # TODO(ingress): finalize once envoy-gateway + DNS land.
       - name: PUBLIC_API_URL
         value: https://${APP_DOMAIN}
-      # Server-side (SSR) calls stay in-cluster.
       - name: YUCCA_API_URL
         value: http://yucca-api:3020/

--- a/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/apps/yucca-admin-api
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -26,18 +25,14 @@ spec:
   values:
     image:
       repository: ghcr.io/immich-app/yucca/yucca-admin-api
-      # Substituted from the image-versions ConfigMap: staging's is rewritten
-      # in-cluster to the latest CI build (flux-operator ResourceSet), prod's is
-      # release-please-stamped in git. If unset, the empty default lets the
-      # chart fall back to v<appVersion> — the matching release image.
+      # From the image-versions ConfigMap (staging: rewritten in-cluster by the flux-operator
+      # ResourceSet to latest CI build; prod: release-please-stamped in git). Empty default →
+      # chart falls back to v<appVersion>, the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
-    # secretData nulled: replaced by the TF-provisioned `yucca-admin-api` Secret
-    # (OIDC_ADMIN_CLIENT_ID/SECRET) via the chart's envFrom: secretRef.
+    # Real values come from the TF-provisioned `yucca-admin-api` Secret (envFrom).
     secretData: null
-    # Not publicly routed — reached over the NetBird overlay at
-    # ${YUCCA_ADMIN_HOST} (per-cluster, from cluster-settings). Admin auth uses
-    # the internal FUTO Zitadel (FUTO_ZITADEL_OAUTH_*_YUCCA_INTERNAL_TOOLING in
-    # shared_tf), not the customer ${OIDC_ISSUER}.
+    # NetBird overlay only. Admin auth uses the internal FUTO Zitadel
+    # (FUTO_ZITADEL_OAUTH_*_YUCCA_INTERNAL_TOOLING in shared_tf), not the customer ${OIDC_ISSUER}.
     oidcIssuer: https://auth.internal.futo.org
     oidcRedirectUri: https://${YUCCA_ADMIN_HOST}/api/auth/oidc/callback
     oidcLogoutRedirectUri: https://${YUCCA_ADMIN_HOST}
@@ -48,9 +43,6 @@ spec:
         value: "3030"
       - name: LOG_LEVEL
         value: info
-      # Fleet topology (the yucca-topology ConfigMap the chart mounts at
-      # /etc/yucca) — the per-site rest_url in it replaces the old single
-      # RESTIC_ENDPOINT.
       - name: TOPOLOGY_FILE
         value: /etc/yucca/topology.json
       # Pinned origin of rows created before placement columns existed.

--- a/kubernetes/apps/base/yucca-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-api/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/apps/yucca-api
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -24,31 +23,25 @@ spec:
     remediation:
       retries: 3
   values:
-    # Per-cluster replica count (staging 2, father 3).
     replicas: ${API_REPLICAS}
     image:
       repository: ghcr.io/immich-app/yucca/yucca-api
-      # Substituted from the image-versions ConfigMap: staging's is rewritten
-      # in-cluster to the latest CI build (flux-operator ResourceSet), prod's is
-      # release-please-stamped in git. If unset, the empty default lets the
-      # chart fall back to v<appVersion> — the matching release image.
+      # From the image-versions ConfigMap (staging: rewritten in-cluster by the flux-operator
+      # ResourceSet to latest CI build; prod: release-please-stamped in git). Empty default →
+      # chart falls back to v<appVersion>, the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
     # Migration Job assumes the dev image layout; dist-only prod image migrates
     # at boot. Re-enable once the Job has a prod-compatible command.
     migration:
       enabled: false
-    # secretData nulled: the chart's dev fixture (JWT + OIDC placeholders) is
-    # replaced by the TF-provisioned `yucca-api` Secret (JWT_PRIVATE_KEY +
-    # OIDC_CLIENT_ID/SECRET), picked up via the chart's envFrom: secretRef.
+    # Real values come from the TF-provisioned `yucca-api` Secret (envFrom).
     secretData: null
-    # Real IdP (no mock-oidc). Chart maps these onto explicit env (which beats
-    # envFrom). Redirects target the staging ingress domain.
+    # Chart maps these onto explicit env (which beats envFrom).
     # TODO(ingress): confirm callback host once envoy-gateway + DNS land.
     oidcIssuer: ${OIDC_ISSUER}
     oidcRedirectUri: https://${APP_DOMAIN}/api/auth/oidc/callback
     oidcLogoutRedirectUri: https://${APP_DOMAIN}
-    # Full replacement of the chart's dev env: production mode, no
-    # *_ALLOW_INSECURE (real HTTPS issuer), OTLP to the in-cluster agents.
+    # Full replacement of the chart's dev env; no *_ALLOW_INSECURE (real HTTPS issuer).
     env:
       - name: NODE_ENV
         value: production
@@ -60,9 +53,6 @@ spec:
       # numeric id via postBuild substitution gets coerced to a float and breaks.
       - name: OIDC_DEVICE_ISSUER
         value: ${OIDC_ISSUER}
-      # Fleet topology (the yucca-topology ConfigMap the chart mounts at
-      # /etc/yucca) — the per-site rest_url in it replaces the old single
-      # RESTIC_ENDPOINT.
       - name: TOPOLOGY_FILE
         value: /etc/yucca/topology.json
       # Pinned origin of rows created before placement columns existed. These
@@ -71,12 +61,10 @@ spec:
         value: ${LEGACY_SITE_CODE}
       - name: LEGACY_STORAGE_CLUSTER_CODE
         value: ${LEGACY_STORAGE_CLUSTER_CODE}
-      # Absolute base of this API, as advertised to clients through /meta and
-      # the .well-known pointer — must match what the meta pod hands out.
+      # Must match what the meta pod hands out via the .well-known pointer.
       - name: API_ROOT
         value: https://${APP_DOMAIN}/api
-      # Beta email allowlist: comma-separated domains that may sign up without
-      # an allowlist entry. Empty default = allowlist/invite-code only.
+      # Empty default = allowlist/invite-code only.
       - name: ALLOWED_EMAIL_DOMAINS
         value: ${ALLOWED_EMAIL_DOMAINS:=}
       - name: OTEL_METRICS

--- a/kubernetes/apps/base/yucca-database/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-database/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/platform/cnpg-cluster
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -23,22 +22,15 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-  # HA across the 3 control-planes: CNPG runs a primary + 2 streaming replicas
-  # and spreads them one-per-node via its default pod anti-affinity. This base
-  # is consumed only by the real clusters (staging/production) — local dev uses
-  # the separate dev-mirror tree, which keeps the chart's 1-instance default.
+  # One-per-node spread comes from CNPG's default anti-affinity.
   # TODO: point backups at object storage; consider synchronous replication.
   values:
     instances: 3
     storage: 10Gi
-    # Generous requests, huge memory limit (no CPU limit — CFS throttling hurts
-    # postgres tail latency more than contention does).
+    # No CPU limit — CFS throttling hurts postgres tail latency more than contention.
     resources:
       requests: { cpu: 500m, memory: 1Gi }
       limits: { memory: 8Gi }
-    # Node-local NVMe (no replicated block storage). CNPG provides HA at the app
-    # layer: primary + 2 streaming replicas, spread one-per-node by its default
-    # anti-affinity, each binding a local PV on its node (WaitForFirstConsumer).
-    # Per-cluster class: staging = openebs-spare-disk (overlay SC), prod =
-    # openebs-hostpath (chart localpv class) — set in each cluster-settings.
+    # Node-local NVMe — CNPG is the HA layer. staging = openebs-spare-disk (overlay SC),
+    # prod = openebs-hostpath (chart localpv class).
     storageClass: ${DB_STORAGE_CLASS}

--- a/kubernetes/apps/base/yucca-metrics-worker/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-metrics-worker/helmrelease.yaml
@@ -9,8 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/apps/yucca-metrics-worker
-      # Repackage on every git revision — the in-repo charts keep a static
-      # version, so the default ChartVersion strategy never ships template edits.
+      # In-repo charts keep a static version; Revision repackages every git rev (ChartVersion would never ship template edits).
       reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
@@ -26,32 +25,18 @@ spec:
   values:
     image:
       repository: ghcr.io/immich-app/yucca/yucca-metrics-worker
-      # Substituted from the image-versions ConfigMap: staging's is rewritten
-      # in-cluster to the latest CI build (flux-operator ResourceSet), prod's is
-      # release-please-stamped in git. If unset, the empty default lets the
-      # chart fall back to v<appVersion> — the matching release image.
+      # From the image-versions ConfigMap (staging: rewritten in-cluster by the flux-operator
+      # ResourceSet to latest CI build; prod: release-please-stamped in git). Empty default →
+      # chart falls back to v<appVersion>, the matching release image.
       tag: ${YUCCA_IMAGE_TAG:=}
-    # Shares yucca-api's CNPG database; the chart reads creds from the
-    # <cluster>-app Secret (yucca-db-app), which CNPG manages.
     postgresClusterName: yucca-db
-    # Per-bucket usage comes from the bare-metal RGW admin API of every storage
-    # cluster in the topology file (ConfigMap yucca-topology, rgw_admin_endpoint
-    # per cluster). It serves HTTPS behind a self-signed cert, so the worker
-    # skips TLS verification (NODE_TLS_REJECT_UNAUTHORIZED below), mirroring
-    # michael's S3_TLS_SKIP_VERIFY. The fallback admin credentials
-    # (AccessKey/SecretKey) are TF-provisioned into the yucca-metrics-rgw Secret
-    # (tf .../secrets.tf), like yucca-michael — not managed in this repo;
-    # additional clusters get RADOS_*_<CODE> env pairs.
+    # Fallback admin creds TF-provisioned (tf .../secrets.tf); extra clusters get
+    # RADOS_*_<CODE> pairs in the same Secret.
     radosSecretName: yucca-metrics-rgw
-    # Drop the chart's dev-fixture POLAR_* placeholder Secret (same pattern as
-    # the yucca-api/michael/admin-api HelmReleases) — real billing creds arrive
-    # via ExternalSecret when Polar integration lands; until then rendering the
-    # placeholders into a prod Secret invites silently-broken billing.
+    # Real billing creds arrive via ExternalSecret when Polar lands — POLAR_* placeholders
+    # in a prod Secret invite silently-broken billing.
     secretData: null
-    # Full replacement of the chart's dev env: production mode, OTLP metrics to
-    # the in-cluster vmagent. Logs are collected node-side by
-    # victoria-logs-collector (pod stdout), so no OTEL_LOGGING push here.
-    # RADOS_* and POSTGRES_* are appended by the chart from the Secrets above.
+    # No OTEL_LOGGING push: logs are collected node-side by victoria-logs-collector.
     env:
       - name: NODE_ENV
         value: production

--- a/kubernetes/apps/dev/local/repos/git-yucca.yaml
+++ b/kubernetes/apps/dev/local/repos/git-yucca.yaml
@@ -13,7 +13,6 @@ spec:
   # fine-grained PAT) BEFORE applying this tree — see kubernetes/bootstrap/.
   secretRef:
     name: yucca-repo-auth
-  # Flux pulls only the GitOps manifests and the Helm charts they reference.
   ignore: |
     /*
     !/kubernetes

--- a/kubernetes/apps/dev/local/rook-ceph/rook-ceph-cluster/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/rook-ceph/rook-ceph-cluster/app/helmrelease.yaml
@@ -19,6 +19,5 @@ spec:
   upgrade:
     remediation:
       retries: 3
-  # Dev defaults (single-node, single-replica, loopback OSD) live in the chart's
-  # values.yaml. This is DEV ONLY — prod object storage is a separate Ceph.
+  # DEV ONLY — prod object storage is a separate, bare-metal Ceph.
   values: {}

--- a/kubernetes/apps/dev/local/rook-ceph/rook-ceph-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/rook-ceph/rook-ceph-operator/app/helmrelease.yaml
@@ -21,13 +21,12 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV footprint: object store only needs the bucket provisioner, not CSI.
+    # Object store only needs the bucket provisioner, not CSI.
     csi:
       enableRbdDriver: false
       enableCephfsDriver: false
     enableDiscoveryDaemon: true
     monitoring:
       enabled: false
-    # The dev cluster's OSD runs on a loopback block device (k3d has no spare
-    # disk); Rook filters loop devices out of discovery unless this is set.
+    # Rook filters loop devices out of discovery unless this is set; the dev OSD is one.
     allowLoopDevices: true

--- a/kubernetes/apps/dev/local/yucca/database/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/database/app/helmrelease.yaml
@@ -19,6 +19,5 @@ spec:
   upgrade:
     remediation:
       retries: 3
-  # Dev-mirror posture: chart defaults (1 instance, 1Gi) keep this tree 1:1
-  # with the Tilt deployment. TODO(prod): a prod overlay raises instances/storage.
+  # TODO(prod): a prod overlay raises instances/storage.
   values: {}

--- a/kubernetes/apps/dev/local/yucca/meta/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/meta/app/helmrelease.yaml
@@ -20,6 +20,4 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-  # No values: stock upstream nginx (nothing Tilt builds, so none of the
-  # dev rootfs/securityContext relaxations the other releases need), and the
-  # chart's default wellKnown.meta_url already points at the dev port-forward.
+  # Nothing Tilt builds here, so none of the dev rootfs relaxations the other releases need.

--- a/kubernetes/apps/dev/local/yucca/metrics-object-user/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/metrics-object-user/app/helmrelease.yaml
@@ -20,9 +20,7 @@ spec:
     remediation:
       retries: 3
   values:
-    # Dedicated RGW user for the metrics worker. michael is a plain S3 user with
-    # no admin caps, so it can't read per-bucket stats via the RGW admin API.
-    # Rook writes this user's keys to rook-ceph-object-user-yucca-metrics.
+    # michael's plain S3 user has no admin caps, so it can't read per-bucket stats.
     userName: metrics
     capabilities:
       bucket: read

--- a/kubernetes/apps/dev/local/yucca/metrics-worker/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/metrics-worker/app/helmrelease.yaml
@@ -21,9 +21,7 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV-ONLY relaxation: Tilt live_update syncs source into /app inside the
-    # running container, and michael's `air` rebuilds in-place — both need a
-    # writable rootfs (the chart default is readOnlyRootFilesystem: true).
+    # Tilt live_update / air rebuilds need a writable rootfs (chart default is read-only).
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false

--- a/kubernetes/apps/dev/local/yucca/metrics-worker/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/metrics-worker/ks.yaml
@@ -21,5 +21,4 @@ spec:
   dependsOn:
     - name: yucca-database
     - name: yucca-object-user
-    # ConfigMap mounted at /etc/yucca and parsed at boot.
     - name: yucca-topology

--- a/kubernetes/apps/dev/local/yucca/michael/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/michael/app/helmrelease.yaml
@@ -21,17 +21,13 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV-ONLY relaxation: Tilt live_update syncs source into /app inside the
-    # running container, and michael's `air` rebuilds in-place — both need a
-    # writable rootfs (the chart default is readOnlyRootFilesystem: true).
+    # Tilt live_update / air rebuilds need a writable rootfs (chart default is read-only).
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
       capabilities:
         drop: [ALL]
-    # Dev (Tilt) uses the chart defaults; prod overrides the image + secrets.
-    # useDevKeypair renders the well-known dev JWT public key (chart default is
-    # false so real overlays fail loudly instead).
+    # Chart default is false so real overlays fail loudly instead.
     useDevKeypair: true
     image:
       repository: ghcr.io/immich-app/yucca/michael # TODO: confirm prod registry

--- a/kubernetes/apps/dev/local/yucca/mock-oidc/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/mock-oidc/app/helmrelease.yaml
@@ -20,16 +20,13 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV-ONLY relaxation: Tilt live_update syncs source into /app inside the
-    # running container, and michael's `air` rebuilds in-place — both need a
-    # writable rootfs (the chart default is readOnlyRootFilesystem: true).
+    # Tilt live_update / air rebuilds need a writable rootfs (chart default is read-only).
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
       capabilities:
         drop: [ALL]
-    # DEV ONLY. Prod uses a real IdP (e.g. Zitadel) — drop this release and
-    # point yucca-api/admin-api OIDC_* at the real issuer via ExternalSecrets.
+    # DEV ONLY — prod uses a real IdP; drop this release there.
     fullnameOverride: yucca-mock-oidc
     image:
       repository: ghcr.io/immich-app/yucca/mock-oidc-provider # TODO: confirm prod registry

--- a/kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml
+++ b/kubernetes/apps/dev/local/yucca/topology/app/configmap.yaml
@@ -1,16 +1,7 @@
 ---
-# Dev copy of the fleet topology that Flux renders per cluster in the real
-# clusters (kubernetes/apps/base/topology). Written out LITERALLY because the
-# dev/local entry point runs no postBuild substitution — there is no
-# cluster-settings ConfigMap here, so ${VAR} tokens would reach the services
-# verbatim and fail the schema at boot.
-#
-# Not the same as the in-image packages/*/topology.dev.json fixture, which
-# targets `mise dev` (compose, everything on localhost): in k3d the services
-# talk to each other over cluster DNS.
-#
-# Tilt applies this file directly too (see the Tiltfile) — k3d-with-Flux and
-# k3d-with-Tilt must agree, so keep it the single dev source of truth.
+# LITERAL, not templated: the dev/local entry point runs no postBuild substitution —
+# ${VAR} tokens would reach the services verbatim and fail the boot schema. Tilt applies
+# this file directly too; keep it the single dev source of truth.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/dev/local/yucca/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/victoria-logs/app/helmrelease.yaml
@@ -18,7 +18,6 @@ spec:
   values:
     server:
       fullnameOverride: victoria-logs
-      # Dev-mirror posture (Tilt installs these exact values).
       # TODO(prod): enable + size persistence for the target cluster.
       persistentVolume:
         enabled: false

--- a/kubernetes/apps/dev/local/yucca/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/victoria-metrics/app/helmrelease.yaml
@@ -18,7 +18,6 @@ spec:
   values:
     server:
       fullnameOverride: victoria-metrics
-      # Dev-mirror posture (Tilt installs these exact values).
       # TODO(prod): enable + size persistence for the target cluster.
       persistentVolume:
         enabled: false

--- a/kubernetes/apps/dev/local/yucca/web/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/web/app/helmrelease.yaml
@@ -21,9 +21,7 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV-ONLY relaxation: Tilt live_update syncs source into /app inside the
-    # running container, and michael's `air` rebuilds in-place — both need a
-    # writable rootfs (the chart default is readOnlyRootFilesystem: true).
+    # Tilt live_update / air rebuilds need a writable rootfs (chart default is read-only).
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
@@ -32,5 +30,4 @@ spec:
     image:
       repository: ghcr.io/immich-app/yucca/web # TODO: confirm prod registry
       tag: 0.0.1
-    # YUCCA_API_URL/PUBLIC_API_URL default to the in-cluster yucca-api service,
-    # which is correct in prod too. TODO(prod): add ingress for external access.
+    # TODO(prod): add ingress for external access.

--- a/kubernetes/apps/dev/local/yucca/yucca-admin-api/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/yucca-admin-api/app/helmrelease.yaml
@@ -21,16 +21,13 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV-ONLY relaxation: Tilt live_update syncs source into /app inside the
-    # running container, and michael's `air` rebuilds in-place — both need a
-    # writable rootfs (the chart default is readOnlyRootFilesystem: true).
+    # Tilt live_update / air rebuilds need a writable rootfs (chart default is read-only).
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
       capabilities:
         drop: [ALL]
-    # Dev-only: render the well-known local-dev JWT signing key into the chart
-    # Secret (the chart default is false so real overlays fail loudly instead).
+    # Chart default is false so real overlays fail loudly instead.
     useDevKeypair: true
     image:
       repository: ghcr.io/immich-app/yucca/yucca-admin-api # TODO: confirm prod registry

--- a/kubernetes/apps/dev/local/yucca/yucca-admin-api/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/yucca-admin-api/ks.yaml
@@ -21,5 +21,4 @@ spec:
   dependsOn:
     - name: yucca-database
     - name: yucca-mock-oidc
-    # ConfigMap mounted at /etc/yucca and parsed at boot.
     - name: yucca-topology

--- a/kubernetes/apps/dev/local/yucca/yucca-api/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/yucca-api/app/helmrelease.yaml
@@ -21,24 +21,19 @@ spec:
     remediation:
       retries: 3
   values:
-    # DEV-ONLY relaxation: Tilt live_update syncs source into /app inside the
-    # running container, and michael's `air` rebuilds in-place — both need a
-    # writable rootfs (the chart default is readOnlyRootFilesystem: true).
+    # Tilt live_update / air rebuilds need a writable rootfs (chart default is read-only).
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
       capabilities:
         drop: [ALL]
-    # Dev-only: render the well-known local-dev JWT signing key into the chart
-    # Secret (the chart default is false so real overlays fail loudly instead).
+    # Chart default is false so real overlays fail loudly instead.
     useDevKeypair: true
     image:
       repository: ghcr.io/immich-app/yucca/yucca-api # TODO: confirm prod registry
       tag: 0.0.1
-    # Disabled: the migration Job currently assumes the DEV image layout (it
-    # runs `pnpm install` + sql-tools from the source tree), which a dist-only
-    # prod image doesn't have. Re-enable once the Job has a prod-compatible
-    # command. Dev migrates at boot either way.
+    # Job assumes the DEV image layout (`pnpm install` + sql-tools from source); dist-only
+    # prod images lack it. Dev migrates at boot either way.
     migration:
       enabled: false
     # TODO(prod): real OIDC issuer/redirect URLs, ingress, probes, replicas,

--- a/kubernetes/apps/dev/local/yucca/yucca-api/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/yucca-api/ks.yaml
@@ -22,5 +22,4 @@ spec:
     - name: yucca-database
     - name: yucca-mock-oidc
     - name: yucca-michael
-    # ConfigMap mounted at /etc/yucca and parsed at boot.
     - name: yucca-topology

--- a/kubernetes/apps/prod/htz-fsn1/cilium-bgp.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/cilium-bgp.yaml
@@ -1,28 +1,18 @@
-# Cilium BGP (north-south LoadBalancer VIPs). The worker speakers iBGP-peer the spine's
-# kube-VLAN IRB (10.40.10.1, AS 402421) and advertise LoadBalancer /32s from the two
-# public pools; the spine ECMPs each VIP per-flow across ALL advertising workers
-# (multipath + forwarding-table load-balance, fabric side: tf/.../core-fabric/
-# bgp-nodes.tf) and it's covered by the transit 69.48.224.0/24 advertisement.
-# With Cilium DSR (loadBalancer.mode hybrid, talos cilium values) the gw LB
-# Service runs externalTrafficPolicy: Cluster: every worker advertises the VIP,
-# the spine ECMPs the /32 across all of them, the landing node dispatches to a
-# backend, and the backend's node replies straight to the client from the VIP —
-# no SNAT hop, client IP preserved, ECMP width independent of pod placement.
-# NOTE: applied to the father cluster directly for now; to be adopted into the Flux tree
-# once GitOps is bootstrapped on prod.
+# Workers iBGP-peer the spine kube-VLAN IRB (10.40.10.1, AS 402421) and advertise LB /32s
+# covered by the transit 69.48.224.0/24; fabric side is tf/.../core-fabric/bgp-nodes.tf.
+# DSR (loadBalancer.mode hybrid) + externalTrafficPolicy: Cluster on gw keeps client IPs and
+# makes ECMP width independent of pod placement.
+# NOTE: applied to father directly for now; adopt into the Flux tree once GitOps lands on prod.
 ---
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: lb-public-a
 spec:
-  # Skip the network/broadcast addresses — .0 is dropped by upstream routers.
+  # .0 is dropped by upstream routers.
   allowFirstLastIPs: "No"
-  # Pool-a is the DEFAULT public pool: every LB service EXCEPT ones labeled
-  # lb=internal (NetBird-only VIP from lb-internal, must never draw a public IP)
-  # or lb=public-b (explicit opt-in to pool-b below). Disjoint selectors keep
-  # pool assignment deterministic — with identical selectors Cilium picks
-  # arbitrarily between matching pools.
+  # lb=internal must never draw a public IP. Selectors must stay disjoint — identical
+  # selectors make Cilium pick between pools arbitrarily.
   serviceSelector:
     matchExpressions:
       - { key: lb, operator: NotIn, values: ["internal", "public-b"] }
@@ -35,17 +25,14 @@ metadata:
   name: lb-public-b
 spec:
   allowFirstLastIPs: "No"
-  # Opt-in only: label a Service lb=public-b to draw from this range.
   serviceSelector:
     matchLabels:
       lb: public-b
   blocks:
     - cidr: 69.48.224.64/26
 ---
-# Internal (NetBird-only) VIPs — 10.40.12.0/24 (fabric-addressing lb_internal).
-# Advertised to the spine over the same iBGP (CILIUM-NODES-IN accepts the range)
-# but NOT covered by the transit advertisement, so unreachable from the internet;
-# NetBird peers reach it via the mgmt route (netbird stack lb_internal resource).
+# 10.40.12.0/24 = fabric-addressing lb_internal. Advertised over the same iBGP but NOT in
+# the transit advert, so internet-unreachable; NetBird peers reach it via the mgmt route.
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -55,17 +42,16 @@ spec:
   serviceSelector:
     matchLabels:
       lb: internal
-  # Ranges, not the full /24: .17 is carved out for lb-gw-internal below
-  # (overlapping pools would mark each other conflicting and disable).
+  # .17 is carved out for lb-gw-internal below — overlapping pools mark each other
+  # conflicting and disable.
   blocks:
     - start: 10.40.12.1
       stop: 10.40.12.16
     - start: 10.40.12.18
       stop: 10.40.12.254
 ---
-# Dedicated internal VIP for the gw (michael) envoy Service: it already draws
-# its public IP from pool-a (lb: public), so a second, label-disjoint pool
-# grants the internal twin (${GW_INT_VIP}) requested via lbipam.cilium.io/ips.
+# The gw envoy Service already draws its public IP from pool-a, so the internal twin
+# (${GW_INT_VIP}) needs a second, label-disjoint pool.
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -90,7 +76,7 @@ spec:
       service:
         addresses:
           - LoadBalancerIP
-      # Match every service (opt a service out with the label bgp=disabled).
+      # Opt a service out with the label bgp=disabled.
       selector:
         matchExpressions:
           - { key: bgp, operator: NotIn, values: ["disabled"] }
@@ -112,7 +98,7 @@ kind: CiliumBGPClusterConfig
 metadata:
   name: father
 spec:
-  # Workers only — the CPs live on the kube-cp VLAN; the spine's iBGP group peers
+  # Workers only: the CPs live on the kube-cp VLAN, and the spine's iBGP group peers
   # from the kube VLAN (10.40.10.0/24) only.
   nodeSelector:
     matchExpressions:

--- a/kubernetes/apps/prod/htz-fsn1/coredns.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/coredns.yaml
@@ -1,13 +1,7 @@
-# coredns for the father cluster — OWNED HERE, not by Talos.
-#
-# Talos's bootstrap-manifest reconciliation kept reverting the worker-affinity pin
-# (any CP machineconfig change re-applied the stock deployment and coredns drifted
-# back onto the CPs, where worker pods can't reliably reach it — the CP<->worker
-# pod-to-pod path rides the flaky mgmt NetBird route). cluster.coreDNS.disabled=true
-# (talos stack) stops Talos from managing these objects; this manifest is the source
-# of truth. Snapshotted from the Talos-rendered objects + the nodeAffinity pin.
-# To be adopted by Flux when GitOps lands on father. Upgrades of the coredns image
-# are ours to do now.
+# OWNED HERE, not by Talos: bootstrap-manifest reconciliation kept reverting the
+# worker-affinity pin (coredns drifted onto the CPs, which worker pods reach only over the
+# flaky mgmt NetBird route). cluster.coreDNS.disabled=true in the talos stack stops Talos
+# managing these objects — coredns image upgrades are ours now.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/diskpools.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/diskpools.yaml
@@ -1,11 +1,7 @@
-# Mayastor DiskPools — one per worker on the r-mayastor RAW partition (the 50/50
-# split of the data NVMe; the other half is the u-localpv xfs volume for CNPG's
-# node-local PG storage — see talos.tf worker_volumes_patch). by-partlabel is
-# node-local and immune to nvme0/nvme1 renumbering (observed swapping across
-# boots). These back the `openebs-replicated` StorageClass (repl=2).
-# OpenEBS itself is installed by Helm (see kustomization.yaml in this dir for the
-# Flux HelmRelease); prereqs (hugepages, nvme_tcp, engine label) are Talos machine
-# config (talos.tf worker_mayastor_patch).
+# r-mayastor RAW partition = half the data NVMe; other half is u-localpv xfs for CNPG
+# (talos.tf worker_volumes_patch). by-partlabel is immune to nvme0/nvme1 renumbering,
+# observed swapping across boots. Prereqs (hugepages, nvme_tcp, engine label) are Talos
+# machine config (talos.tf worker_mayastor_patch).
 apiVersion: openebs.io/v1beta3
 kind: DiskPool
 metadata:
@@ -33,10 +29,8 @@ spec:
   node: yucca-htz-fsn-father-k8s-dianna
   disks: ["aio:///dev/disk/by-partlabel/r-mayastor"]
 ---
-# Replicated volumes (2 copies on distinct workers, NVMe-oF/TCP attach). For
-# VictoriaMetrics and anything that should survive a node loss. PG (CNPG) will use
-# LOCAL volumes instead (openebs-hostpath) — replication happens at the Postgres
-# layer there, not the block layer.
+# For workloads that must survive node loss. CNPG deliberately uses LOCAL openebs-hostpath
+# instead — replication at the Postgres layer, not block.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/flux-system/notifications.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/flux-system/notifications.yaml
@@ -1,16 +1,7 @@
 ---
-# notification-controller posts each Kustomization/HelmRelease reconcile result
-# as a GitHub commit status (✅/❌ on the deployed commit), so deploy outcome is
-# visible in GitHub without CI reaching into the cluster.
-#
-# The `github-app` Secret currently carries the shared `push-o-matic` GitHub App
-# creds (TF-provisioned from op://shared_tf/GITHUB_APP_IMMICH_PUSH_O_MATIC) — the
-# dedicated least-privilege `yucca-flux` app doesn't exist yet. Swap the 1P refs
-# in the prod stack's env file once it does; nothing here changes.
-#
-# NB: authored ahead of the cluster — the prod Talos/flux stack isn't built yet
-# (tf/deployment/prod/htz-fsn1 is fabric-only), so this activates once that
-# stack provisions the `github-app` Secret and flux syncs clusters/production.
+# `github-app` Secret carries the shared push-o-matic App creds
+# (op://shared_tf/GITHUB_APP_IMMICH_PUSH_O_MATIC) until a least-privilege `yucca-flux`
+# app exists — then swap the 1P refs in the prod stack's env file; nothing here changes.
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
@@ -19,11 +10,8 @@ metadata:
 spec:
   type: github
   address: https://github.com/immich-app/yucca
-  # Prefix the commit-status context with the environment so prod-htz-fsn1 and
-  # staging (which both reconcile this monorepo and post to the same commits)
-  # show as DISTINCT statuses instead of overwriting one another — e.g.
-  # "prod-htz-fsn1/kustomization/yucca-api". Without this, the default context
-  # (kind/name/<provider-uid>) is opaque and clusters can collide.
+  # Env-prefixed: prod and staging post to the same commits, and the default context
+  # (kind/name/<provider-uid>) is opaque and collides.
   commitStatusExpr: "('prod-htz-fsn1/' + event.involvedObject.kind + '/' + event.involvedObject.name).lowerAscii()"
   secretRef:
     name: github-app

--- a/kubernetes/apps/prod/htz-fsn1/gw-internal.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-internal.yaml
@@ -1,11 +1,7 @@
 ---
-# Internal (on-net) access to michael via ${GW_INT_HOST} → ${GW_INT_VIP}.
-# The public gw VIP rides the transit aggregate and is NOT routable from inside
-# Hetzner (mgmt hosts); this twin listener/VIP serves the same michael backend
-# over the fabric. DNS lives in the NetBird zone (netbird stack dns.tf `gw`).
-#
-# Cert: same DNS-01 pipeline as netops-wildcard; the Secret must live beside
-# the Gateway (envoy-system).
+# The public gw VIP rides the transit aggregate and is NOT routable from inside Hetzner;
+# this twin serves the same backend over the fabric. DNS lives in the NetBird zone
+# (netbird stack dns.tf `gw`). The cert Secret must sit beside the Gateway (envoy-system).
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -19,8 +15,7 @@ spec:
   dnsNames:
     - "${GW_INT_HOST}"
 ---
-# Route the internal hostname to michael — mirror of apps/base/httproutes/gw.yaml
-# (which stays ${GW_HOST}-only; this listener is prod-specific).
+# Mirror of apps/base/httproutes/gw.yaml, which stays ${GW_HOST}-only.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -38,9 +33,8 @@ spec:
         - name: yucca-michael
           port: 3010
 ---
-# Upstream buffer tuning for envoy→michael (the restore direction rides these);
-# lives here rather than gw-proxy/ because that tree is targetNamespace-forced
-# to envoy-system and this policy must sit beside its HTTPRoute in yucca.
+# Lives here rather than gw-proxy/ because that tree is targetNamespace-forced to
+# envoy-system and this policy must sit beside its HTTPRoute in yucca.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/certificate.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/certificate.yaml
@@ -1,9 +1,7 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cert-manager.io/certificate_v1.json
-# Cert for the public restic hostname (${GW_HOST}). rest.htz-fsn1. is two
-# labels below APP_DOMAIN, so the shared *.APP_DOMAIN wildcard doesn't cover
-# it; same DNS-01 pipeline as gw-internal. Lands in envoy-system
-# (targetNamespace-forced) beside the Gateway.
+# rest.htz-fsn1. is two labels below APP_DOMAIN, so the shared *.APP_DOMAIN wildcard
+# doesn't cover it. Lands in envoy-system (targetNamespace-forced) beside the Gateway.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/envoyproxy.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/envoyproxy.yaml
@@ -1,12 +1,8 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
-# Data-plane config for the DEDICATED michael (restic) gateway — sized for the
-# backup data plane (60+ Gbps target), separate from the 2-replica app gateway.
-# One replica per worker; the LB Service draws its VIP from the public pool-a
-# (lb: public matches its NotIn selector). externalTrafficPolicy: Cluster +
-# Cilium DSR (loadBalancer.mode hybrid, talos cilium values): every worker
-# advertises the /32 so the spine ECMPs across all of them regardless of pod
-# placement, the landing node geneve-dispatches to a backend, and the backend's
-# node replies straight to the client — no SNAT hop, client IPs preserved.
+# Sized for the 60+ Gbps backup path: one replica per worker, separate from the
+# 2-replica app gateway. externalTrafficPolicy: Cluster + Cilium DSR means every worker
+# advertises the /32 (spine ECMPs regardless of pod placement) and the backend node
+# replies direct — no SNAT hop, client IPs preserved.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/gateway.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/gateway.yaml
@@ -1,10 +1,7 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/gateway_v1.json
-# The michael (restic) Gateway: HTTPS-only, scoped to ${GW_HOST}. Shares the
-# `envoy` GatewayClass but attaches its own EnvoyProxy via
-# infrastructure.parametersRef (Envoy Gateway creates one proxy fleet per
-# Gateway). TLS terminates with the gw-public cert (certificate.yaml — the
-# *.APP_DOMAIN wildcard doesn't reach rest.htz-fsn1.); no :80 listener —
-# restic clients speak HTTPS only.
+# Shares the `envoy` GatewayClass but attaches its own EnvoyProxy via
+# infrastructure.parametersRef — one proxy fleet per Gateway. No :80 listener:
+# restic speaks HTTPS only.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -29,8 +26,7 @@ spec:
         certificateRefs:
           - kind: Secret
             name: gw-public-tls
-    # Internal twin (${GW_INT_VIP}): same envoy fleet, NetBird-zone hostname,
-    # own DNS-01 cert (gw-internal.yaml at the overlay root).
+    # Internal twin: same envoy fleet, own DNS-01 cert (gw-internal.yaml at the overlay root).
     - name: https-internal
       protocol: HTTPS
       port: 443

--- a/kubernetes/apps/prod/htz-fsn1/infra/cert-manager.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/cert-manager.yaml
@@ -1,9 +1,7 @@
 ---
-# cert-manager on father — CHERRY-PICKED from components/infra/network (the full
-# infra component stays off until the yucca platform launches; certs are needed
-# now for the netops UIs). REMOVE this file when components/infra is enabled in
-# kustomization.yaml, or the duplicate Kustomization names will collide.
-# The cloudflare-api-token Secret is TF-provisioned (talos stack secrets.tf).
+# Cherry-picked from components/infra/network, which stays off until the platform
+# launches. REMOVE this file when components/infra is enabled, else Kustomization names
+# collide. cloudflare-api-token Secret is TF-provisioned (talos stack secrets.tf).
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -26,10 +24,9 @@ spec:
     name: ${MANIFEST_SOURCE:=flux-system}
     namespace: flux-system
   targetNamespace: cert-manager
-  # PROD TOPOLOGY: the webhook must run on the CONTROL PLANES. The apiserver
-  # (hostNetwork on the CPs) calls admission webhooks itself, and CP→worker-pod
-  # traffic rides geneve over the NetBird mgmt route — where TLS-sized packets
-  # blackhole (same plane the coredns pin dodges). On a CP the call is local.
+  # The webhook must run on the CONTROL PLANES: the apiserver (hostNetwork on the CPs)
+  # calls admission webhooks itself, and CP→worker-pod traffic rides geneve over the
+  # NetBird mgmt route where TLS-sized packets blackhole. On a CP the call is local.
   patches:
     - target:
         kind: HelmRelease

--- a/kubernetes/apps/prod/htz-fsn1/infra/cnpg.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/cnpg.yaml
@@ -1,7 +1,5 @@
-# CNPG operator on father — CHERRY-PICKED from components/infra/cnpg-system
-# (the full infra component stays off: its storage layer would collide with the
-# prod-owned openebs install, see kustomization.yaml). CRD provider for the
-# yucca-database Cluster CR, so it lives in the cluster-infra layer.
+# Cherry-picked from components/infra/cnpg-system, which stays off wholesale (its storage
+# layer collides with the prod-owned openebs).
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/prod/htz-fsn1/infra/envoy.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/envoy.yaml
@@ -1,8 +1,5 @@
-# Envoy Gateway on father — CHERRY-PICKED from components/infra/network (same
-# caveat as cert-manager.yaml: REMOVE this file when components/infra is enabled,
-# or the Kustomization names collide). Deploys the operator + the APP gateway
-# (pre-staged for the yucca launch: VIP ${INGRESS_VIP}, cert for
-# ${APP_DOMAIN}); the NETOPS gateway lives in netops/gateway.yaml.
+# Cherry-picked from components/infra/network; REMOVE when that component is enabled,
+# else Kustomization names collide. The NETOPS gateway lives in netops/gateway.yaml.
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -50,22 +47,12 @@ spec:
     name: ${MANIFEST_SOURCE:=flux-system}
     namespace: flux-system
   targetNamespace: envoy-system
-  # PROD-ONLY: the discovery pointer lives on ${META_HOST} = meta.futo.cloud,
-  # which is outside the *.${APP_DOMAIN} wildcard the base cert covers (staging's
-  # META_HOST is under its app domain, so staging needs none of this).
-  #
-  # Deliberately an extra SAN on the EXISTING cert rather than a second
-  # certificateRef on the gateway listener: Gateway API makes a listener whose
-  # certificateRef can't be resolved Programmed=False, so a new ref would take
-  # the whole https listener (web + api) down for as long as it takes
-  # cert-manager to issue — an outage designed into a routine merge. Editing
-  # dnsNames instead just triggers a reissue; the old Secret keeps serving
-  # throughout and the listener never changes.
-  #
-  # NB: kustomize applies this patch, THEN postBuild substitutes — which is why
-  # a ${VAR} in the patch value resolves. Coupling accepted: a meta.futo.cloud
-  # DNS-01 failure now blocks renewal of the app cert too, but both names sit in
-  # the same Cloudflare zone behind the same token, so they fail together anyway.
+  # PROD-ONLY: ${META_HOST} is outside the *.${APP_DOMAIN} wildcard (staging's sits under
+  # its app domain). Extra SAN on the EXISTING cert, NOT a second certificateRef: an
+  # unresolvable ref makes the listener Programmed=False, taking web + api down until
+  # cert-manager issues; editing dnsNames just reissues while the old Secret keeps serving.
+  # kustomize patches THEN postBuild substitutes — that's why ${VAR} resolves here.
+  # Coupling accepted: both names share the same Cloudflare zone/token and fail together.
   patches:
     - target:
         group: cert-manager.io

--- a/kubernetes/apps/prod/htz-fsn1/infra/kustomization.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/kustomization.yaml
@@ -1,11 +1,7 @@
 ---
-# prod@htz-fsn1 INFRA layer — the CRD/operator providers (cert-manager,
-# envoy-gateway + Gateway API, OpenEBS/mayastor) + their namespaces. Applied by
-# the `cluster-infra` Flux Kustomization (clusters/prod/htz-fsn1/apps.yaml),
-# which `cluster-apps` dependsOn: everything here must be READY (healthChecks →
-# operators running → CRDs registered) before the app layer's custom resources
-# (Certificates, Gateways, EnvoyProxy, DiskPools) are even dry-run — the flat
-# single-layer tree deadlocked on exactly that during the 2026-07 rebuild.
+# Everything here must be READY (healthChecks → operators → CRDs registered) before the
+# app layer's CRs are even dry-run — the flat single-layer tree deadlocked on exactly
+# that during the 2026-07 rebuild.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/prod/htz-fsn1/infra/namespace-envoy-system.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/namespace-envoy-system.yaml
@@ -1,11 +1,8 @@
 ---
-# envoy-system on father — needed by the cherry-picked envoy.yaml (the full
-# components/infra, whose network/namespace.yaml normally owns this, stays off
-# until launch). Content matches the component copy, so enabling components/infra
-# later is a clean handover (same field manager, no fight); REMOVE this file at
-# that point alongside envoy.yaml. The cert-manager namespace is NOT declared
-# here — the talos TF stack creates it (secrets.tf) to bootstrap the
-# cloudflare-api-token Secret, and declaring it twice would race TF.
+# Content matches components/infra/network/namespace.yaml so enabling that component
+# later is a clean handover; REMOVE this file then, alongside envoy.yaml. The cert-manager
+# ns is NOT declared here — the talos TF stack creates it (secrets.tf) to bootstrap
+# cloudflare-api-token, and declaring it twice would race TF.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/infra/namespace-openebs.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/namespace-openebs.yaml
@@ -1,9 +1,7 @@
 ---
-# The openebs namespace — owned HERE (cluster-apps), not by the openebs
-# Kustomization that targets it: pruning lessons of 2026-07-06 (the namespace
-# briefly lived in a since-removed manifest; the restructure pruned it and took
-# the whole storage control plane down with it). privileged: hostPath + hugepages
-# + /dev access for the Mayastor io-engine.
+# Owned HERE, not by the openebs Kustomization targeting it: the 2026-07-06 restructure
+# pruned it out of a since-removed manifest and took the whole storage control plane down.
+# privileged: hostPath + hugepages + /dev for the Mayastor io-engine.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/infra/openebs.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/infra/openebs.yaml
@@ -1,14 +1,8 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# OpenEBS on father — the SHARED apps/base/openebs (same chart + values as
-# staging), specialized via the OPENEBS_* cluster-settings: Mayastor ON (the
-# openebs-replicated SC + DiskPools next door on the r-mayastor partitions),
-# LocalPV on the u-localpv xfs partition (CNPG's node-local PG volumes — CNPG
-# replicates at the Postgres layer, deliberately not block-level).
-# targetNamespace `openebs` (father predates the shared base's openebs-system;
-# the helm release + Mayastor state live there — renaming would churn storage).
-# Talos prereqs (hugepages, nvme_tcp, /var/mnt rbind, firewall ports, volumes)
-# live in the talos stack.
+# targetNamespace `openebs`, not the shared base's openebs-system: father predates it and
+# the helm release + Mayastor state live there — renaming would churn storage. Talos
+# prereqs (hugepages, nvme_tcp, /var/mnt rbind, firewall, volumes) live in the talos stack.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/kustomization.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/kustomization.yaml
@@ -1,15 +1,9 @@
 ---
-# prod@htz-fsn1 cluster overlay — father: the APP layer (custom resources +
-# workloads). The CRD/operator providers live in ./infra, applied by the
-# `cluster-infra` Flux Kustomization that this layer dependsOn — see
-# infra/kustomization.yaml for why (fresh-cluster dry-run deadlock).
-#
-# SCOPE: cluster baseline (coredns, Cilium BGP LB config, netops, OpenEBS
-# pools) + the yucca platform/app set. components/infra stays off WHOLESALE —
-# its storage layer collides with the prod-owned openebs (infra/openebs.yaml,
-# targetNamespace `openebs`) and netbird-operator has no prod service user —
-# so the platform pieces are cherry-picked: operators in ./infra
-# (cluster-infra layer), issuer/proxies/routes/observability in ./platform.
+# APP layer; CRD/operator providers live in ./infra via the `cluster-infra` Kustomization
+# this layer dependsOn — see infra/kustomization.yaml (fresh-cluster dry-run deadlock).
+# components/infra stays off WHOLESALE: its storage layer collides with the prod-owned
+# openebs (targetNamespace `openebs`) and netbird-operator has no prod service user;
+# pieces are cherry-picked into ./infra and ./platform instead.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/prod/htz-fsn1/lb-return-route.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/lb-return-route.yaml
@@ -1,14 +1,7 @@
-# LoadBalancer return-path routing (workers).
-#
-# Inbound to a LoadBalancer VIP arrives via the fabric (BGP → transit), but the workers'
-# default route is their public eth0. A reply sourced from a VIP (69.48.224.0/24) sent out
-# eth0 is dropped by Hetzner Robot as spoofed (the VIP isn't the NIC's IP). So we source-
-# route VIP-sourced traffic back through the fabric core (the spine IRB, 10.40.10.1), where
-# 69.48.224.0/24 is a valid source — making the path symmetric. General egress stays on eth0.
-#
-# Talos has no policy-routing knob in machineconfig, so this runs as a privileged, self-
-# healing DaemonSet on the workers. When GitOps lands on prod, adopt it into the Flux tree
-# (and template the CIDR/gateway from cluster-settings instead of hardcoding).
+# VIP traffic arrives via the fabric, but workers default-route out public eth0, where
+# Hetzner Robot drops VIP-sourced (69.48.224.0/24) replies as spoofed. Source-route them
+# back via the spine IRB (10.40.10.1), where the range is a valid source; general egress
+# stays on eth0. A DaemonSet because Talos has no policy-routing knob in machineconfig.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/certificate.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/certificate.yaml
@@ -1,8 +1,6 @@
 ---
-# Wildcard TLS for the netops UIs: *.father.fsn.htz.yucca.futo.network via
-# Let's Encrypt DNS-01 (cloudflare, futo.network zone — split-horizon: only the
-# ACME TXT records are public, the A records live in the NetBird zone). Consumed
-# by the future ingress/gateway; issued now so the pipeline is proven.
+# Split-horizon: only the ACME TXT records are public, the A records live in the
+# NetBird zone.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/gateway.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/gateway.yaml
@@ -1,8 +1,5 @@
 ---
-# The netops Gateway — terminates *.father.fsn.htz.yucca.futo.network with the
-# cert-manager wildcard (certificate.yaml) on the SAME VIP the netops DNS records
-# point at. Its Envoy data plane deploys into THIS namespace (operator runs in
-# GatewayNamespace mode). Per-host routing: httproutes.yaml.
+# Its Envoy data plane deploys into THIS namespace (operator runs in GatewayNamespace mode).
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/grafana-dashboards.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/grafana-dashboards.yaml
@@ -1,5 +1,4 @@
-# Provisioned Grafana dashboards (netops). GENERATED-then-committed — edit the
-# dashboard in Grafana, export JSON, and paste back here (or regenerate).
+# GENERATED-then-committed: edit in Grafana, export JSON, paste back here.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/grafana.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/grafana.yaml
@@ -1,9 +1,6 @@
-# Grafana — the netops pane of glass, on an INTERNAL VIP only (lb-internal pool,
-# NetBird-reachable): http://grafana.father.fsn.htz.yucca.futo.network
-# Admin password: 1Password item op://yucca_tf_prod/FATHER_GRAFANA_ADMIN/password —
-# the `grafana-admin` Secret is created from it (op read), never from git.
-# Datasource + dashboards are fully provisioned (no clicking): the in-cluster
-# VictoriaMetrics is the (prometheus-compatible) default datasource.
+# INTERNAL VIP only (lb-internal pool, NetBird-reachable).
+# Admin password: op://yucca_tf_prod/FATHER_GRAFANA_ADMIN/password — the `grafana-admin`
+# Secret is created from it (op read), never from git.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/httproutes.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/httproutes.yaml
@@ -1,5 +1,5 @@
 ---
-# HTTP -> HTTPS for everything on the netops gateway.
+# No hostnames filter: intentional catch-all.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -80,7 +80,7 @@ spec:
           namespace: kube-system
           port: 80
 ---
-# Allow the cross-namespace backendRef above (netops HTTPRoute -> kube-system Service).
+# Required for the cross-namespace backendRef above.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -95,8 +95,7 @@ spec:
     - group: ""
       kind: Service
 ---
-# yucca-admin-api — NetBird-only human access (${YUCCA_ADMIN_HOST}); the admin
-# OIDC redirect URIs in the base HR derive from the same host.
+# The admin OIDC redirect URIs in the base HR derive from this same host.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -111,7 +110,7 @@ spec:
           namespace: yucca
           port: 3030
 ---
-# Allow the cross-namespace backendRef above (netops HTTPRoute -> yucca Service).
+# Required for the cross-namespace backendRef above.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -126,8 +125,7 @@ spec:
     - group: ""
       kind: Service
 ---
-# The yucca namespace is default-deny (components/apps/networkpolicies.yaml);
-# open admin-api to the netops gateway's envoy pods only.
+# The yucca namespace is default-deny (components/apps/networkpolicies.yaml).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/hyperglass.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/hyperglass.yaml
@@ -1,9 +1,5 @@
-# hyperglass — looking glass for the fabric (BGP route lookups, ping, traceroute
-# from the switches' vantage point). Internal VIP:
-# http://lg.father.fsn.htz.yucca.futo.network
-#
-# devices.yaml is NOT here: it embeds the netops password (netmiko can't key-auth
-# through hyperglass config), so it's a Secret the talos stack renders from
+# devices.yaml is a Secret, NOT here: it embeds the netops password (netmiko can't
+# key-auth through hyperglass config). The talos stack renders it from
 # op://yucca_tf_prod/NETOPS_FABRIC_PASSWORD (netops-secrets.tf).
 apiVersion: v1
 kind: ConfigMap
@@ -32,8 +28,7 @@ spec:
       containers:
         - name: hyperglass
           image: ghcr.io/thatmattlove/hyperglass:latest@sha256:7e7515bf6e27d0980f82516b62b4d0fcebdddb81140e17ee1be2f29f8cc929ab
-          # Without --workers it forks one per CPU — 192 on the EPYC workers — and
-          # instantly OOMs. The startup UI build also needs headroom (2Gi limit).
+          # Without --workers it forks one per CPU — 192 on the EPYC workers — and OOMs.
           command: ["hyperglass", "start", "--workers", "4"]
           env:
             - { name: HYPERGLASS_APP_PATH, value: /etc/hyperglass }
@@ -46,9 +41,8 @@ spec:
             - { name: devices, mountPath: /etc/hyperglass/devices.yaml, subPath: devices.yaml }
           resources:
             requests: { cpu: 200m, memory: 1Gi }
-            # The one-shot startup UI build (Next.js) keys its worker count off the
-            # node's 192 hardware threads and peaks absurdly high; the limit is
-            # build headroom only — steady-state is <1Gi on a 128GB idle worker.
+            # Sized for the one-shot startup UI build, which keys its worker count off the
+            # node's 192 threads; steady-state is <1Gi.
             limits: { memory: 16Gi }
       volumes:
         - name: config
@@ -66,7 +60,7 @@ spec:
   ports:
     - { name: http, port: 80, targetPort: 8001 }
 ---
-# hyperglass's cache/queue backend (it dials `redis:6379` by default).
+# hyperglass dials `redis:6379` by default — hence the name.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/junos-exporter.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/junos-exporter.yaml
@@ -1,8 +1,6 @@
-# junos_exporter — NETCONF/SSH scraper for the fabric switches (interface octets,
-# BGP sessions, environment, optics). Auth: the read-only `netops` Junos login
-# (fabric.tf netops_users) with the key from the `netops-ssh` Secret (created
-# imperatively; never in git). Pods reach the switch vme IPs (10.40.5.x) over the
-# mesh via the talos→resources NetBird policy.
+# Auth: the read-only `netops` Junos login (fabric.tf netops_users) with the key from the
+# `netops-ssh` Secret (created imperatively; never in git). Pods reach the switch vme IPs
+# (10.40.5.x) over the mesh via the talos→resources NetBird policy.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,9 +15,8 @@ data:
       - host: 10.40.5.125
         username: netops
         key_file: /ssh/id_ed25519
-    # Feature set is latency-tuned: `routes` (route-table summaries) is DISABLED —
-    # the spine carries a full transit table (>1M routes) and the collector pushed
-    # a scrape past 20s; queues likewise. Interfaces/BGP/optics cover the dashboard.
+    # `routes` and `queues` are DISABLED: the spine carries a full transit table
+    # (>1M routes) and collecting it pushed a scrape past 20s.
     features:
       alarm: true
       environment: true

--- a/kubernetes/apps/prod/htz-fsn1/netops/kustomization.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/kustomization.yaml
@@ -1,8 +1,6 @@
 ---
-# The father netops stack. The namespace + its Secrets (netops-ssh,
-# grafana-admin, hyperglass-devices) are NOT in git — the talos stack provisions
-# them from 1Password (tf/deployment/prod/htz-fsn1/talos/netops-secrets.tf);
-# Flux only manages the workloads around them.
+# The namespace + its Secrets (netops-ssh, grafana-admin, hyperglass-devices) are NOT in
+# git — the talos stack provisions them from 1Password (talos/netops-secrets.tf).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/prod/htz-fsn1/netops/networkpolicies.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/networkpolicies.yaml
@@ -1,10 +1,7 @@
 ---
-# Ingress-only network policies for netops. The stack is deliberately
-# self-contained (its own gateway/envoy pods, vmagent, VictoriaMetrics all live
-# HERE), so one intra-namespace allow covers every internal flow; the only
-# cross-boundary ingress is the gateway VIP (10.40.12.16) and the spine's raw
-# sFlow stream (10.40.12.14). These pods mount fabric credentials (netops-ssh,
-# hyperglass password) — nothing else in the cluster gets to talk to them.
+# Ingress-only. The stack is self-contained, so one intra-namespace allow covers internal
+# flows; the only cross-boundary ingress is the gateway VIP (10.40.12.16) and the spine's
+# sFlow stream (10.40.12.14). These pods mount fabric credentials.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,8 +17,7 @@ metadata:
   name: allow-intra-namespace
   namespace: netops
 spec:
-  # gateway→backends (grafana/sflow-rt/smokeping/oxidized/hyperglass/redis),
-  # vmagent scrapes, grafana→victoria-metrics — all stay inside netops.
+  # gateway→backends, vmagent scrapes and grafana→VM all stay inside netops.
   podSelector: {}
   policyTypes: [Ingress]
   ingress:
@@ -34,11 +30,8 @@ metadata:
   name: allow-ingress-gateway
   namespace: netops
 spec:
-  # The front door: NetBird peers hit the internal VIP, which DNATs to the
-  # envoy pods' data-plane container ports (envoy-gateway maps listener 443 to
-  # a 10xxx containerPort, so no port pin here). 0.0.0.0/0 is safe: the VIP is
-  # in the lb-internal pool — excluded from the transit advertisement and
-  # reachable only over the NetBird mgmt route.
+  # No port pin: envoy-gateway maps listener 443 to a 10xxx containerPort.
+  # 0.0.0.0/0 is safe — lb-internal VIP, excluded from transit, NetBird mgmt route only.
   podSelector:
     matchLabels:
       app.kubernetes.io/name: envoy
@@ -54,11 +47,9 @@ metadata:
   name: allow-ingress-sflow-collector
   namespace: netops
 spec:
-  # The spine streams sFlow datagrams at 10.40.12.14 (see sflow-rt.yaml). Kept
-  # DELIBERATELY wide: with externalTrafficPolicy Cluster the stream can arrive
-  # SNAT'd to a node IP, and this feed has already been lost silently once
-  # (2026-07-06) — a clever source filter risks repeating that for zero gain
-  # (the VIP itself is internal-only).
+  # DELIBERATELY wide: with externalTrafficPolicy Cluster the stream can arrive SNAT'd to
+  # a node IP, and the feed was silently lost once (2026-07-06). The VIP is internal-only,
+  # so a source filter would risk repeating that for zero gain.
   podSelector:
     matchLabels:
       app: sflow-rt

--- a/kubernetes/apps/prod/htz-fsn1/netops/oxidized.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/oxidized.yaml
@@ -1,6 +1,5 @@
-# oxidized — switch config backup (versioned): pulls `show configuration` from every
-# VC over SSH (the read-only netops login + key) into a local git repo on the
-# hostPath. Web UI (config diffs/history): http://oxidized.father.fsn.htz.yucca.futo.network
+# Pulls `show configuration` from every VC over SSH (read-only netops login + key) into a
+# local git repo on the hostPath.
 # TODO: point the git output at a real remote once one exists.
 apiVersion: v1
 kind: ConfigMap
@@ -62,8 +61,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: yucca-htz-fsn-father-k8s-jeanne
-      # hostPath dirs are root-owned and fsGroup does not apply to hostPath —
-      # hand the repo dir to the oxidized uid before it starts.
+      # fsGroup does not apply to hostPath, and hostPath dirs are root-owned.
       initContainers:
         - name: chown-data
           image: busybox:1.36

--- a/kubernetes/apps/prod/htz-fsn1/netops/sflow-rt.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/sflow-rt.yaml
@@ -1,9 +1,6 @@
-# sflow-rt — real-time sFlow analytics for the fabric. The spine streams hardware
-# counter samples (5s) + 1:2048 packet samples to the VIP (UDP 6343); sflow-rt's
-# prometheus app exposes per-port rates that vmagent scrapes every 5s — the
-# seconds-granularity bandwidth source (junos_exporter stays for device health).
-# UI (top talkers, flow browser): http://sflow.father.fsn.htz.yucca.futo.network
-# Image: sflow/prometheus = sflow-rt with the prometheus + browse-metrics apps.
+# The spine streams hardware counter samples (5s) + 1:2048 packet samples to the VIP
+# (UDP 6343). This is the seconds-granularity bandwidth source; junos_exporter stays for
+# device health. Image sflow/prometheus = sflow-rt with the prometheus + browse-metrics apps.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,10 +39,9 @@ spec:
     - { name: sflow, port: 6343, targetPort: 6343, protocol: UDP }
     - { name: http, port: 80, targetPort: 8008, protocol: TCP }
 ---
-# The raw sFlow COLLECTOR endpoint — this one must stay a LoadBalancer VIP: the
-# spine's `protocols sflow collector 10.40.12.14` (fabric TF) streams UDP here
-# via the Cilium iBGP /32; only the UI moved behind the ingress. Losing this VIP
-# silently kills all 5s bandwidth data (learned 2026-07-06).
+# Must stay a LoadBalancer VIP: the spine's `protocols sflow collector 10.40.12.14`
+# (fabric TF) streams UDP here via the Cilium iBGP /32. Losing this VIP silently kills
+# all 5s bandwidth data (learned 2026-07-06).
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/smokeping.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/smokeping.yaml
@@ -1,8 +1,5 @@
-# smokeping — latency/loss history for the paths that matter: the fabric switches,
-# the spine gateway, the workers, the mgmt hosts, the transit next-hop, and the
-# internet. Internal VIP: http://smokeping.father.fsn.htz.yucca.futo.network
-# (linuxserver image seeds /config from /defaults on first boot — our Targets is
-# mounted over /defaults so a fresh /config always picks it up.)
+# The linuxserver image seeds /config from /defaults on first boot, so our Targets is
+# mounted over /defaults for a fresh /config to pick it up.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/victoria-metrics.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/victoria-metrics.yaml
@@ -1,11 +1,6 @@
-# VictoriaMetrics single — the SHORT-TERM, HIGH-GRANULARITY tier of the hybrid
-# design: 30d retention at 10s scrape resolution, in-cluster. vmagent remote-writes
-# here today and will FAN OUT to the o11y cluster later (second -remoteWrite.url in
-# vmagent.yaml) — this instance stays the fast local buffer, o11y the long-term one.
-#
-# Storage: a REPLICATED Mayastor volume (openebs-replicated, repl=2 across the
-# workers' second NVMe) — survives a node loss, attaches over NVMe-oF/TCP.
-# Image digest matches the repo's compose pin.
+# The SHORT-TERM tier (30d @ 10s): the fast local buffer, with o11y the long-term tier
+# via vmagent's second -remoteWrite.url. Storage is a repl=2 Mayastor volume so it
+# survives node loss. Image digest matches the compose pin.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/netops/vmagent.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/vmagent.yaml
@@ -1,7 +1,5 @@
-# vmagent — the single scrape + fan-out point. Scrapes at 10s (high granularity)
-# and remote-writes to BOTH the in-cluster VictoriaMetrics (30d buffer) and
-# o11y's mesh vmauth (long-term tier, over NetBird, unauth). Also scrapes the
-# spice ceph fleet (cluster=spice) over the fabric.
+# Single scrape, fanned out to the in-cluster VM (30d buffer) AND o11y's mesh vmauth
+# (long-term, NetBird, unauth). Also scrapes spice over the fabric.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -39,31 +37,24 @@ data:
   scrape.yml: |
     global:
       scrape_interval: 10s
-      # Site/env identity tags. `cluster` is deliberately NOT here: vmagent
-      # applies external_labels OVER target labels (unlike Prometheus's
-      # fill-gaps semantics — it relabeled all 48 spice targets to
-      # cluster=netops), so each job stamps its own cluster label instead.
+      # No `cluster` here: vmagent applies external_labels OVER target labels (unlike
+      # Prometheus — it relabeled all 48 spice targets to cluster=netops), so each job
+      # stamps its own.
       external_labels:
         site: htz-fsn1
         env: prod
     scrape_configs:
-      # The fabric switches (spine + cls1 leaf) via junos_exporter. The exporter
-      # polls the switches synchronously per scrape and burns ~20s/device in its
-      # SSH layer (the raw RPC is ~2s — known exporter quirk, revisit), so this job
-      # runs at 60s with a generous timeout. 60s counter resolution is plenty for
-      # bandwidth dashboards; sFlow is the upgrade path if we ever need seconds.
+      # The exporter burns ~20s/device in its SSH layer (raw RPC ~2s — known quirk),
+      # hence the 60s interval + long timeout; sFlow covers seconds-granularity needs.
       - job_name: junos
         scrape_interval: 60s
         scrape_timeout: 55s
         static_configs:
           - labels: { cluster: netops }
             targets: ["junos-exporter.netops.svc:9326"]
-      # sflow-rt: seconds-granularity per-port fabric rates (the spine exports
-      # counter samples every 5s; the prometheus app serves them PRE-RATED — the
-      # sflow_* series are already per-second gauges, no rate() needed). The
-      # datasource label is the SNMP ifIndex (persistent on Junos); the relabels
-      # map it to the port name (regenerate from `show snmp mib walk ifDescr`
-      # after channelization changes).
+      # Served PRE-RATED: sflow_* are per-second gauges, no rate(). The datasource is
+      # SNMP ifIndex (persistent on Junos) — regenerate the port relabels from
+      # `show snmp mib walk ifDescr` after channelization changes.
       - job_name: sflow
         scrape_interval: 5s
         metrics_path: /prometheus/metrics/ALL/ifinoctets,ifoutoctets,ifinutilization,ifoututilization,ifinerrors,ifouterrors,ifindiscards,ifoutdiscards,ifinpkts,ifoutpkts/txt
@@ -91,7 +82,6 @@ data:
           - {source_labels: [datasource], regex: "669", target_label: port, replacement: "ae3"}
           - {source_labels: [datasource], regex: "671", target_label: port, replacement: "ae2"}
           - {source_labels: [datasource], regex: "675", target_label: port, replacement: "ae1"}
-      # Self-observability of the metrics tier.
       - job_name: victoria-metrics
         static_configs:
           - labels: { cluster: netops }
@@ -100,12 +90,11 @@ data:
         static_configs:
           - labels: { cluster: netops }
             targets: ["localhost:8429"]
-      # coredns (service metrics port).
       - job_name: coredns
         static_configs:
           - labels: { cluster: netops }
-            targets: ["kube-dns.kube-system.svc:9153"]
-      # Node + container metrics straight from every kubelet (no apiserver proxy).
+            targets: ["kube-dns.kube-system.svc:9153"] # :9153 = coredns metrics, not DNS
+      # Scraped direct off each kubelet, not through the apiserver proxy.
       - job_name: kubelet
         scheme: https
         tls_config: { insecure_skip_verify: true }
@@ -123,13 +112,9 @@ data:
         kubernetes_sd_configs: [{ role: node }]
         relabel_configs:
           - { target_label: cluster, replacement: netops }
-      # ─── spice (bare-metal Ceph) ────────────────────────────────────────
-      # All 48 nodes' fabric VLAN-120 IPs (host_index 4-51; roster
-      # tf/.../ceph/spice-hosts.yaml — same list the s3 DNS records pin),
-      # reached over the spine-routed kube↔cls1-public path. cluster=spice is
-      # stamped per-target (see the external_labels note: vmagent would
-      # override it from globals). 30s: 48 node-exporters at the global 10s
-      # would triple the sample volume for no operational gain.
+      # All 48 spice nodes' fabric VLAN-120 IPs (host_index 4-51; roster
+      # tf/.../ceph/spice-hosts.yaml), via the spine-routed kube↔cls1-public path.
+      # 30s, not 10s: the shorter interval would 3x sample volume.
       - job_name: ceph-node-exporter
         scrape_interval: 30s
         static_configs:
@@ -144,7 +129,6 @@ data:
               "10.40.20.40:9100", "10.40.20.41:9100", "10.40.20.42:9100", "10.40.20.43:9100", "10.40.20.44:9100", "10.40.20.45:9100",
               "10.40.20.46:9100", "10.40.20.47:9100", "10.40.20.48:9100", "10.40.20.49:9100", "10.40.20.50:9100", "10.40.20.51:9100"
             ]
-      # Per-daemon Ceph metrics (the cephadm ceph-exporter on every node).
       - job_name: ceph-exporter
         scrape_interval: 30s
         static_configs:
@@ -159,11 +143,8 @@ data:
               "10.40.20.40:9926", "10.40.20.41:9926", "10.40.20.42:9926", "10.40.20.43:9926", "10.40.20.44:9926", "10.40.20.45:9926",
               "10.40.20.46:9926", "10.40.20.47:9926", "10.40.20.48:9926", "10.40.20.49:9926", "10.40.20.50:9926", "10.40.20.51:9926"
             ]
-      # Cluster-level metrics (health, pools) from the mgr prometheus module.
-      # mgr is count:3 with cephadm-chosen placement that MOVES on redeploy, so
-      # scrape :9283 on every node: only mgr hosts answer (active = full set,
-      # standby = tiny), the rest refuse — one RST per interval, and
-      # up{job="ceph-mgr"} tracks where the mgrs actually live.
+      # mgr placement moves on redeploy, so scrape :9283 everywhere: only mgr hosts answer
+      # (active=full, standby=tiny), the rest RST; up{job="ceph-mgr"} tracks where they live.
       - job_name: ceph-mgr
         scrape_interval: 30s
         static_configs:
@@ -198,11 +179,9 @@ spec:
           image: victoriametrics/vmagent:latest@sha256:4f2d79253c1ce04296e4624724a815e53ea5ebadd465a1d0291153afb9893a30
           args:
             - -promscrape.config=/config/scrape.yml
-            # Pick up ConfigMap edits without a pod restart.
             - -promscrape.configCheckInterval=1m
             - -remoteWrite.url=http://victoria-metrics.netops.svc:8428/api/v1/write
-            # o11y long-term tier: the unauth mesh vmauth over NetBird (same
-            # path as the observability agents; NetBird ACL is the only gate).
+            # Unauth over NetBird: the NetBird ACL is the only gate.
             - -remoteWrite.url=https://vmauth.o11y.futo.network/insert/0/prometheus/api/v1/write
             # Bound each URL's spill so two queues fit the 2Gi buffer emptyDir.
             - -remoteWrite.maxDiskUsagePerURL=900MB
@@ -215,8 +194,7 @@ spec:
             - { name: buffer, mountPath: /buffer }
           resources:
             requests: { cpu: 50m, memory: 256Mi }
-            # 512Mi OOM-looped every ~8min once the 12 k8s + 5 static targets
-            # were all scraping (269 restarts over 6 days).
+            # 512Mi OOM-looped ~8min with all targets scraping (269 restarts / 6 days).
             limits: { memory: 4Gi }
       volumes:
         - name: config

--- a/kubernetes/apps/prod/htz-fsn1/observability/kustomization.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/observability/kustomization.yaml
@@ -1,18 +1,14 @@
 ---
-# prod@htz-fsn1 observability overlay — the shared components/infra/observability
-# slice, with the remote-write egress repointed at o11y's MESH vmauth
-# (vmauth.o11y.futo.network → 10.69.0.10 over NetBird, unauthenticated: the
-# NetBird ACL `yucca-prod-htz-fsn1-talos → o11y-production-k8s-gateway:443` is
-# the only gate; the mesh-unauth vmauth 401s requests that DO carry a bearer,
-# so the token wiring must go, not just be ignored). Staging keeps the authed
-# public futostatus path. Pods resolve the mesh name via the coredns hosts
-# entry (../coredns.yaml) — the NetBird DNS zone is not distributed to nodes.
+# Remote-write repointed at o11y's MESH vmauth (10.69.0.10 over NetBird; the ACL
+# `yucca-prod-htz-fsn1-talos → o11y-production-k8s-gateway:443` is the only gate). That
+# vmauth 401s requests that DO carry a bearer — token wiring must be removed, not ignored.
+# The mesh name resolves via the coredns hosts entry (../coredns.yaml); the NetBird DNS
+# zone is not distributed to nodes.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../../components/infra/observability
 patches:
-  # vmagent: mesh URL, no bearer.
   - target:
       group: kustomize.toolkit.fluxcd.io
       kind: Kustomization
@@ -30,8 +26,7 @@ patches:
                 value: https://vmauth.o11y.futo.network/insert/0/prometheus/api/v1/write
               - op: remove
                 path: /spec/values/vmagent/spec/remoteWrite/0/bearerTokenSecret
-  # logs collector: URL comes from VLOGS_REMOTE_URL (cluster-settings); only the
-  # bearer must go.
+  # URL already comes from VLOGS_REMOTE_URL; only the bearer must go.
   - target:
       group: kustomize.toolkit.fluxcd.io
       kind: Kustomization

--- a/kubernetes/apps/prod/htz-fsn1/platform/gw-proxy.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/platform/gw-proxy.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# Dedicated michael (restic) gateway — see ../gw-proxy/. Separate from the app
-# gateway so the backup data plane (60+ Gbps target) scales independently.
+# Separate from the app gateway so the backup data plane (60+ Gbps target) scales
+# independently.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/platform/httproutes.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/platform/httproutes.yaml
@@ -1,8 +1,6 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# HTTPRoutes (web/api on the app gateway, gw on the dedicated michael gateway —
-# GW_PARENT_GATEWAY selects the parent). CHERRY-PICKED from
-# components/infra/network/httproutes.yaml.
+# CHERRY-PICKED from components/infra/network/httproutes.yaml.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/platform/kustomization.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/platform/kustomization.yaml
@@ -1,8 +1,7 @@
 ---
-# prod@htz-fsn1 PLATFORM slice — the app-layer platform pieces cherry-picked
-# from components/infra (which stays off wholesale: its storage layer collides
-# with the prod-owned openebs, and netbird-operator has no prod service user
-# yet). cert-manager/envoy/issuer already live in ../infra (cluster-infra).
+# App-layer pieces cherry-picked from components/infra, which stays off wholesale (its
+# storage layer collides with the prod-owned openebs, and netbird-operator has no prod
+# service user yet). cert-manager/envoy/issuer already live in ../infra.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/prod/htz-fsn1/platform/observability.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/platform/observability.yaml
@@ -1,8 +1,7 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# Observability agents (vmagent + victoria-logs-collector) — the shared
-# components/infra/observability slice via the prod overlay (../observability),
-# which repoints remote-write at o11y's mesh vmauth over NetBird, unauth.
+# Goes through the prod overlay (../observability), which repoints remote-write at
+# o11y's mesh vmauth over NetBird, unauth.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -19,10 +18,9 @@ spec:
     kind: GitRepository
     name: ${MANIFEST_SOURCE:=flux-system}
     namespace: flux-system
-  # The nested vmagent/victoria-logs-collector Kustomizations are applied by
-  # THIS Kustomization, not cluster-apps, so its substituteFrom patch doesn't
-  # reach them — re-apply it here or their ${vars} ship unsubstituted (the
-  # 17h victoria-logs-collector crash loop on father).
+  # The nested Kustomizations are applied by THIS one, not cluster-apps, so its
+  # substituteFrom patch doesn't reach them — re-apply it here or their ${vars} ship
+  # unsubstituted (the 17h victoria-logs-collector crash loop on father).
   patches:
     - target:
         group: kustomize.toolkit.fluxcd.io

--- a/kubernetes/apps/staging/austin/cilium-lb.yaml
+++ b/kubernetes/apps/staging/austin/cilium-lb.yaml
@@ -1,13 +1,8 @@
 ---
-# Staging LB topology (formerly apps/base/cilium-lb, moved here because pool
-# layout is per-cluster: father uses BGP pools in its cilium-bgp.yaml, and a
-# shared base pool would CIDR-overlap its lb-internal /24 → Conflicting pools).
-# Applied directly by cluster-apps (no postBuild substitution on raw overlay
-# resources), so the VIP is LITERAL here — keep in sync with INGRESS_VIP
-# in clusters/staging/austin/cluster-settings.yaml.
-#
-# Single-address LB-IPAM pool for the ingress VIP. The envoy Service requests it
-# explicitly via the `lbipam.cilium.io/ips` annotation (see envoyproxy.yaml).
+# Per-cluster, not in apps/base: a shared base pool would CIDR-overlap father's
+# lb-internal /24 → Conflicting pools. No postBuild substitution on raw overlay
+# resources, so the VIP is LITERAL — keep it in sync with INGRESS_VIP in
+# clusters/staging/austin/cluster-settings.yaml.
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -16,9 +11,7 @@ spec:
   blocks:
     - cidr: 10.10.10.16/32
 ---
-# Announce LoadBalancer IPs via L2 (ARP) on the node bond so the VIP is
-# reachable on the LAN. Requires l2announcements enabled in the Cilium config
-# (tf .../cilium-values.yaml.tftpl).
+# Requires l2announcements enabled in the Cilium config (tf .../cilium-values.yaml.tftpl).
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy
 metadata:

--- a/kubernetes/apps/staging/austin/flux-system/image-automation.yaml
+++ b/kubernetes/apps/staging/austin/flux-system/image-automation.yaml
@@ -1,29 +1,25 @@
 ---
-# Pull-based image delivery (flux-operator). The input provider watches GHCR
-# for new monorepo build tags (0.0.<run_number>, pushed by CI); the ResourceSet
-# templates the `image-versions` ConfigMap from the latest tag. cluster-apps'
-# postBuild.substituteFrom then feeds ${YUCCA_IMAGE_TAG} into every app
-# HelmRelease. No CI cluster access, no per-deploy git commit — CI only builds+pushes.
+# Pull-based: the ResourceSet templates `image-versions` from the latest GHCR tag and
+# cluster-apps postBuild feeds ${YUCCA_IMAGE_TAG} into every app HR. No CI cluster access
+# and no per-deploy git commit — CI only builds+pushes.
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSetInputProvider
 metadata:
   name: yucca-image
   namespace: flux-system
   annotations:
-    # Poll GHCR every minute (flux-operator reconcile interval; default 10m).
+    # flux-operator default is 10m.
     fluxcd.controlplane.io/reconcileEvery: "1m"
 spec:
   type: OCIArtifactTag
-  # Any app repo works as the version oracle — all 5 ship at the same monorepo
-  # tag (release-please linked-versions).
+  # Any app repo works as the version oracle — all 5 ship at the same monorepo tag
+  # (release-please linked-versions).
   url: oci://ghcr.io/immich-app/yucca/yucca-api
   filter:
-    # CI build track: 0.0.<github.run_number>, monotonically increasing. The
-    # upper bound keeps release-please release tags (>= 0.1.0) off this track —
-    # staging must follow CI builds, not published releases.
+    # The upper bound keeps release-please tags (>= 0.1.0) off: staging follows the
+    # monotonic CI build track 0.0.<run_number>, not published releases.
     semver: ">=0.0.0 <0.1.0"
-  # No secretRef: the app images are public, so the provider reads tags
-  # from GHCR unauthenticated.
+  # No secretRef: the app images are public.
 ---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet

--- a/kubernetes/apps/staging/austin/flux-system/notifications.yaml
+++ b/kubernetes/apps/staging/austin/flux-system/notifications.yaml
@@ -1,12 +1,7 @@
 ---
-# notification-controller posts each Kustomization/HelmRelease reconcile result
-# as a GitHub commit status (✅/❌ on the deployed commit), so deploy outcome is
-# visible in GitHub without CI reaching into the cluster.
-#
-# The `github-app` Secret currently carries the shared `push-o-matic` GitHub App
-# creds (TF-provisioned from op://shared_tf/GITHUB_APP_IMMICH_PUSH_O_MATIC) — the
-# dedicated least-privilege `yucca-flux` app doesn't exist yet. Swap the 1P refs
-# in tf/.env once it does; nothing here changes (same secret name + keys).
+# `github-app` Secret carries the shared push-o-matic App creds
+# (op://shared_tf/GITHUB_APP_IMMICH_PUSH_O_MATIC) until a least-privilege `yucca-flux`
+# app exists — then swap the 1P refs in tf/.env; nothing here changes.
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
@@ -15,11 +10,8 @@ metadata:
 spec:
   type: github
   address: https://github.com/immich-app/yucca
-  # Prefix the commit-status context with the environment so staging and
-  # prod-htz-fsn1 (which both reconcile this monorepo and post to the same
-  # commits) show as DISTINCT statuses instead of overwriting one another —
-  # e.g. "staging/kustomization/yucca-api". Without this, the default context
-  # (kind/name/<provider-uid>) is opaque and clusters can collide.
+  # Env-prefixed: staging and prod post to the same commits, and the default context
+  # (kind/name/<provider-uid>) is opaque and collides.
   commitStatusExpr: "('staging/' + event.involvedObject.kind + '/' + event.involvedObject.name).lowerAscii()"
   secretRef:
     name: github-app

--- a/kubernetes/apps/staging/austin/kustomization.yaml
+++ b/kubernetes/apps/staging/austin/kustomization.yaml
@@ -1,9 +1,5 @@
 ---
-# staging@austin cluster overlay. The flux-instance sync (installed by the TF
-# helm module) reconciles clusters/staging/austin, which points cluster-apps at
-# this path. Role + infra are selected by composing two Components: `infra`
-# (role-independent platform layers) and `roles/primary` (the full app set —
-# austin is the staging partition's primary region).
+# austin is the staging partition's primary region, hence `roles/primary`.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/staging/austin/openebs/kustomization.yaml
+++ b/kubernetes/apps/staging/austin/openebs/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
-# Staging's per-spare-NVMe StorageClasses — CLUSTER-specific (disk layout), so they
-# live in this overlay, not apps/base/openebs (father uses the chart's hostpath
-# class + Mayastor instead; see the OPENEBS_* cluster-settings).
+# In this overlay, not apps/base/openebs, because the disk layout is cluster-specific:
+# father uses the chart's hostpath class + Mayastor instead.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/staging/austin/openebs/storageclass-spare-disk-2.yaml
+++ b/kubernetes/apps/staging/austin/openebs/storageclass-spare-disk-2.yaml
@@ -1,7 +1,6 @@
 ---
-# Second spare-NVMe StorageClass (nvme1n1) — backs the Talos UserVolumeConfig
-# `local-hostpath-2` at /var/mnt/local-hostpath-2. Reserved for workloads that
-# want I/O isolation from the spare-disk pool; not the default class.
+# Backs the Talos UserVolumeConfig `local-hostpath-2` on nvme1n1. Reserved for workloads
+# that want I/O isolation from the spare-disk pool; not the default class.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/kubernetes/apps/staging/austin/openebs/storageclass-spare-disk.yaml
+++ b/kubernetes/apps/staging/austin/openebs/storageclass-spare-disk.yaml
@@ -1,8 +1,6 @@
 ---
-# Spare-NVMe StorageClass (nvme0n1) — backs the Talos UserVolumeConfig
-# `local-hostpath` at /var/mnt/local-hostpath (staging/austin clusters.auto.tfvars).
-# This is the cluster-default class: the only persistent consumer (yucca-database
-# CNPG) and any future stateful workload land here on local NVMe.
+# Backs the Talos UserVolumeConfig `local-hostpath` on nvme0n1 (staging/austin
+# clusters.auto.tfvars). Cluster-default class, so stateful workloads land on local NVMe.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/kubernetes/clusters/prod/htz-fsn1/apps.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/apps.yaml
@@ -1,19 +1,10 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# prod@htz-fsn1 entry points — TWO layers, so a fresh cluster can't deadlock:
-# the 2026-07 rebuild proved a flat tree wedges itself (kustomize-controller
-# server-side dry-runs every object, so any CR whose CRD is missing blocks the
-# WHOLE apply — including the HelmReleases that would install those CRDs).
-#
-#   cluster-infra  operators/CRD providers (apps/prod/htz-fsn1/infra) — wait: true,
-#                  so Ready ⇒ operators running ⇒ CRDs registered.
-#   cluster-apps   everything else (CRs + workloads) — dependsOn cluster-infra.
-#
-# Substitution precedence (last wins): cluster-settings-generated (TF) ->
-# cluster-settings (human) -> image-versions (release-please-stamped prod
-# image pin; see image-versions.yaml); keys are disjoint by design. Injected
-# into the NESTED Kustomizations via the patches block (both layers' direct
-# objects use no ${vars} themselves).
+# TWO layers so a fresh cluster can't deadlock: the 2026-07 rebuild proved a flat tree
+# wedges (kustomize-controller server-side dry-runs every object, so any CR with a missing
+# CRD blocks the WHOLE apply — including the HelmReleases that would install those CRDs).
+# Substitution precedence (last wins): cluster-settings-generated (TF) → cluster-settings
+# (human) → image-versions (release-please-stamped prod pin); keys disjoint by design.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -29,13 +20,12 @@ spec:
     # Release-pinned (see flux-release.yaml); root flux-system stays on main.
     name: flux-release
     namespace: flux-system
-  # The health gate cluster-apps depends on: every nested Kustomization here
-  # carries healthChecks on its HelmRelease, so wait covers operator readiness.
+  # The health gate cluster-apps depends on: every nested Kustomization here carries
+  # healthChecks on its HelmRelease, so wait covers operator readiness.
   wait: true
   timeout: 10m
-  # Direct objects (the nested Kustomization CRs) now carry substitutable
-  # source refs (${MANIFEST_SOURCE}), so this layer substitutes them itself
-  # too — the patches block below still covers the NESTED layers.
+  # The nested Kustomization CRs carry ${MANIFEST_SOURCE} refs, so this layer substitutes
+  # them itself; the patches block below covers the NESTED layers.
   postBuild:
     substituteFrom:
       - kind: ConfigMap
@@ -70,9 +60,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  # Fast retry: CRD registration can trail the infra layer's Ready by moments
-  # (mayastor's diskpool operator creates its CRD at startup) — without
-  # retryInterval a dry-run failure waits the full 1h interval.
+  # CRD registration can trail infra Ready (mayastor's diskpool CRD is created at
+  # startup); without retryInterval a dry-run failure waits the full 1h interval.
   retryInterval: 2m
   dependsOn:
     - name: cluster-infra

--- a/kubernetes/clusters/prod/htz-fsn1/cluster-settings.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/cluster-settings.yaml
@@ -1,37 +1,28 @@
 ---
-# Per-cluster, HUMAN-managed settings for prod@htz-fsn1. Neither CI nor TF
-# touch this file. Keys are disjoint from cluster-settings.generated.yaml (TF)
-# and image-versions.yaml (CI).
+# Human-managed; keys disjoint from cluster-settings.generated.yaml (TF) and
+# image-versions.yaml (CI).
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-settings
   namespace: flux-system
 data:
-  # ─── Release pinning ─────────────────────────────────────────────────
-  # App-tree manifests + in-repo charts build from the flux-release
-  # GitRepository (release-please tag, see flux-release.yaml). Staging keeps
-  # the ${...:=flux-system} defaults and tracks main.
+  # Points manifests + charts at the flux-release GitRepository; staging keeps the
+  # ${...:=flux-system} defaults (main).
   MANIFEST_SOURCE: flux-release
   CHART_SOURCE: flux-release
 
-  # Production Zitadel instance; clients in 1P (CUSTOMER_ZITADEL_OAUTH_*).
+  # Clients in 1P (CUSTOMER_ZITADEL_OAUTH_*).
   OIDC_ISSUER: https://external-prod-r5dlf0.us1.zitadel.cloud
 
-  # Beta gate: these email domains may sign up without an allowlist entry;
-  # everyone else needs a `yuctl users allowlist` entry or invite code.
+  # Beta gate: these domains sign up freely; others need `yuctl users allowlist` or invite code.
   ALLOWED_EMAIL_DOMAINS: futo.org
 
-  # admin-api host on the NetBird overlay (netops gateway wildcard); the
-  # admin OIDC redirect URIs derive from this (see base yucca-admin-api HR).
+  # The admin OIDC redirect URIs derive from this (see base yucca-admin-api HR).
   YUCCA_ADMIN_HOST: admin.father.fsn.htz.yucca.futo.network
 
-  # ─── Fleet topology ──────────────────────────────────────────────────
-  # Rendered into the yucca-topology ConfigMap (apps/base/topology), which
-  # yucca-api/admin-api/metrics-worker parse at boot. SITE_CODE and
-  # STORAGE_CLUSTER_CODE are IDENTIFIERS, not labels: they end up in repository
-  # rows and restic JWT claims, so changing one after launch orphans data.
-  # Codes are immutable internal identifiers; display names are presentation.
+  # SITE_CODE / STORAGE_CLUSTER_CODE are immutable identifiers (repository rows + restic
+  # JWT claims — changing one orphans data); display names are presentation.
   SITE_CODE: father
   SITE_DISPLAY_NAME: "Hetzner Falkenstein-1"
   SITE_DESCRIPTION: "Located in Falkenstein, Germany"
@@ -41,49 +32,38 @@ data:
   # the active write cluster changes.
   LEGACY_SITE_CODE: father
   LEGACY_STORAGE_CLUSTER_CODE: father-spice
-  # The vendor-stable discovery host: clients hard-code
-  # https://${META_HOST}/.well-known/yucca.json and learn everything else from
-  # there, so it must NOT move with the product domain. Own cert
-  # (meta-domain.yaml) — futo.cloud is outside the *.backups.futo.cloud
-  # wildcard; A record in tf/deployment/prod/global/dns.
+  # Clients hard-code this, so it must NOT move with the product domain. Own cert
+  # (outside the *.backups.futo.cloud wildcard); A record in tf/deployment/prod/global/dns.
   META_HOST: meta.futo.cloud
 
-  # ─── Ingress entry points ────────────────────────────────────────────
-  # App gateway (web/api): public pool-a VIP, BGP-advertised /32 covered by the
-  # 69.48.224.0/24 transit aggregate. lb: public selects pool-a.
+  # pool-a VIP, BGP-advertised /32 covered by the 69.48.224.0/24 transit aggregate.
   INGRESS_LB_LABEL: public
   INGRESS_VIP: 69.48.224.5
-  # Dedicated michael (restic) gateway — see apps/prod/htz-fsn1/gw-proxy.
   # externalTrafficPolicy: Local + one envoy per worker → spine ECMP.
   GW_PARENT_GATEWAY: gw
   GW_VIP: 69.48.224.6
-  # Internal (NetBird-zone) twin of the gw VIP: on-net clients (mgmt hosts,
-  # yuctl tools bench) can't reach the public aggregate from inside Hetzner.
-  # DNS: netbird dns.tf `gw` record; pool: lb-gw-internal in cilium-bgp.yaml.
+  # On-net clients can't reach the public aggregate from inside Hetzner.
+  # DNS: netbird dns.tf `gw`; pool: lb-gw-internal in cilium-bgp.yaml.
   GW_INT_VIP: 10.40.12.17
   GW_INT_HOST: gw.father.fsn.htz.yucca.futo.network
   GW_PROXY_REPLICAS: "3"
   # (netops keeps its own internal VIP, pinned at 10.40.12.16 in netops/.)
 
-  # ─── App fleet sizing ────────────────────────────────────────────────
-  # michael sized for the 60+ Gbps backup data plane (~4 per worker today;
-  # scale with the worker count). API is stateless behind the app gateway.
+  # michael sized for the 60+ Gbps backup data plane (~4 per worker; scale with the
+  # worker count).
   MICHAEL_REPLICAS: "12"
   API_REPLICAS: "3"
 
   # ACME registration contact for Let's Encrypt. TODO: real ops address.
   ACME_EMAIL: fubar-prod@futo.org
 
-  # ─── OpenEBS (shared apps/base/openebs, see the father openebs wrapper) ──
-  # Mayastor ON: openebs-replicated (repl=2) on the r-mayastor partitions.
+  # Mayastor: openebs-replicated (repl=2) on the r-mayastor partitions.
   # LocalPV on the u-localpv xfs partition (node-local; CNPG replicates itself).
   OPENEBS_MAYASTOR_ENABLED: "true"
   OPENEBS_HOSTPATH_CLASS_ENABLED: "true"
   OPENEBS_LOCALPV_BASEPATH: /var/mnt/localpv/hostpath
   OPENEBS_MAYASTOR_ETCD_BASEPATH: /var/mnt/openebs/etcd
 
-  # ─── Storage ─────────────────────────────────────────────────────────
-  # CNPG database PVs: LOCAL volumes on the u-localpv partition (see
-  # openebs/diskpools.yaml) — Postgres replicates itself; Mayastor is for
+  # Node-local u-localpv: Postgres replicates itself, so Mayastor is reserved for
   # workloads without app-level replication.
   DB_STORAGE_CLASS: openebs-hostpath

--- a/kubernetes/clusters/prod/htz-fsn1/flux-release.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/flux-release.yaml
@@ -1,16 +1,10 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/gitrepository_v1.json
 ---
-# RELEASE-PINNED source for prod's app tree + charts, one half of the prod pin
-# (the other is the image tag in image-versions.yaml). The root flux-system
-# GitRepository stays on main and syncs only this cluster entrypoint;
-# cluster-infra/cluster-apps and every chart build from THIS repository at the
-# tag below.
-#
-# Both pin lines are stamped by release-please in the release PR itself
-# (extra-files in release-please-config.json), so merging the release PR IS
-# the prod promotion — no promote workflow, no bot push, and the two halves
-# can't diverge. Roll back by reverting both stamped lines in a normal PR
-# (the old tag's images still exist in GHCR).
+# One half of the prod pin; the other is the image tag in image-versions.yaml. Root
+# flux-system stays on main and syncs only the cluster entrypoint. Both pin lines are
+# release-please-stamped in the release PR (extra-files in release-please-config.json),
+# so merging it IS the prod promotion and the halves can't diverge. Roll back by
+# reverting both stamped lines — old images persist in GHCR.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/kubernetes/clusters/prod/htz-fsn1/image-versions.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/image-versions.yaml
@@ -1,12 +1,8 @@
 ---
-# RELEASE-STAMPED image pin, the second half of the prod pin (the first is the
-# flux-release GitRepository tag — see flux-release.yaml). Both lines are
-# stamped by release-please in the release PR (extra-files in
-# release-please-config.json), so they can't diverge: merging the release PR
-# promotes manifests, charts, and images together. Roll back by reverting both
-# stamped lines in a normal PR. Kept DISJOINT from cluster-settings (human) +
-# generated (TF). Unlike staging's copy this is git-owned (no ssa annotation,
-# no in-cluster automation rewrites it).
+# Second half of the prod pin; the first is the flux-release tag. Both lines are
+# release-please-stamped in the same release PR so they can't diverge. Keys DISJOINT from
+# cluster-settings (human) + generated (TF). Unlike staging's copy this is git-owned —
+# no ssa annotation, no in-cluster automation rewrites it.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/clusters/staging/austin/apps.yaml
+++ b/kubernetes/clusters/staging/austin/apps.yaml
@@ -1,11 +1,9 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# cluster-apps entry point — the flux-instance sync (installed by the TF helm
-# module) points here (kubernetes/clusters/staging/austin). A single
-# Kustomization over kubernetes/apps/staging/austin, plus one patch that gives
-# EVERY child Kustomization a postBuild.substituteFrom over the three disjoint
-# settings ConfigMaps. Precedence (last wins): cluster-settings-generated (TF) ->
-# cluster-settings (human) -> image-versions (CI); keys are disjoint by design.
+# The flux-instance sync from the TF helm module points here. The patch below gives EVERY
+# child Kustomization postBuild.substituteFrom over the three settings ConfigMaps.
+# Precedence (last wins): cluster-settings-generated (TF) → cluster-settings (human) →
+# image-versions (CI); keys are disjoint by design.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -21,9 +19,8 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
-  # Direct objects (the nested Kustomization CRs) carry substitutable source
-  # refs (${MANIFEST_SOURCE:=flux-system}); staging keeps the default, but the
-  # substitution pass must run for the default to resolve.
+  # Nested Kustomization CRs carry ${MANIFEST_SOURCE:=flux-system}; staging keeps the
+  # default, but the substitution pass must run for the default to resolve.
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/staging/austin/cluster-settings.yaml
+++ b/kubernetes/clusters/staging/austin/cluster-settings.yaml
@@ -1,9 +1,6 @@
 ---
-# Per-cluster, HUMAN-managed settings. Injected into every child Kustomization
-# via the cluster-apps postBuild.substituteFrom patch (see apps.yaml). Neither CI
-# nor TF touch this file — image tags live in image-versions (CI), and derived
-# topology lives in cluster-settings.generated.yaml (TF). Keys here are disjoint
-# from those two.
+# Human-managed; keys disjoint from image-versions (CI) and
+# cluster-settings.generated.yaml (TF).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,16 +9,12 @@ metadata:
 data:
   OIDC_ISSUER: https://external-dev-gkhk8b.us1.zitadel.cloud
 
-  # Beta gate: these email domains may sign up without an allowlist entry;
-  # everyone else needs a `yuctl users allowlist` entry or invite code.
+  # Beta gate: these domains sign up freely; others need `yuctl users allowlist` or invite code.
   ALLOWED_EMAIL_DOMAINS: futo.org
 
-  # admin-api host on the NetBird overlay; the admin OIDC redirect URIs derive
-  # from this (see base yucca-admin-api HR).
+  # The admin OIDC redirect URIs derive from this (see base yucca-admin-api HR).
   YUCCA_ADMIN_HOST: admin.luke.aus.int.yucca.futo.network
 
-  # ─── Fleet topology ──────────────────────────────────────────────────
-  # Rendered into the yucca-topology ConfigMap (apps/base/topology), which
   # Codes are immutable internal identifiers; display names are presentation.
   SITE_CODE: luke
   SITE_DISPLAY_NAME: "Austin"
@@ -32,30 +25,24 @@ data:
   # the active write cluster changes.
   LEGACY_SITE_CODE: luke
   LEGACY_STORAGE_CLUSTER_CODE: luke-sietch
-  # Discovery host for the staging fleet. Unlike prod's meta.futo.cloud this
-  # one sits UNDER the app domain, so the existing *.${APP_DOMAIN} wildcard
-  # cert and DNS record already cover it — no extra cert/record needed.
+  # Sits UNDER the app domain (unlike prod's), so the *.${APP_DOMAIN} wildcard cert +
+  # DNS record already cover it.
   META_HOST: meta.staging.backups.futo.cloud
 
-  # ─── Ingress entry point ─────────────────────────────────────────────
-  # Internal VIP the in-cluster LB/Gateway announces (Cilium L2; distinct from
-  # the 10.10.10.15 control-plane API VIP). Public IP is the NAT in front of it,
-  # which staging.backups.futo.cloud resolves to publicly. The lb label is
-  # ignored here (the pool matches by IP annotation, no serviceSelector).
+  # Internal VIP announced via Cilium L2 (distinct from the 10.10.10.15 CP API VIP); the
+  # public IP is the NAT in front, which staging.backups.futo.cloud resolves to.
+  # lb label ignored here — the pool matches by IP annotation, no serviceSelector.
   INGRESS_LB_LABEL: internal
   INGRESS_VIP: 10.10.10.16
   INGRESS_PUBLIC_IP: 97.77.242.205
-  # Single shared gateway: michael's gw. route attaches to the app gateway
-  # (father runs a dedicated gw-proxy instead).
+  # michael's gw. route attaches to the app gateway; father runs a dedicated gw-proxy.
   GW_PARENT_GATEWAY: envoy
 
-  # ─── App fleet sizing ────────────────────────────────────────────────
   MICHAEL_REPLICAS: "2"
   API_REPLICAS: "2"
 
   # ACME registration contact for Let's Encrypt. TODO: real ops address.
   ACME_EMAIL: fubar-prod@futo.org
 
-  # ─── Storage ─────────────────────────────────────────────────────────
-  # CNPG database PVs: node-local NVMe via the overlay's spare-disk SC.
+  # Node-local NVMe via the overlay's spare-disk SC.
   DB_STORAGE_CLASS: openebs-spare-disk

--- a/kubernetes/clusters/staging/austin/image-versions.yaml
+++ b/kubernetes/clusters/staging/austin/image-versions.yaml
@@ -1,11 +1,9 @@
 ---
-# BOOTSTRAP-ONLY. This git copy exists so cluster-apps' postBuild substitution
-# has a source on a fresh cluster; after bootstrap the flux-operator ResourceSet
-# (apps/staging/austin/flux-system/image-automation.yaml) owns YUCCA_IMAGE_TAG,
-# rewriting it to the latest 0.0.<run> build tag from GHCR. The ssa annotation
-# below makes the git sync create-but-never-update this object — without it,
-# kustomize-controller force-reapplies `main` every minute and fights the
-# ResourceSet. Kept DISJOINT from cluster-settings (human) + generated (TF).
+# BOOTSTRAP-ONLY: gives cluster-apps' postBuild a source on a fresh cluster; afterwards
+# the flux-operator ResourceSet (apps/staging/austin/flux-system/image-automation.yaml)
+# owns YUCCA_IMAGE_TAG. The ssa annotation makes git sync create-but-never-update —
+# without it kustomize-controller reapplies `main` every minute and fights the ResourceSet.
+# Keys DISJOINT from cluster-settings (human) + generated (TF).
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/components/apps/meta.yaml
+++ b/kubernetes/components/apps/meta.yaml
@@ -6,8 +6,8 @@ metadata:
   name: yucca-meta
   namespace: flux-system
 spec:
-  # No dependsOn: the pointer is a static file, and it should come up (and stay
-  # up) even when the API behind the URL it advertises is down.
+  # No dependsOn, deliberately: it must come up and stay up even when the API behind
+  # the URL it advertises is down.
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/components/apps/michael.yaml
+++ b/kubernetes/components/apps/michael.yaml
@@ -6,9 +6,8 @@ metadata:
   name: michael
   namespace: flux-system
 spec:
-  # michael load-balances across the RGW daemons itself now (no HAProxy hop).
   dependsOn:
-    # Mounted at /etc/yucca — it must exist before the pods boot.
+    # Must exist before the pods boot — they parse it at startup.
     - name: yucca-topology
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/components/apps/namespace.yaml
+++ b/kubernetes/components/apps/namespace.yaml
@@ -4,10 +4,8 @@ kind: Namespace
 metadata:
   name: yucca
   labels:
-    # Enforce the restricted PodSecurity standard: this namespace holds the JWT
-    # signing key and S3 credentials — no root, no writable rootfs, no caps.
-    # The yucca-common chart's securityContext defaults comply; CNPG-operator
-    # pods are restricted-compliant by design.
+    # This ns holds the JWT signing key + S3 creds. The yucca-common chart's
+    # securityContext defaults comply; CNPG-operator pods are compliant by design.
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/audit: restricted

--- a/kubernetes/components/apps/networkpolicies.yaml
+++ b/kubernetes/components/apps/networkpolicies.yaml
@@ -1,24 +1,10 @@
 ---
-# Ingress-only network policies for the yucca namespace — the pods here hold
-# the JWT signing key, S3 credentials, and the database, so lateral movement
-# from any other compromised pod must not reach them. Egress is deliberately
-# NOT restricted in this pass (external RGW/OIDC/Polar egress needs FQDN rules
-# — a CiliumNetworkPolicy follow-up). Flow inventory:
-#   envoy (envoy-system)      → yucca-api:3020, web:5173, michael:3010,
-#                               meta:8080 (HTTPRoutes)
-#   yucca-api → michael       = hairpin via the ingress VIP, so it ARRIVES as
-#                               envoy traffic — no direct pod-to-pod allow needed
-#   web (SSR)                 → yucca-api:3020
-#   api/admin-api/worker      → CNPG pods :5432 (yucca-db-rw/-ro)
-#   CNPG replication          → CNPG pods :5432 (pod↔pod)
-#   cnpg-system operator      → CNPG pods :8000 (instance manager)
-#   admin-api / metrics-worker: NO inbound in this component (no HTTPRoute;
-#                               cron worker) — the default-deny is their whole
-#                               policy here. father additionally opens admin-api
-#                               to its netops gateway (apps/prod/htz-fsn1/netops/
-#                               httproutes.yaml, NetBird-only access).
-#   nothing scrapes this namespace; logs are collected node-side; kubelet
-#   probes are exempt from NetworkPolicy
+# Ingress-only. Egress deliberately unrestricted for now — external RGW/OIDC/Polar would
+# need FQDN rules (CiliumNetworkPolicy follow-up). yucca-api→michael hairpins via the
+# ingress VIP so it ARRIVES as envoy traffic, hence no pod-to-pod allow. admin-api and
+# metrics-worker get NO inbound rule: default-deny is their whole policy (father
+# additionally opens admin-api to its netops gateway, NetBird-only). Nothing scrapes this
+# ns, logs are collected node-side, and kubelet probes are NetworkPolicy-exempt.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -40,14 +26,14 @@ spec:
   policyTypes: [Ingress]
   ingress:
     - from:
-        # The app gateway's proxy pods (GatewayNamespace mode → envoy-system).
+        # The app gateway's proxy pods land here in GatewayNamespace mode.
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: envoy-system
           podSelector:
             matchLabels:
               app.kubernetes.io/name: envoy
-        # web's server-side rendering (YUCCA_API_URL=http://yucca-api:3020).
+        # web's server-side rendering.
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: web
@@ -108,8 +94,7 @@ spec:
   policyTypes: [Ingress]
   ingress:
     - from:
-        # Both public restic clients (${GW_HOST}) and yucca-api's hairpined
-        # RESTIC_ENDPOINT traffic arrive via the gateway.
+        # Both public restic clients and yucca-api's hairpinned traffic arrive via the gateway.
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: envoy-system
@@ -125,13 +110,12 @@ metadata:
   name: allow-ingress-database
   namespace: yucca
 spec:
-  # CNPG instance pods (primary + streaming replicas).
   podSelector:
     matchLabels:
       cnpg.io/cluster: yucca-db
   policyTypes: [Ingress]
   ingress:
-    # Postgres: the app set + instance↔instance streaming replication.
+    # The app set + instance↔instance streaming replication.
     - from:
         - podSelector:
             matchExpressions:
@@ -143,7 +127,7 @@ spec:
               cnpg.io/cluster: yucca-db
       ports:
         - { port: 5432, protocol: TCP }
-    # Instance-manager REST (status/reload) from the CNPG operator.
+    # Instance-manager REST (status/reload).
     - from:
         - namespaceSelector:
             matchLabels:

--- a/kubernetes/components/apps/topology.yaml
+++ b/kubernetes/components/apps/topology.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# Just the yucca-topology ConfigMap, but a Kustomization of its own so the
-# services that parse it at boot can dependsOn it — a pod that starts before
-# the ConfigMap exists sits in ContainerCreating, and one that starts against a
-# stale one silently serves the wrong rest_url.
+# Its own Kustomization so boot-time parsers can dependsOn it: starting before it exists
+# is ContainerCreating, and against a stale one is a silently wrong rest_url.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -15,8 +13,8 @@ spec:
   timeout: 5m
   path: ./kubernetes/apps/base/topology
   prune: true
-  # No healthChecks: `wait` alone is the gate (kstatus reports a ConfigMap
-  # Current as soon as it applies).
+  # No healthChecks: `wait` alone is the gate — kstatus reports a ConfigMap Current
+  # as soon as it applies.
   wait: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/components/apps/yucca-admin-api.yaml
+++ b/kubernetes/components/apps/yucca-admin-api.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dependsOn:
     - name: yucca-database
-    # Mounted at /etc/yucca — it must exist before the pods boot.
+    # Must exist before the pods boot — they parse it at startup.
     - name: yucca-topology
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/components/apps/yucca-api.yaml
+++ b/kubernetes/components/apps/yucca-api.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dependsOn:
     - name: yucca-database
-    # Mounted at /etc/yucca — it must exist before the pods boot.
+    # Must exist before the pods boot — they parse it at startup.
     - name: yucca-topology
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/components/apps/yucca-metrics-worker.yaml
+++ b/kubernetes/components/apps/yucca-metrics-worker.yaml
@@ -6,9 +6,7 @@ metadata:
   name: yucca-metrics-worker
   namespace: flux-system
 spec:
-  # Shares yucca-api's database; needs the CNPG app Secret to exist. The
-  # topology ConfigMap (rgw_admin_endpoint per storage cluster) is mounted at
-  # /etc/yucca, so it has to land first too.
+  # Needs the CNPG app Secret and the topology ConfigMap to exist before it boots.
   dependsOn:
     - name: yucca-database
     - name: yucca-topology

--- a/kubernetes/components/common/kustomization.yaml
+++ b/kubernetes/components/common/kustomization.yaml
@@ -1,6 +1,5 @@
-# Reusable Kustomize component. Reserved for cross-app concerns that should be
-# applied uniformly (e.g. common labels, a shared ExternalSecret store ref).
-# Consume from an app's app/kustomization.yaml via:
+# Reserved for cross-app concerns applied uniformly (common labels, a shared
+# ExternalSecret store ref). Consume via:
 #   components: [../../../../components/common]
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component

--- a/kubernetes/components/infra/kustomization.yaml
+++ b/kubernetes/components/infra/kustomization.yaml
@@ -1,12 +1,5 @@
-# Role-INDEPENDENT per-cluster infrastructure. Every cluster overlay pulls this
-# in via `components: [../../../components/infra, ...]`, regardless of whether
-# the region is primary or secondary. These are the platform layers the apps sit
-# on: the CNPG operator, node-local storage (OpenEBS LocalPV), the network/ingress stack
-# (cert-manager, cilium-lb, envoy gateway/proxy, httproutes, netbird-operator),
-# and observability agents (vmagent, victoria-logs-collector).
-#
-# Each entry is itself a kustomize Kustomization of Flux Kustomizations pointing
-# at apps/base/<x>; the Component just accumulates them into the overlay.
+# Role-INDEPENDENT: pulled in by every overlay, primary or secondary. Each entry is a
+# kustomize Kustomization of Flux Kustomizations over apps/base/<x>.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/kubernetes/components/infra/network/httproutes.yaml
+++ b/kubernetes/components/infra/network/httproutes.yaml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
-# HTTPRoutes live in the yucca namespace (alongside their backend Services) and
-# attach to the envoy Gateway. Reconciled after the Gateway + the app Services.
+# In the yucca namespace, alongside their backend Services.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/components/infra/network/kustomization.yaml
+++ b/kubernetes/components/infra/network/kustomization.yaml
@@ -5,10 +5,8 @@ resources:
   - ./namespace.yaml
   - ./cert-manager.yaml
   - ./cert-manager-issuer.yaml
-  # LB IP pools + announcement are CLUSTER TOPOLOGY, not shared infra: staging
-  # defines its L2/ARP pool in its overlay (cilium-lb.yaml), father its BGP
-  # pools in cilium-bgp.yaml. A shared pool here would CIDR-overlap father's
-  # lb-internal /24 and Cilium marks overlapping pools Conflicting.
+  # LB IP pools are per-cluster, not shared infra: a shared pool would CIDR-overlap
+  # father's lb-internal /24 (overlapping pools → Conflicting).
   - ./envoy-gateway.yaml
   - ./envoy-proxy.yaml
   - ./httproutes.yaml

--- a/kubernetes/components/infra/network/namespace.yaml
+++ b/kubernetes/components/infra/network/namespace.yaml
@@ -13,7 +13,6 @@ metadata:
   name: envoy-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-# NB: the `netbird` namespace is NOT declared here — it's created by the
-# staging/talos TF stack (secrets.tf), which bootstraps the netbird-mgmt-api-key
-# Secret into it before Flux reconciles. Declaring it here too would race TF for
-# ownership and 409 on apply, so TF is the sole creator.
+# The `netbird` ns is NOT declared here — the staging/talos TF stack (secrets.tf) creates
+# it and bootstraps the netbird-mgmt-api-key Secret before Flux reconciles; declaring it
+# here too would race TF for ownership and 409.

--- a/kubernetes/components/infra/network/netbird-operator.yaml
+++ b/kubernetes/components/infra/network/netbird-operator.yaml
@@ -6,8 +6,8 @@ metadata:
   name: netbird-operator
   namespace: flux-system
 spec:
-  # cert-manager must be Ready first: the operator provisions its admission
-  # webhook certs through it (webhook.enableCertManager).
+  # The operator provisions its admission webhook certs through cert-manager
+  # (webhook.enableCertManager), so it must be Ready first.
   dependsOn:
     - name: cert-manager
   healthChecks:

--- a/kubernetes/components/infra/observability/namespace.yaml
+++ b/kubernetes/components/infra/observability/namespace.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: observability
-  # victoria-logs-collector is a DaemonSet that hostPath-mounts /var/log to tail
-  # pod logs — forbidden under Talos' default `baseline` PSS, so enforce privileged.
+  # victoria-logs-collector hostPath-mounts /var/log, forbidden under Talos' default
+  # `baseline` PSS.
   labels:
     pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/components/infra/observability/networkpolicies.yaml
+++ b/kubernetes/components/infra/observability/networkpolicies.yaml
@@ -1,9 +1,6 @@
 ---
-# Ingress-only network policies for observability. Inbound surface: OTLP
-# metric pushes from the yucca apps into the vmagent (vmagent-yucca:8429) and
-# the apiserver's calls to the VM-operator admission webhook. The
-# victoria-logs-collector DaemonSet tails logs node-side and only pushes
-# outward — no ingress needed.
+# Ingress-only. victoria-logs-collector tails node-side and only pushes outward, so it
+# needs no ingress rule.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -32,7 +29,7 @@ metadata:
   name: allow-otlp-ingest
   namespace: observability
 spec:
-  # VM-operator-managed VMAgent pods (CR `yucca` via fullnameOverride).
+  # The CR is named `yucca` via fullnameOverride.
   podSelector:
     matchLabels:
       app.kubernetes.io/name: vmagent
@@ -51,10 +48,9 @@ metadata:
   name: allow-vm-operator-webhook
   namespace: observability
 spec:
-  # The apiserver must reach the k8s-stack's VM-operator admission webhook or
-  # every VM CR write starts failing admission. The apiserver is NOT a pod
-  # (hcloud CPs / host network), so it can't be namespace-selected — allow the
-  # webhook port from anywhere.
+  # The apiserver must reach the VM-operator admission webhook or every VM CR write
+  # starts failing admission — and it is NOT a pod (hcloud CPs / host network), so it
+  # can't be namespace-selected.
   podSelector:
     matchLabels:
       app.kubernetes.io/name: victoria-metrics-operator

--- a/kubernetes/components/infra/storage/namespace.yaml
+++ b/kubernetes/components/infra/storage/namespace.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: openebs-system
   labels:
-    # OpenEBS localpv provisioner + helper pods run privileged (hostpath).
+    # The localpv provisioner + helper pods need hostpath.
     pod-security.kubernetes.io/enforce: privileged
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/components/roles/primary/kustomization.yaml
+++ b/kubernetes/components/roles/primary/kustomization.yaml
@@ -1,12 +1,6 @@
-# PRIMARY region app set. A partition's primary region runs the FULL stack: the
-# control-plane services (yucca-api, yucca-admin-api, web) and the database live
-# ONLY here (product invariant: api + DB run in the primary region), alongside
-# the storage-region-local services (michael, metrics-worker).
-#
-# Selected compile-time by a cluster overlay via:
-#   components: [../../../components/infra, ../../../components/roles/primary]
-# kept in lockstep with the runtime CLUSTER_ROLE=primary from the generated
-# cluster-settings fragment (a validate check enforces the pairing).
+# Control-plane services + database live ONLY in a primary region (product invariant).
+# Selected compile-time by an overlay, in lockstep with runtime CLUSTER_ROLE=primary —
+# a validate check enforces the pairing.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/kubernetes/components/roles/secondary/kustomization.yaml
+++ b/kubernetes/components/roles/secondary/kustomization.yaml
@@ -1,30 +1,16 @@
-# SECONDARY region app set. A partition's secondary region runs only the
-# storage-region-local services that sit next to *that* region's Ceph/S3 —
-# michael (restic gateway) and the metrics-worker. It runs NO api/admin/db/web:
-# those stay in the primary region (product invariant).
-#
-# Selected compile-time by a cluster overlay via:
-#   components: [../../../components/infra, ../../../components/roles/secondary]
-# kept in lockstep with the runtime CLUSTER_ROLE=secondary from the generated
-# cluster-settings fragment.
-#
-# No partition spans two regions yet, so no overlay currently selects this role —
-# it is built ahead of need (per plan §2.2). The region-local Ceph object-users
-# (charts/platform/ceph-objectuser) join here once per-region in-cluster Rook
-# lands; today both real clusters reach an EXTERNAL Ceph (sietch) over S3, so no
-# CephObjectStoreUser CR is reconciled on-cluster and none exists under
-# apps/base yet.
+# NO api/admin/db/web here — those stay in the primary region (product invariant).
+# Selected compile-time by an overlay, in lockstep with runtime CLUSTER_ROLE=secondary.
+# No overlay selects this yet: no partition spans two regions, and both real clusters
+# reach EXTERNAL Ceph (sietch) over S3, so there is no CephObjectStoreUser CR under
+# apps/base to make region-local.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - ../../apps/namespace.yaml
   - ../../apps/topology.yaml
-  # Policies referencing apps a secondary doesn't run are inert (selectors
-  # match nothing); the default-deny + michael/db rules are what matter here.
+  # Policies referencing apps a secondary doesn't run are inert — selectors match nothing.
   - ../../apps/networkpolicies.yaml
   - ../../apps/michael.yaml
-  # NOT yucca-metrics-worker: its Kustomization dependsOn yucca-database, which
-  # secondary never deploys (it would wedge permanently on "dependency not
-  # found"), and the chart hard-wires POSTGRES_* from the absent yucca-db-app
-  # Secret. Re-add once the secondary metrics design exists (region-local
-  # metering without the primary DB).
+  # NOT yucca-metrics-worker: it dependsOn yucca-database (never deployed on a secondary
+  # → permanent "dependency not found") and hard-wires POSTGRES_* from the absent
+  # yucca-db-app Secret.


### PR DESCRIPTION
Comment-only pass over `kubernetes/` and `charts/`. Non-machine-read comment lines 916 -> 592 in the final sweep.

**Deleted:** scrape-job and `# --- Fleet topology / Storage / Ingress ---` dividers, value labels the key already gives (`# OIDC provider in-cluster service`, `# CNPG-managed postgres Cluster name`), dependency labels carrying no why, and headers that summarise the manifests below.

**Kept:**
- Incidents with dates: the 2026-07 fresh-cluster dry-run deadlock (why infra/apps are split), the 2026-07-06 namespace prune and sFlow silent loss, the netbird-operator webhook cascade, vmagent 512Mi OOM (269 restarts in 6 days), the 17h victoria-logs-collector crash loop, hyperglass 192-worker OOM.
- Contracts: `fullnameOverride` DNS parity between Tilt and Flux, envFrom last-source-wins, substitution precedence, the `ssa` bootstrap note, and both halves of the release-please double-pin.
- Provenance not present in the value: `op://` item paths and the netops VIPs.

**Salvage rather than delete:** the coredns scrape label was dropped but its non-obvious part kept on the target itself -- `# :9153 = coredns metrics, not DNS`.

**Verification:** diff is comment-content only; all 115 changed non-template YAML files re-parse under `yq`; `helm template` renders `charts/apps/yucca-api` (exercising `lib/yucca-common`) and `charts/platform/rook-ceph-cluster`. `# yaml-language-server:`, `# x-release-please-version` and renovate annotations are byte-identical. No cluster contact.