### PR TITLE
chore(go): trim narration from comments

### DIFF
--- a/packages/michael/e2e_test.go
+++ b/packages/michael/e2e_test.go
@@ -1,25 +1,10 @@
 //go:build e2e
 
-// Package e2e test: proves the load-balancing Pool works end-to-end against the
-// REAL Ceph RGW running in the local k3d cluster.
-//
-// The harness (.mise/tasks/michael/test/e2e) port-forwards svc/rook-ceph-rgw-yucca
-// to S3_ENDPOINT and exports the michael object-user credentials. This test then:
-//
-//  1. Fronts that single real RGW with TWO in-process transparent TCP proxies.
-//     Both forward to the same Ceph store, so they are interchangeable backends —
-//     exactly the production model (multiple RGW gateways, one object store).
-//  2. Builds the michael Pool over the two proxy endpoints and runs the full
-//     restic blob workflow through michael's real HTTP handler stack. Data really
-//     lands in k3d's Ceph.
-//  3. Asserts traffic spreads across both backends (least-outstanding balancing).
-//  4. Fails one proxy and proves active-probe ejection + that the workflow keeps
-//     working through the survivor, then restores it and proves reinstatement.
-//  5. Proves passive ejection (consecutive request failures) independently.
-//
-// A second test reuses the same harness for claim-based cluster routing: the two
-// proxies become two SEPARATE storage clusters, and the token's storageCluster
-// claim decides which one serves each request.
+// Drives the load-balancing Pool against the real Ceph RGW in the local k3d
+// cluster. The harness (.mise/tasks/michael/test/e2e) port-forwards
+// svc/rook-ceph-rgw-yucca to S3_ENDPOINT and exports the michael object-user
+// credentials; two in-process TCP proxies front the one RGW as interchangeable
+// backends (the production model: many gateways, one store).
 package main
 
 import (
@@ -94,9 +79,8 @@ func e2eJWT(t *testing.T, repo string, writeOnce bool) string {
 	return e2eJWTForCluster(t, repo, writeOnce, "")
 }
 
-// e2eJWTForCluster mints a token carrying an explicit storageCluster claim.
-// An empty storageCluster omits the claim entirely — the shape of a token
-// minted before multi-cluster routing existed.
+// e2eJWTForCluster mints a token with an explicit storageCluster claim; empty
+// omits the claim entirely (pre-multi-cluster token shape).
 func e2eJWTForCluster(t *testing.T, repo string, writeOnce bool, storageCluster string) string {
 	t.Helper()
 	claims := jwt.MapClaims{
@@ -116,13 +100,9 @@ func e2eJWTForCluster(t *testing.T, repo string, writeOnce bool, storageCluster 
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte("restic:"+signed))
 }
 
-// --- controllable transparent TCP proxy ---
-
-// tcpProxy forwards raw TCP to a target. Failing it both refuses NEW
-// connections and tears down LIVE ones — the latter matters because the S3
-// client keeps keep-alive connections pooled, and dropping only new connections
-// would let a probe sail through a reused connection. Together this faithfully
-// simulates a dead gateway (transport failure on every request).
+// tcpProxy forwards raw TCP. Failing it refuses NEW connections AND tears down
+// LIVE ones — pooled keep-alive connections would otherwise let a probe sail
+// through; together this simulates a dead gateway (transport failure everywhere).
 type tcpProxy struct {
 	ln     net.Listener
 	target string
@@ -208,8 +188,6 @@ func (p *tcpProxy) pipe(client net.Conn) {
 
 func (p *tcpProxy) close() { _ = p.ln.Close() }
 
-// --- helpers ---
-
 func targetHostPort(t *testing.T, endpoint string) string {
 	t.Helper()
 	u, err := url.Parse(endpoint)
@@ -279,8 +257,6 @@ func mustStatus(t *testing.T, resp *http.Response, want int, what string) {
 	}
 }
 
-// rawClient builds an S3 client straight to the real RGW (not via the proxies),
-// used only for test bucket cleanup.
 func rawClient(cfg config.Config) *s3.Client {
 	return s3.New(s3.Options{
 		Region:       cfg.S3Region,
@@ -305,7 +281,6 @@ func cleanupBucket(t *testing.T, cfg config.Config, bucket string) {
 	}
 }
 
-// healthyCount returns how many backends in the pool are currently healthy.
 func healthyCount(p *storage.Pool) int {
 	n := 0
 	for _, s := range p.Stats() {
@@ -325,12 +300,10 @@ func statByEndpoint(p *storage.Pool, endpoint string) (storage.BackendStat, bool
 	return storage.BackendStat{}, false
 }
 
-// TestE2E_PoolAgainstRealRGW is the full end-to-end proof.
 func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	cfg := e2eConfig(t)
 	target := targetHostPort(t, cfg.S3Endpoint)
 
-	// Two interchangeable backends, both proxying to the same real RGW.
 	pa := newTCPProxy(t, target)
 	pb := newTCPProxy(t, target)
 	defer pa.close()
@@ -352,7 +325,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	client := srv.Client()
 	auth := e2eJWT(t, repo, false)
 
-	// ---- Phase 1: full restic workflow through the pool, real data to Ceph ----
 	resp := do(t, client, http.MethodPost, srv.URL+"/"+repo+"/?create=true", auth, nil)
 	mustStatus(t, resp, http.StatusOK, "create repo")
 	resp.Body.Close()
@@ -395,7 +367,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 		}
 	}
 
-	// List blobs (restic v2).
 	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/"+repo+"/data", nil)
 	req.Header.Set("Authorization", auth)
 	req.Header.Set("Accept", handlers.ContentTypeResticV2)
@@ -410,7 +381,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 		t.Fatalf("list: expected %d blobs, got %d", len(blobNames), len(listed))
 	}
 
-	// Assert the load balancer actually spread traffic across BOTH backends.
 	sa, _ := statByEndpoint(pool, pa.url())
 	sb, _ := statByEndpoint(pool, pb.url())
 	t.Logf("balancing: backend A served %d reqs (%d up / %d down bytes), backend B served %d reqs (%d up / %d down)",
@@ -419,7 +389,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 		t.Fatalf("expected both backends to serve traffic, got A=%d B=%d", sa.Requests, sb.Requests)
 	}
 
-	// ---- Phase 2: active-probe ejection; workflow continues via survivor ----
 	pa.setFailed(true)
 	if err := pool.Reconcile(context.Background()); err != nil {
 		t.Logf("reconcile resolver note: %v", err)
@@ -432,7 +401,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	}
 	t.Log("backend A ejected via active probe; routing only to B")
 
-	// All operations still succeed through the surviving backend.
 	data := []byte("blob written while A is down")
 	sum := sha256.Sum256(data)
 	name := hex.EncodeToString(sum[:])
@@ -445,7 +413,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	resp.Body.Close()
 	t.Log("workflow continued successfully while A was ejected")
 
-	// ---- Phase 3: reinstatement ----
 	pa.setFailed(false)
 	if err := pool.Reconcile(context.Background()); err != nil {
 		t.Logf("reconcile note: %v", err)
@@ -455,10 +422,9 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	}
 	t.Log("backend A reinstated via active probe; both healthy again")
 
-	// ---- Phase 4: passive ejection (consecutive request failures) ----
 	pb.setFailed(true)
-	// Hit backend B directly until its consecutive-failure streak trips ejection.
-	// (Some calls land on A and succeed; B's per-backend streak is what matters.)
+	// Some calls land on A and succeed; B's per-backend failure streak is what
+	// trips ejection.
 	ejected := false
 	for i := range 12 {
 		_, _ = pool.HeadObject(context.Background(), repo, "config")
@@ -480,7 +446,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	}
 	t.Log("backend B reinstated; e2e proof complete")
 
-	// ---- cleanup of created blobs/config (bucket removed by deferred cleanup) ----
 	for _, n := range blobNames {
 		resp = do(t, client, http.MethodDelete, srv.URL+"/"+repo+"/data/"+n, auth, nil)
 		resp.Body.Close()
@@ -489,7 +454,6 @@ func TestE2E_PoolAgainstRealRGW(t *testing.T) {
 	resp.Body.Close()
 }
 
-// totalRequests sums the requests every backend in a pool has served.
 func totalRequests(p *storage.Pool) int64 {
 	var n int64
 	for _, s := range p.Stats() {
@@ -498,12 +462,6 @@ func totalRequests(p *storage.Pool) int64 {
 	return n
 }
 
-// TestE2E_ClusterRoutingAgainstRealRGW proves claim-based routing end-to-end:
-// michael fronts TWO storage clusters (each a one-backend pool over its own TCP
-// proxy to the real RGW) and the token's storageCluster claim decides which one
-// serves the request. Both proxies reach the same Ceph — what is under test is
-// which cluster's pool the traffic went through, which the per-pool request
-// counters show exactly.
 func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	cfg := e2eConfig(t)
 	target := targetHostPort(t, cfg.S3Endpoint)
@@ -528,7 +486,6 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	defer srv.Close()
 	client := srv.Client()
 
-	// A repository is a bucket, so each cluster gets its own to write into.
 	runWorkflow := func(repo, auth string) {
 		t.Helper()
 		resp := do(t, client, http.MethodPost, srv.URL+"/"+repo+"/?create=true", auth, nil)
@@ -549,7 +506,6 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 		}
 	}
 
-	// ---- A token with NO claim must be served by the default cluster ----
 	beforeDefault, beforeSpice := totalRequests(defaultPool), totalRequests(spicePool)
 	runWorkflow(defaultRepo, e2eJWT(t, defaultRepo, false))
 	if totalRequests(defaultPool) <= beforeDefault {
@@ -560,7 +516,6 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	}
 	t.Log("legacy (claimless) token routed to the default cluster")
 
-	// ---- A token claiming "spice" must be served by that cluster ----
 	beforeDefault, beforeSpice = totalRequests(defaultPool), totalRequests(spicePool)
 	runWorkflow(spiceRepo, e2eJWTForCluster(t, spiceRepo, false, "spice"))
 	if totalRequests(spicePool) <= beforeSpice {
@@ -571,7 +526,7 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	}
 	t.Log("storageCluster=spice routed to the spice cluster")
 
-	// ---- A claim naming a cluster michael doesn't front must fail closed ----
+	// A claim naming a cluster michael doesn't front must fail closed.
 	beforeDefault, beforeSpice = totalRequests(defaultPool), totalRequests(spicePool)
 	unknown := e2eJWTForCluster(t, defaultRepo, false, "sietch")
 	resp := do(t, client, http.MethodGet, srv.URL+"/"+defaultRepo+"/config", unknown, nil)
@@ -582,7 +537,6 @@ func TestE2E_ClusterRoutingAgainstRealRGW(t *testing.T) {
 	}
 	t.Log("unknown storageCluster rejected with 400 and no backend traffic")
 
-	// ---- cleanup (buckets removed by the deferred cleanups) ----
 	for repo, auth := range map[string]string{
 		defaultRepo: e2eJWT(t, defaultRepo, false),
 		spiceRepo:   e2eJWTForCluster(t, spiceRepo, false, "spice"),

--- a/packages/michael/integration_test.go
+++ b/packages/michael/integration_test.go
@@ -36,13 +36,13 @@ const (
 
 func integrationConfig() config.Config {
 	return config.Config{
-		Port:             3010,
-		JWTPublicKey:     testPublicKey,
-		S3AccessKeyID:    envOrDefault("S3_ACCESS_KEY_ID", "minio"),
+		Port:              3010,
+		JWTPublicKey:      testPublicKey,
+		S3AccessKeyID:     envOrDefault("S3_ACCESS_KEY_ID", "minio"),
 		S3SecretAccessKey: envOrDefault("S3_SECRET_ACCESS_KEY", "miniominio"),
-		S3Region:         envOrDefault("S3_REGION", "minio"),
-		S3Endpoint:       envOrDefault("S3_ENDPOINT", "http://localhost:9000"),
-		S3ForcePathStyle: true,
+		S3Region:          envOrDefault("S3_REGION", "minio"),
+		S3Endpoint:        envOrDefault("S3_ENDPOINT", "http://localhost:9000"),
+		S3ForcePathStyle:  true,
 	}
 }
 
@@ -85,7 +85,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 
 	client := ts.Client()
 
-	// 1. Create repository
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/"+repo+"/?create=true", nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err := client.Do(req)
@@ -97,7 +96,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Fatalf("create repo: expected 200, got %d", resp.StatusCode)
 	}
 
-	// 2. Create again → 409
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/"+repo+"/?create=true", nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -109,7 +107,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Fatalf("create repo again: expected 409, got %d", resp.StatusCode)
 	}
 
-	// 3. Save config
 	configData := []byte("test-config-data")
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/"+repo+"/config", bytes.NewReader(configData))
 	req.Header.Set("Authorization", authHeader)
@@ -122,7 +119,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Fatalf("save config: expected 200, got %d", resp.StatusCode)
 	}
 
-	// 4. Check config
 	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/"+repo+"/config", nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -134,7 +130,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Fatalf("check config: expected 200, got %d", resp.StatusCode)
 	}
 
-	// 5. Get config
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/"+repo+"/config", nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -150,7 +145,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Errorf("get config: expected %q, got %q", configData, body)
 	}
 
-	// 6. Save a blob
 	blobData := []byte("hello world blob data for testing")
 	hash := sha256.Sum256(blobData)
 	blobName := hex.EncodeToString(hash[:])
@@ -166,7 +160,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Fatalf("save blob: expected 200, got %d", resp.StatusCode)
 	}
 
-	// 7. Check blob
 	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/"+repo+"/data/"+blobName, nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -181,7 +174,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Errorf("check blob: expected Content-Length %d, got %s", len(blobData), cl)
 	}
 
-	// 8. Get blob
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/"+repo+"/data/"+blobName, nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -197,7 +189,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Errorf("get blob: expected %q, got %q", blobData, body)
 	}
 
-	// 9. List blobs
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/"+repo+"/data", nil)
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Accept", handlers.ContentTypeResticV2)
@@ -218,7 +209,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Errorf("list blobs: expected name %s, got %s", blobName, blobs[0].Name)
 	}
 
-	// 10. Delete blob
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/"+repo+"/data/"+blobName, nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -230,7 +220,6 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		t.Fatalf("delete blob: expected 200, got %d", resp.StatusCode)
 	}
 
-	// 11. Delete config
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/"+repo+"/config", nil)
 	req.Header.Set("Authorization", authHeader)
 	resp, err = client.Do(req)
@@ -258,7 +247,6 @@ func TestIntegration_WORM(t *testing.T) {
 
 	client := ts.Client()
 
-	// Create repo
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/"+repo+"/?create=true", nil)
 	req.Header.Set("Authorization", normalAuth)
 	resp, err := client.Do(req)
@@ -267,7 +255,6 @@ func TestIntegration_WORM(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	// Save config with WORM
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/"+repo+"/config", bytes.NewReader([]byte("worm-config")))
 	req.Header.Set("Authorization", wormAuthHeader)
 	resp, err = client.Do(req)
@@ -279,7 +266,6 @@ func TestIntegration_WORM(t *testing.T) {
 		t.Fatalf("save config: expected 200, got %d", resp.StatusCode)
 	}
 
-	// Delete config with WORM → 403
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/"+repo+"/config", nil)
 	req.Header.Set("Authorization", wormAuthHeader)
 	resp, err = client.Do(req)
@@ -291,7 +277,6 @@ func TestIntegration_WORM(t *testing.T) {
 		t.Errorf("delete config worm: expected 403, got %d", resp.StatusCode)
 	}
 
-	// Save blob with WORM
 	blobData := []byte("worm blob data for testing")
 	hash := sha256.Sum256(blobData)
 	blobName := hex.EncodeToString(hash[:])
@@ -307,7 +292,6 @@ func TestIntegration_WORM(t *testing.T) {
 		t.Fatalf("save blob: expected 200, got %d", resp.StatusCode)
 	}
 
-	// Delete blob with WORM → 403
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/"+repo+"/data/"+blobName, nil)
 	req.Header.Set("Authorization", wormAuthHeader)
 	resp, err = client.Do(req)
@@ -319,7 +303,6 @@ func TestIntegration_WORM(t *testing.T) {
 		t.Errorf("delete blob worm: expected 403, got %d", resp.StatusCode)
 	}
 
-	// Save lock blob
 	lockData := []byte("lock data for testing worm exemption")
 	lockHash := sha256.Sum256(lockData)
 	lockName := hex.EncodeToString(lockHash[:])
@@ -332,7 +315,6 @@ func TestIntegration_WORM(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	// Delete lock with WORM → should succeed (locks exempt)
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/"+repo+"/locks/"+lockName, nil)
 	req.Header.Set("Authorization", wormAuthHeader)
 	resp, err = client.Do(req)

--- a/packages/michael/internal/auth/auth.go
+++ b/packages/michael/internal/auth/auth.go
@@ -33,7 +33,6 @@ type contextKey string
 
 const authContextKey contextKey = "auth"
 
-// NewContext returns a new context with the given Auth value.
 func NewContext(ctx context.Context, a Auth) context.Context {
 	return context.WithValue(ctx, authContextKey, a)
 }
@@ -53,18 +52,17 @@ const (
 	defaultCacheTTL = 5 * time.Minute
 )
 
-// Verifier authenticates requests, caching verified tokens so the hot path is
-// a map lookup instead of an ECDSA verify per request (restic reuses one token
-// for a whole session). Only signature-valid tokens enter the cache, and
-// entries expire with the token's exp claim.
+// Verifier authenticates requests, caching verified tokens (restic reuses one
+// per session) so the hot path is a map lookup, not an ECDSA verify. Only
+// signature-valid tokens enter; entries expire with the token's exp claim.
 type Verifier struct {
 	publicKey *ecdsa.PublicKey
 	cache     *tokenCache
 	onLookup  func(hit bool)
 }
 
-// NewVerifier builds a Verifier. onLookup, if non-nil, is called with the
-// cache outcome of every authenticated request.
+// onLookup, if non-nil, is called with the cache outcome of every
+// authenticated request.
 func NewVerifier(publicKey *ecdsa.PublicKey, onLookup func(hit bool)) *Verifier {
 	return &Verifier{
 		publicKey: publicKey,
@@ -112,7 +110,6 @@ func (v *Verifier) Middleware() func(http.Handler) http.Handler {
 				return
 			}
 
-			// Validate path param matches auth repository
 			path := chi.URLParam(r, "path")
 			if path != "" && path != auth.Repository {
 				httputil.WriteError(w, r, http.StatusBadRequest, "Repository mismatch")
@@ -138,8 +135,7 @@ func (e *authError) Error() string {
 	return e.message
 }
 
-// extractAuth verifies the request's token and returns the Auth plus the
-// token's exp claim (zero if absent).
+// Returns the Auth plus the token's exp claim (zero if absent).
 func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, *authError) {
 	header := r.Header.Get("Authorization")
 	if header == "" {
@@ -153,7 +149,6 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, 
 	encoded := strings.TrimPrefix(header, "Basic ")
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		// Try URL-safe or raw encoding
 		decoded, err = base64.RawStdEncoding.DecodeString(encoded)
 		if err != nil {
 			return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid base64 in Authorization header"}
@@ -182,7 +177,6 @@ func extractAuth(r *http.Request, publicKey *ecdsa.PublicKey) (Auth, time.Time, 
 		return Auth{}, time.Time{}, &authError{http.StatusUnauthorized, "Invalid JWT claims"}
 	}
 
-	// Extract and validate auth fields
 	auth := Auth{}
 
 	user, ok := claims["user"].(string)

--- a/packages/michael/internal/auth/auth_test.go
+++ b/packages/michael/internal/auth/auth_test.go
@@ -192,7 +192,6 @@ func TestAuthOptionalClaims(t *testing.T) {
 func TestAuthMiddlewareRepoMismatch(t *testing.T) {
 	token := makeJWT(t, validClaims())
 
-	// Create a chi router to test the middleware with path params
 	r := chi.NewRouter()
 	r.Route("/{path}", func(r chi.Router) {
 		r.Use(Middleware(testPublicKey))
@@ -201,7 +200,6 @@ func TestAuthMiddlewareRepoMismatch(t *testing.T) {
 		})
 	})
 
-	// Use a different path than the repository in the JWT
 	req := httptest.NewRequest(http.MethodGet, "/wrong-repo-id/config", nil)
 	req.Header.Set("Authorization", makeBasicAuth(token))
 	rec := httptest.NewRecorder()

--- a/packages/michael/internal/auth/cluster_test.go
+++ b/packages/michael/internal/auth/cluster_test.go
@@ -67,9 +67,8 @@ func TestAuthStorageClusterInvalid(t *testing.T) {
 	}
 }
 
-// The token cache is keyed by the Authorization header, so two tokens differing
-// only in storageCluster must not share an entry — a collision would serve one
-// user's repository out of another cluster.
+// Cache is keyed by the Authorization header: tokens differing only in
+// storageCluster must not collide — that would serve a repo from another cluster.
 func TestVerifierCacheKeepsClustersDistinct(t *testing.T) {
 	v := NewVerifier(testPublicKey, nil)
 

--- a/packages/michael/internal/cluster/cluster.go
+++ b/packages/michael/internal/cluster/cluster.go
@@ -1,28 +1,17 @@
-// Package cluster names the storage clusters a single michael fronts.
-//
-// One michael serves a site backed by one or more Ceph clusters. A restic
-// token's optional storageCluster claim selects which of them a request is
-// served from; tokens minted before multi-cluster existed carry no claim and
-// route to DefaultCode.
 package cluster
 
 import "regexp"
 
-// DefaultCode is the code assigned to the cluster described by michael's flat
-// S3_* environment variables, and the cluster a token with no storageCluster
-// claim routes to. Overridable via S3_DEFAULT_CLUSTER.
+// DefaultCode names the flat-S3_* cluster, where claimless tokens route.
+// Overridable via S3_DEFAULT_CLUSTER.
 const DefaultCode = "default"
 
-// codePattern is deliberately narrow: a cluster code arrives in a JWT claim and
-// becomes both a map key and a metric label, so it must not be able to carry
-// path separators, whitespace, or unbounded length.
+// codePattern is deliberately narrow: the code arrives in a JWT claim and
+// becomes a map key + metric label — no separators, whitespace, or unbounded length.
 var codePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
 
-// CodePattern is the human-readable form of the code charset, for error
-// messages.
 const CodePattern = `^[a-z0-9][a-z0-9-]{0,63}$`
 
-// IsValidCode reports whether s is a well-formed storage cluster code.
 func IsValidCode(s string) bool {
 	return codePattern.MatchString(s)
 }

--- a/packages/michael/internal/config/clusters_test.go
+++ b/packages/michael/internal/config/clusters_test.go
@@ -82,9 +82,8 @@ func TestParseClustersFull(t *testing.T) {
 	}
 }
 
-// Unset knobs inherit the default cluster, EXCEPT the backend source, which
-// must not be inherited: pointing a new cluster at the default cluster's
-// gateways would serve its repositories from the wrong Ceph.
+// Unset knobs inherit the default cluster EXCEPT the backend source —
+// inheriting it would serve repositories from the wrong Ceph.
 func TestParseClustersInheritsDefaults(t *testing.T) {
 	doc := `{"clusters":[{"code":"spice","endpoint":"http://s3.spice.example","access_key_env":"K","secret_key_env":"S"}]}`
 

--- a/packages/michael/internal/config/config.go
+++ b/packages/michael/internal/config/config.go
@@ -29,9 +29,8 @@ type Config struct {
 	S3Endpoint        string
 	S3ForcePathStyle  bool
 
-	// S3 load-balancing pool. When S3BackendSource is empty, michael talks to
-	// the single S3Endpoint (legacy behavior). When set to "file" or "dns", it
-	// balances across the resolved backend gateways instead.
+	// S3 load-balancing pool. Empty S3BackendSource = single S3Endpoint
+	// (legacy); "file"/"dns" = balance across resolved gateways.
 	S3BackendSource     string // "" | "file" | "dns"
 	S3BackendFile       string // path, for source=file
 	S3BackendDNSHost    string // hostname to resolve, for source=dns
@@ -43,20 +42,18 @@ type Config struct {
 	S3EjectThreshold    int    // consecutive transport failures before ejection
 	S3ReconcileInterval time.Duration
 
-	// S3DefaultCluster is the code of the storage cluster the flat S3_* fields
-	// above describe. Requests whose token carries no storageCluster claim are
-	// served from it.
+	// S3DefaultCluster: cluster the flat S3_* fields describe; serves tokens
+	// without a storageCluster claim.
 	S3DefaultCluster string
 	// Clusters is every storage cluster this michael fronts, the default one
 	// first, followed by any declared in S3_CLUSTERS_FILE.
 	Clusters []ClusterConfig
 
-	// ASNDatabasePath is the MaxMind-format IP→ASN database used to label
-	// traffic with its source network. The image bakes one in; a deployment
-	// without it still serves, with every source network reported as unknown.
+	// ASNDatabasePath: MaxMind-format IP→ASN DB (baked into the image); absent
+	// still serves, with every source network reported unknown.
 	ASNDatabasePath string
-	// ClientIPHeader is the header the gateway writes the observed client
-	// address into. Only its LAST entry is trusted — see geoip.ClientAddr.
+	// ClientIPHeader: gateway-written client address header; only its LAST
+	// entry is trusted — see geoip.ClientAddr.
 	ClientIPHeader string
 
 	OTLPMetricsEndpoint string
@@ -70,10 +67,9 @@ type Config struct {
 	LogPretty           bool
 }
 
-// ClusterConfig is everything needed to talk to ONE storage cluster: its S3
-// endpoint and credentials plus that cluster's own backend-pool settings. The
-// flat S3_* environment variables describe the default cluster; S3_CLUSTERS_FILE
-// declares any additional ones.
+// ClusterConfig: everything to talk to ONE storage cluster (endpoint,
+// credentials, pool settings). Flat S3_* env = default cluster;
+// S3_CLUSTERS_FILE declares additional ones.
 type ClusterConfig struct {
 	Code              string
 	S3AccessKeyID     string
@@ -94,7 +90,6 @@ type ClusterConfig struct {
 	S3ReconcileInterval time.Duration
 }
 
-// DefaultCluster returns the cluster described by the flat S3_* configuration.
 func (c Config) DefaultCluster() ClusterConfig {
 	return ClusterConfig{
 		Code:                c.S3DefaultCluster,
@@ -160,8 +155,7 @@ func LoadConfig() Config {
 	backendFile := os.Getenv("S3_BACKEND_FILE")
 	backendDNSHost := os.Getenv("S3_BACKEND_DNS_HOST")
 
-	// Scheme/port default to those parsed from S3_ENDPOINT, so a DNS source only
-	// needs the hostname configured.
+	// Scheme/port default from S3_ENDPOINT so a DNS source only needs the hostname.
 	defScheme, defPort := schemeAndPort(s3Endpoint)
 	backendScheme := envOr("S3_BACKEND_SCHEME", defScheme)
 	backendPort := envOr("S3_BACKEND_PORT", defPort)
@@ -203,7 +197,6 @@ func LoadConfig() Config {
 
 	switch backendSource {
 	case "":
-		// single-endpoint mode
 	case "file":
 		if backendFile == "" {
 			log.Fatal().Msg("S3_BACKEND_FILE is required when S3_BACKEND_SOURCE=file")
@@ -315,8 +308,8 @@ func LoadConfig() Config {
 	return cfg
 }
 
-// clustersFile is the S3_CLUSTERS_FILE document: the storage clusters michael
-// fronts IN ADDITION to the default one configured by the flat S3_* variables.
+// clustersFile is the S3_CLUSTERS_FILE document: clusters fronted IN ADDITION
+// to the flat-S3_* default.
 type clustersFile struct {
 	Clusters []clusterEntry `json:"clusters"`
 }
@@ -344,11 +337,9 @@ type topologyCluster struct {
 	S3               *clusterEntry `json:"s3"`
 }
 
-// clusterEntry is one cluster in S3_CLUSTERS_FILE. Credentials are named
-// indirectly — the entry gives the NAMES of the environment variables holding
-// them — so the file can be a plain ConfigMap while the secrets stay in a k8s
-// Secret. Pointer fields distinguish "absent, inherit the default cluster" from
-// an explicit false.
+// clusterEntry: one cluster in S3_CLUSTERS_FILE. Credential fields are env-var
+// NAMES (file stays a plain ConfigMap, secrets in a k8s Secret). Pointer fields
+// distinguish absent-inherit-default from explicit false.
 type clusterEntry struct {
 	Code           string `json:"code"`
 	Endpoint       string `json:"endpoint"`
@@ -357,9 +348,8 @@ type clusterEntry struct {
 	AccessKeyEnv   string `json:"access_key_env"`
 	SecretKeyEnv   string `json:"secret_key_env"`
 
-	// Backend pool. These deliberately do NOT inherit from the default cluster:
-	// inheriting a DNS host or backend file would silently point this cluster at
-	// the default cluster's gateways. Absent means single-endpoint mode.
+	// Backend pool: deliberately NOT inherited — an inherited DNS host/file
+	// would silently point at the default cluster's gateways. Absent = single-endpoint.
 	BackendSource  string `json:"backend_source"`
 	BackendFile    string `json:"backend_file"`
 	BackendDNSHost string `json:"backend_dns_host"`
@@ -374,11 +364,9 @@ type clusterEntry struct {
 	ReconcileIntervalMS int    `json:"reconcile_interval_ms"`
 }
 
-// ParseClusters decodes the S3_CLUSTERS_FILE contents into the additional
-// clusters michael should front. def supplies the fallback for the knobs an
-// entry leaves unset, and getenv resolves the credential env-var names. Unknown
-// JSON fields are rejected: a typo'd key would otherwise silently leave a
-// cluster on an inherited default.
+// ParseClusters decodes S3_CLUSTERS_FILE extras; def fills unset knobs, getenv
+// resolves credential env names. Unknown fields rejected — a typo'd key would
+// silently leave an inherited default.
 func ParseClusters(data []byte, def ClusterConfig, getenv func(string) string) ([]ClusterConfig, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
@@ -404,9 +392,8 @@ func ParseClusters(data []byte, def ClusterConfig, getenv func(string) string) (
 }
 
 // ParseTopologyClusters selects one site's clusters from the shared fleet
-// topology. Every cluster, including the default, must carry a non-secret s3
-// block whose credential fields name environment variables. This keeps API
-// placement and michael routing on one declarative cluster list.
+// topology. Every cluster (incl. default) needs a non-secret s3 block naming
+// credential env vars — one declarative list for API placement + michael routing.
 func ParseTopologyClusters(
 	data []byte,
 	siteCode string,
@@ -500,7 +487,6 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 
 	switch e.BackendSource {
 	case "":
-		// single-endpoint mode
 	case "file":
 		if e.BackendFile == "" {
 			return ClusterConfig{}, fmt.Errorf("cluster %q: backend_file is required when backend_source=file", e.Code)
@@ -569,9 +555,8 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-// schemeAndPort extracts the scheme and port from an endpoint URL, used to
-// default the templating for DNS-resolved backends. Falls back to http and the
-// scheme's default port when unset.
+// schemeAndPort extracts scheme/port from an endpoint URL for DNS-backend
+// templating; defaults http and the scheme's default port.
 func schemeAndPort(endpoint string) (scheme, port string) {
 	scheme, port = "http", "80"
 	u, err := url.Parse(endpoint)

--- a/packages/michael/internal/geoip/geoip.go
+++ b/packages/michael/internal/geoip/geoip.go
@@ -1,7 +1,5 @@
-// Package geoip identifies the remote end of a request: its network address and
-// the autonomous system announcing that address. Traffic metrics are labelled by
-// AS rather than by address — an AS label is bounded by the number of networks
-// that reach us, an address label is not.
+// Package geoip identifies a request's remote end: address + announcing AS.
+// Traffic metrics label by AS (bounded), never by address (unbounded).
 package geoip
 
 import (
@@ -16,31 +14,26 @@ import (
 	"github.com/oschwald/maxminddb-golang/v2"
 )
 
-// Sentinel AS labels. Every request gets one of these or a real "AS<number>",
-// so a traffic series is never dropped for want of a lookup.
+// Sentinel AS labels: every request gets one of these or a real "AS<number>",
+// so a series is never dropped for want of a lookup.
 const (
-	// ASNPrivate covers addresses no registry announces: RFC1918, loopback,
-	// link-local, unique-local, CGNAT. On-net clients (NetBird, the internal
-	// gateway VIP) land here.
+	// ASNPrivate: unannounced addresses (RFC1918, loopback, link-local, ULA,
+	// CGNAT). On-net clients (NetBird, internal gateway VIP) land here.
 	ASNPrivate = "private"
-	// ASNUnknown is a public address the database does not resolve — including
-	// every address when no database is loaded.
+	// ASNUnknown: public address the DB doesn't resolve — every address when no DB loaded.
 	ASNUnknown = "unknown"
 )
 
-// Client is the resolved identity of a request's remote end.
 type Client struct {
-	// IP is the client address in textual form, empty when unresolvable.
 	IP string
 	// ASN is "AS<number>", ASNPrivate, or ASNUnknown.
 	ASN string
-	// Org is the AS organization name; it mirrors ASN for the sentinels.
+	// Org mirrors ASN for the sentinels.
 	Org string
 }
 
-// Labels returns c's AS labels, substituting the unknown sentinel for a Client
-// nothing resolved — a metric series labelled with an empty AS would be worse
-// than one labelled unknown.
+// Labels returns c's AS labels, substituting ASNUnknown for empties (an empty
+// AS label would be worse than unknown).
 func (c Client) Labels() (asn, org string) {
 	asn, org = c.ASN, c.Org
 	if asn == "" {
@@ -52,15 +45,13 @@ func (c Client) Labels() (asn, org string) {
 	return asn, org
 }
 
-// Database resolves addresses against a MaxMind-format ASN database. A nil
-// *Database resolves nothing — that is what a deployment whose image carries no
-// database file gets, and it degrades to ASNUnknown rather than failing.
+// Database resolves addresses against a MaxMind-format ASN database. nil
+// resolves nothing (image without a DB file) — degrades to ASNUnknown.
 type Database struct {
 	reader *maxminddb.Reader
 }
 
-// asnRecord is the subset of an ASN database record we label with. Field names
-// are fixed by the MaxMind ASN schema, which DB-IP's free ASN database follows.
+// asnRecord: field names fixed by the MaxMind ASN schema (DB-IP's free DB follows it).
 type asnRecord struct {
 	Number uint32 `maxminddb:"autonomous_system_number"`
 	Org    string `maxminddb:"autonomous_system_organization"`
@@ -82,7 +73,6 @@ func (d *Database) Close() error {
 	return d.reader.Close()
 }
 
-// Lookup returns the AS labels for addr.
 func (d *Database) Lookup(addr netip.Addr) (asn, org string) {
 	if !addr.IsValid() {
 		return ASNUnknown, ASNUnknown
@@ -104,8 +94,6 @@ func (d *Database) Lookup(addr netip.Addr) (asn, org string) {
 	return "AS" + strconv.FormatUint(uint64(rec.Number), 10), org
 }
 
-// Resolve returns the client identity of a request. The address is read from
-// header, falling back to the transport peer when the header is absent.
 func (d *Database) Resolve(r *http.Request, header string) Client {
 	addr := ClientAddr(r, header)
 	asn, org := d.Lookup(addr)
@@ -116,8 +104,7 @@ func (d *Database) Resolve(r *http.Request, header string) Client {
 	return c
 }
 
-// cgnat is RFC 6598 shared address space — carrier NAT, not globally routed, so
-// it is no more attributable to an AS than RFC1918 is.
+// cgnat: RFC 6598 shared space — carrier NAT, no AS attribution (like RFC1918).
 var cgnat = netip.MustParsePrefix("100.64.0.0/10")
 
 func isPrivate(addr netip.Addr) bool {
@@ -130,13 +117,9 @@ func isPrivate(addr netip.Addr) bool {
 }
 
 // ClientAddr extracts the client address from header, falling back to the
-// request's transport peer when header is unset or holds nothing parseable.
-//
-// The RIGHTMOST header entry wins, and that is the whole point: a client may
-// send any X-Forwarded-For it likes and the gateway APPENDS the address it
-// actually saw, so only the last entry is written by something we trust.
-// Reading the leftmost entry — the usual reflex — would let any client pick its
-// own source network.
+// transport peer. RIGHTMOST entry wins: clients can send any X-Forwarded-For,
+// but the gateway APPENDS what it saw — only the last entry is trusted;
+// leftmost would let clients pick their own source network.
 func ClientAddr(r *http.Request, header string) netip.Addr {
 	if header != "" {
 		values := r.Header.Values(header)
@@ -153,9 +136,8 @@ func ClientAddr(r *http.Request, header string) netip.Addr {
 	return addr
 }
 
-// parseAddr accepts the forms an address reaches us in: bare, bracketed IPv6,
-// and host:port. Zones are dropped — they are meaningless off-host and would
-// split one network's series in two.
+// parseAddr accepts bare, bracketed IPv6, and host:port forms. Zones dropped
+// (meaningless off-host; would split a network's series).
 func parseAddr(s string) (netip.Addr, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -177,20 +159,16 @@ func parseAddr(s string) (netip.Addr, bool) {
 
 type contextKey struct{}
 
-// NewContext returns a new context carrying the given Client.
 func NewContext(ctx context.Context, c Client) context.Context {
 	return context.WithValue(ctx, contextKey{}, c)
 }
 
-// FromContext returns the Client resolved for this request, or the zero Client
-// when no Middleware ran.
+// Zero Client when no Middleware ran.
 func FromContext(ctx context.Context) Client {
 	c, _ := ctx.Value(contextKey{}).(Client)
 	return c
 }
 
-// Middleware resolves the client once per request so the access log and the
-// traffic metrics agree on who sent it without each paying for a lookup.
 func Middleware(resolve func(*http.Request) Client) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/packages/michael/internal/geoip/geoip_bench_test.go
+++ b/packages/michael/internal/geoip/geoip_bench_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 )
 
-// benchDB opens the database the benchmarks resolve against. testdata's fixture
-// holds three networks, which understates lookup cost — a real ASN database is
-// ~400k networks and several levels deeper in the search tree. Point
-// MICHAEL_BENCH_ASN_DB at a real one to measure what production actually pays:
+// benchDB: the testdata fixture holds three networks — understates lookup cost
+// (real ASN DB is ~400k networks, deeper tree). Point MICHAEL_BENCH_ASN_DB at
+// a real one to measure what production pays:
 //
 //	go test ./internal/geoip -bench . -benchmem \
 //	  -args # MICHAEL_BENCH_ASN_DB=/path/to/dbip-asn-lite.mmdb
@@ -33,9 +32,8 @@ func benchDB(b *testing.B) *Database {
 	return db
 }
 
-// The three outcomes cost different amounts: private short-circuits before the
-// database is touched, a hit walks the tree AND decodes a record, a miss walks
-// the tree and stops.
+// Outcomes cost differently: private short-circuits pre-DB; a hit walks the
+// tree AND decodes; a miss walks and stops.
 func BenchmarkLookup(b *testing.B) {
 	db := benchDB(b)
 

--- a/packages/michael/internal/handlers/blob.go
+++ b/packages/michael/internal/handlers/blob.go
@@ -20,12 +20,9 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// GET /{path}/{type}
-//
-// Streams the restic v2 JSON array as listing pages arrive instead of
-// buffering the whole repo listing. data/ (the bulk of a repo, hex-named) fans
-// out across 16 hex prefixes: RGW scans them in parallel and each shard lands
-// on its own pool backend.
+// Streams the restic v2 JSON array as pages arrive (no full-listing buffer).
+// data/ fans out across 16 hex prefixes: RGW scans in parallel, each shard on
+// its own pool backend.
 func (s *Server) listBlobs(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 
@@ -128,7 +125,6 @@ func (s *Server) listBlobs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// HEAD /{path}/{type}/{name}
 func (s *Server) checkBlob(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 	blobType := chi.URLParam(r, "type")
@@ -144,7 +140,6 @@ func (s *Server) checkBlob(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// GET /{path}/{type}/{name}
 func (s *Server) getBlob(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 	blobType := chi.URLParam(r, "type")
@@ -164,7 +159,6 @@ func (s *Server) getBlob(w http.ResponseWriter, r *http.Request) {
 	s.respondWithS3Object(w, r, obj)
 }
 
-// POST /{path}/{type}/{name}
 func (s *Server) saveBlob(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 	blobType := chi.URLParam(r, "type")
@@ -195,7 +189,6 @@ func (s *Server) saveBlob(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// DELETE /{path}/{type}/{name}
 func (s *Server) deleteBlob(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 	blobType := chi.URLParam(r, "type")

--- a/packages/michael/internal/handlers/blob_test.go
+++ b/packages/michael/internal/handlers/blob_test.go
@@ -169,8 +169,6 @@ func TestSaveBlob_ChecksumMismatch(t *testing.T) {
 	}
 }
 
-// --- List Blobs ---
-
 func TestListBlobs_Success(t *testing.T) {
 	store := &mockStorage{
 		listObjectsFn: func(_ context.Context, _, _ string) ([]storage.BlobInfo, error) {
@@ -285,8 +283,6 @@ func TestListBlobs_EmptyResult(t *testing.T) {
 		t.Errorf("expected empty array, got %d blobs", len(blobs))
 	}
 }
-
-// --- Delete Blob ---
 
 func TestDeleteBlob_Success(t *testing.T) {
 	store := &mockStorage{

--- a/packages/michael/internal/handlers/cluster_test.go
+++ b/packages/michael/internal/handlers/cluster_test.go
@@ -17,14 +17,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-// clusterAuth returns an auth carrying an explicit storageCluster claim.
 func clusterAuth(code string) auth.Auth {
 	a := defaultAuth()
 	a.StorageCluster = code
 	return a
 }
 
-// recordingStorage is a mockStorage that remembers whether it was reached.
 type recordingStorage struct {
 	mockStorage
 	hits int
@@ -39,7 +37,6 @@ func newRecordingStorage() *recordingStorage {
 	return rs
 }
 
-// twoClusterServer fronts "default" and "spice", each with its own storage.
 func twoClusterServer() (*Server, *recordingStorage, *recordingStorage) {
 	def, spice := newRecordingStorage(), newRecordingStorage()
 	srv := NewClusterServer(map[string]storage.Storage{
@@ -146,9 +143,8 @@ func TestClusterRoutingUnknownClusterRejected(t *testing.T) {
 	}
 }
 
-// A well-formed claim naming a cluster is still rejected on a single-cluster
-// michael unless it matches that michael's default code — the legacy-token path
-// must not be a wildcard.
+// A well-formed claim is rejected on single-cluster michael unless it matches
+// the default code — the legacy-token path must not be a wildcard.
 func TestClusterRoutingSingleClusterRejectsForeignClaim(t *testing.T) {
 	srv := newTestServer(&mockStorage{})
 

--- a/packages/michael/internal/handlers/config.go
+++ b/packages/michael/internal/handlers/config.go
@@ -12,7 +12,6 @@ import (
 	"michael/internal/storage"
 )
 
-// HEAD /{path}/config
 func (s *Server) checkConfig(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 
@@ -26,7 +25,6 @@ func (s *Server) checkConfig(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// GET /{path}/config
 func (s *Server) getConfig(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 
@@ -41,7 +39,6 @@ func (s *Server) getConfig(w http.ResponseWriter, r *http.Request) {
 	s.respondWithS3Object(w, r, obj)
 }
 
-// POST /{path}/config
 func (s *Server) saveConfig(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 
@@ -63,7 +60,6 @@ func (s *Server) saveConfig(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// DELETE /{path}/config
 func (s *Server) deleteConfig(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 

--- a/packages/michael/internal/handlers/helpers.go
+++ b/packages/michael/internal/handlers/helpers.go
@@ -30,7 +30,6 @@ var writeError = httputil.WriteError
 func (s *Server) respondWithS3Object(w http.ResponseWriter, r *http.Request, obj *storage.S3Object) {
 	defer obj.Body.Close()
 
-	// If-None-Match → 304
 	if etag := r.Header.Get("If-None-Match"); etag != "" && etag == obj.ETag {
 		w.WriteHeader(http.StatusNotModified)
 		return
@@ -54,7 +53,6 @@ func (s *Server) respondWithS3Object(w http.ResponseWriter, r *http.Request, obj
 		w.Header().Set("Content-Length", strconv.FormatInt(obj.ContentLength, 10))
 	}
 
-	// Range → 206
 	rangeHeader := r.Header.Get("Range")
 	if rangeHeader != "" && rangeHeader != "bytes=0-" {
 		w.WriteHeader(http.StatusPartialContent)

--- a/packages/michael/internal/handlers/repo.go
+++ b/packages/michael/internal/handlers/repo.go
@@ -8,7 +8,6 @@ import (
 	"michael/internal/auth"
 )
 
-// POST /{path}?create=true
 func (s *Server) createRepository(w http.ResponseWriter, r *http.Request) {
 	a := auth.FromContext(r.Context())
 
@@ -44,7 +43,6 @@ func (s *Server) createRepository(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// DELETE /{path}
 func (s *Server) deleteRepository(w http.ResponseWriter, r *http.Request) {
 	writeError(w, r, http.StatusNotImplemented, "Not Implemented")
 }

--- a/packages/michael/internal/handlers/server.go
+++ b/packages/michael/internal/handlers/server.go
@@ -21,28 +21,21 @@ import (
 )
 
 type Server struct {
-	// Clusters holds one Storage per storage cluster this michael fronts, keyed
-	// by cluster code. A request's token selects one of them.
+	// Keyed by cluster code; a request's token selects one.
 	Clusters map[string]storage.Storage
-	// DefaultCluster is the code served to tokens carrying no storageCluster
-	// claim — every token minted before multi-cluster routing existed.
+	// DefaultCluster serves tokens without a storageCluster claim (pre-multi-cluster mints).
 	DefaultCluster string
 	JWTPublicKey   *ecdsa.PublicKey
 	Metrics        *metrics.Metrics
-	// ResolveClient identifies the source network of a request, for the traffic
-	// metrics and the access log. Optional: nil leaves both unattributed, which
-	// is what the tests and any deployment without an ASN database get.
+	// ResolveClient identifies the source network (traffic metrics + access
+	// log). nil = unattributed (tests, deployments without an ASN DB).
 	ResolveClient func(*http.Request) geoip.Client
 }
 
-// NewServer builds a single-cluster server: everything is served from s under
-// the default cluster code.
 func NewServer(s storage.Storage, jwtPublicKey *ecdsa.PublicKey, m *metrics.Metrics) *Server {
 	return NewClusterServer(map[string]storage.Storage{cluster.DefaultCode: s}, cluster.DefaultCode, jwtPublicKey, m)
 }
 
-// NewClusterServer builds a server fronting several storage clusters, routing
-// each request by its token's storageCluster claim.
 func NewClusterServer(clusters map[string]storage.Storage, defaultCluster string, jwtPublicKey *ecdsa.PublicKey, m *metrics.Metrics) *Server {
 	return &Server{
 		Clusters:       clusters,
@@ -54,11 +47,9 @@ func NewClusterServer(clusters map[string]storage.Storage, defaultCluster string
 
 type clusterCtxKey struct{}
 
-// resolveCluster maps the request's token to the storage cluster serving it. An
-// absent (or empty) storageCluster claim means the default cluster; a claim
-// naming a cluster this michael does not front is an error rather than a
-// fallback — silently serving a repository from the wrong cluster would look
-// like data loss to the client.
+// resolveCluster maps the token to its storage cluster. Empty claim = default;
+// an unknown cluster is an error, NOT a fallback — silently serving from the
+// wrong cluster would look like data loss.
 func (s *Server) resolveCluster(ctx context.Context) (string, storage.Storage, bool) {
 	code := auth.FromContext(ctx).StorageCluster
 	if code == "" {
@@ -68,9 +59,8 @@ func (s *Server) resolveCluster(ctx context.Context) (string, storage.Storage, b
 	return code, store, ok
 }
 
-// clusterMiddleware resolves the request's storage cluster once, up front, and
-// rejects unknown ones for every route at the same place — so no handler can
-// forget to fail closed.
+// clusterMiddleware resolves the cluster once, rejecting unknown ones for every
+// route in one place — no handler can forget to fail closed.
 func (s *Server) clusterMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		code, store, ok := s.resolveCluster(r.Context())
@@ -86,9 +76,6 @@ func (s *Server) clusterMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// store returns the storage cluster this request routes to. clusterMiddleware
-// has already resolved it and rejected unknown clusters, so by the time a
-// handler runs the lookup has succeeded.
 func (s *Server) store(ctx context.Context) storage.Storage {
 	return ctx.Value(clusterCtxKey{}).(storage.Storage)
 }
@@ -195,11 +182,9 @@ func validateBlobName(next http.Handler) http.Handler {
 	})
 }
 
-// clientLogContext puts the source network on every log line for the request.
-// client_ip is the address behind the gateway — remote_ip is the gateway's own
-// — and it lives on the log rather than on a metric label because per-address
-// series are unbounded; drilling from a busy AS to the addresses inside it is a
-// VictoriaLogs query.
+// clientLogContext puts the source network on every log line. client_ip is the
+// address behind the gateway (remote_ip is the gateway's); it's a log field not
+// a metric label — per-address series are unbounded, drill down via VictoriaLogs.
 func clientLogContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := geoip.FromContext(r.Context())
@@ -214,10 +199,9 @@ func authLogContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		a := auth.FromContext(r.Context())
 		route := chi.RouteContext(r.Context()).RoutePattern()
-		// Mutate the request logger in place instead of deriving a new one:
-		// the AccessHandler completion line logs through the outer request's
-		// logger pointer, so this is what puts user/repository on access logs.
-		// method is omitted — the access line already carries it.
+		// Mutate the request logger in place: AccessHandler logs through the
+		// outer logger pointer — this puts user/repository on access lines.
+		// method omitted (access line carries it).
 		hlog.FromRequest(r).UpdateContext(func(c zerolog.Context) zerolog.Context {
 			return c.Str("user", a.User).Str("repository", a.Repository).Str("route", route)
 		})

--- a/packages/michael/internal/handlers/server_bench_test.go
+++ b/packages/michael/internal/handlers/server_bench_test.go
@@ -21,14 +21,11 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
-// These benchmarks answer one question: what does labelling traffic by source
-// network cost per request? Every variant runs the SAME router with the SAME
-// instrumented meter; the only thing that varies is whether ResolveClient is
-// set, which is exactly the switch that mounts geoip.Middleware +
-// metrics.TrafficMiddleware.
-//
-// Against the committed three-network fixture the lookup is optimistic; export
-// MICHAEL_BENCH_ASN_DB=/path/to/dbip-asn-lite.mmdb to measure a real database.
+// One question: what does source-network labelling cost per request? Same
+// router + instrumented meter throughout; only ResolveClient varies (the switch
+// mounting geoip.Middleware + metrics.TrafficMiddleware). The three-network
+// fixture is optimistic; export MICHAEL_BENCH_ASN_DB=/path/to/dbip-asn-lite.mmdb
+// to measure a real database.
 
 // benchServer builds a server over an instrumented meter (NOT noop — the
 // aggregation work is part of what we are measuring) serving a fixed blob.
@@ -57,9 +54,8 @@ func benchServer(b *testing.B, blob []byte, resolve func(*http.Request) geoip.Cl
 	return srv
 }
 
-// benchRequest builds one reusable authenticated blob GET. The token is signed
-// once: michael caches verified tokens, so re-signing per iteration would
-// benchmark ECDSA instead of the request path.
+// benchRequest builds one reusable authed blob GET, signed once — michael
+// caches verified tokens; re-signing per iteration would benchmark ECDSA.
 func benchRequest(b *testing.B) *http.Request {
 	b.Helper()
 	token := makeJWTForBench(b, jwt.MapClaims{
@@ -104,11 +100,9 @@ func benchResolver(b *testing.B) func(*http.Request) geoip.Client {
 	return func(r *http.Request) geoip.Client { return db.Resolve(r, "X-Forwarded-For") }
 }
 
-// blobSizes brackets the real workload. 16MiB is the representative case: it is
-// this deployment's restic pack size (yucca-api DEFAULT_CONFIG
-// restic_pack_size_mib, and yuctl's --pack-size default). 1KiB is the worst case
-// for RELATIVE overhead — fixed per-request cost with almost no bytes to
-// amortize it over.
+// blobSizes brackets the workload: 16MiB = this deployment's restic pack size
+// (yucca-api DEFAULT_CONFIG restic_pack_size_mib, yuctl --pack-size default);
+// 1KiB = worst case for RELATIVE overhead (nothing to amortize over).
 var blobSizes = []struct {
 	name string
 	size int
@@ -118,9 +112,8 @@ var blobSizes = []struct {
 }
 
 func BenchmarkServeBlob(b *testing.B) {
-	// The access log would otherwise dominate and swamp the signal; michael runs
-	// at info in prod, but writing a line per iteration to a benchmark's stderr
-	// measures the logger, not the handler.
+	// Mute the access log (info in prod): a line per iteration would measure
+	// the logger, not the handler.
 	silenceLogs(b)
 
 	for _, size := range blobSizes {
@@ -183,9 +176,8 @@ func BenchmarkServeBlobParallel(b *testing.B) {
 	}
 }
 
-// BenchmarkSourceNetworkChain attributes the end-to-end delta to the three
-// pieces the feature adds, stacked cumulatively over a no-op handler. Read the
-// deltas between adjacent rows: each is one middleware's per-request cost.
+// BenchmarkSourceNetworkChain stacks the three added middlewares cumulatively
+// over a no-op handler; adjacent-row deltas = each middleware's per-request cost.
 func BenchmarkSourceNetworkChain(b *testing.B) {
 	silenceLogs(b)
 

--- a/packages/michael/internal/handlers/server_test.go
+++ b/packages/michael/internal/handlers/server_test.go
@@ -49,7 +49,6 @@ func makeBasicAuth(token string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte("restic:"+token))
 }
 
-// mockStorage implements the storage.Storage interface for testing.
 type mockStorage struct {
 	checkBucketFn  func(ctx context.Context, bucket string) (bool, error)
 	createBucketFn func(ctx context.Context, bucket string) error
@@ -127,17 +126,14 @@ func (m *mockStorage) DeleteObject(ctx context.Context, bucket, key string) erro
 	return nil
 }
 
-// newTestServer creates a single-cluster Server with mock storage.
 func newTestServer(store *mockStorage) *Server {
 	return NewServer(store, testPublicKey, nil)
 }
 
-// doRequest creates and executes a request against the test server with a real JWT auth header.
 func doRequest(t *testing.T, srv *Server, method, path string, body io.Reader, a auth.Auth, headers map[string]string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(method, path, body)
 
-	// Generate a real JWT for the auth middleware
 	claims := jwt.MapClaims{
 		"user":       a.User,
 		"repository": a.Repository,
@@ -176,7 +172,6 @@ func wormAuth() auth.Auth {
 	}
 }
 
-// parseLogLines parses JSON log output into a slice of maps.
 func parseLogLines(t *testing.T, buf *bytes.Buffer) []map[string]interface{} {
 	t.Helper()
 	var entries []map[string]interface{}
@@ -193,7 +188,6 @@ func parseLogLines(t *testing.T, buf *bytes.Buffer) []map[string]interface{} {
 	return entries
 }
 
-// findLog returns the first log entry matching all given field values.
 func findLog(entries []map[string]interface{}, match map[string]interface{}) map[string]interface{} {
 	for _, e := range entries {
 		hit := true
@@ -210,7 +204,6 @@ func findLog(entries []map[string]interface{}, match map[string]interface{}) map
 	return nil
 }
 
-// captureLogOutput replaces the global logger with one writing to buf, and restores it on cleanup.
 func captureLogOutput(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
@@ -276,7 +269,6 @@ func TestErrorLogOutput(t *testing.T) {
 
 	entries := parseLogLines(t, buf)
 
-	// Should have an error-level log with the error message and request context
 	errLog := findLog(entries, map[string]interface{}{"level": "error"})
 	if errLog == nil {
 		t.Fatalf("no error log entry found in output:\n%s", buf.String())
@@ -314,7 +306,6 @@ func TestAuthFailureLogOutput(t *testing.T) {
 
 	srv := newTestServer(&mockStorage{})
 
-	// Send a request with no auth header
 	req := httptest.NewRequest(http.MethodGet, "/"+testRepository+"/data", nil)
 	req.Header.Set("Accept", ContentTypeResticV2)
 	rec := httptest.NewRecorder()
@@ -326,7 +317,6 @@ func TestAuthFailureLogOutput(t *testing.T) {
 
 	entries := parseLogLines(t, buf)
 
-	// Should still get an access log even for auth failures
 	accessLog := findLog(entries, map[string]interface{}{"status": float64(http.StatusUnauthorized)})
 	if accessLog == nil {
 		t.Fatalf("no access log entry for 401 response:\n%s", buf.String())
@@ -337,9 +327,8 @@ func TestAuthFailureLogOutput(t *testing.T) {
 	}
 }
 
-// Traffic accounting wraps the request body to count it. With the whole chain
-// mounted — Middleware, TrafficMiddleware, BlobMiddleware, each wrapping the
-// body again — an upload must still reach storage byte for byte.
+// The full chain (Middleware, TrafficMiddleware, BlobMiddleware) wraps the body
+// three times; an upload must still reach storage byte for byte.
 func TestUploadBodySurvivesTrafficAccounting(t *testing.T) {
 	m, err := metrics.NewMetrics(noop.NewMeterProvider().Meter("test"))
 	if err != nil {

--- a/packages/michael/internal/metrics/backend.go
+++ b/packages/michael/internal/metrics/backend.go
@@ -10,24 +10,17 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
-// BackendStatsProvider yields a per-backend snapshot. *storage.Pool implements
-// it. Kept as an interface so the metrics layer doesn't depend on the pool's
-// internals and can be tested with a stub.
+// *storage.Pool implements this.
 type BackendStatsProvider interface {
 	Stats() []storage.BackendStat
 }
 
-// RegisterBackendMetrics wires per-backend S3 load-balancer metrics onto meter,
-// one provider per storage cluster keyed by cluster code. All instruments are
-// observable: a single registered callback reads every provider's snapshot each
-// collection cycle and emits one series per backend (tagged with "cluster" and
-// "backend" attributes), so the storage hot path stays free of any OTel calls.
-// The cumulative counters (requests/errors/bytes) are reported as observable
-// counters since the pool already keeps monotonic atomics.
-//
-// The "cluster" attribute is what keeps two clusters' gateways apart: endpoints
-// are per-cluster addresses and nothing stops two clusters resolving the same
-// one (e.g. both behind the same in-cluster service name in dev).
+// RegisterBackendMetrics wires per-backend S3 load-balancer metrics, one
+// provider per cluster code. All instruments are observable — one callback
+// reads snapshots per collection, keeping the storage hot path free of OTel
+// calls; cumulative counters ride the pool's monotonic atomics. The "cluster"
+// attribute disambiguates gateways two clusters may resolve identically (e.g.
+// same in-cluster service name in dev).
 func RegisterBackendMetrics(meter otelmetric.Meter, providers map[string]BackendStatsProvider) error {
 	requests, err := meter.Int64ObservableCounter("s3.backend.requests",
 		otelmetric.WithDescription("Total S3 requests routed to each backend gateway"))

--- a/packages/michael/internal/metrics/backend_test.go
+++ b/packages/michael/internal/metrics/backend_test.go
@@ -40,7 +40,6 @@ func TestRegisterBackendMetrics(t *testing.T) {
 		t.Fatalf("Collect: %v", err)
 	}
 
-	// Index every emitted (metric, cluster/backend) -> value.
 	got := map[string]map[string]int64{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {

--- a/packages/michael/internal/metrics/client.go
+++ b/packages/michael/internal/metrics/client.go
@@ -11,18 +11,14 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
-// clientIdleTTL bounds how long a client with nothing outstanding is kept in
-// the concurrency tracker. It only has to outlive the gap between collection
-// cycles — a client that comes back before eviction simply reuses its entry.
+// clientIdleTTL bounds idle-client retention in the tracker; only needs to
+// outlive a collection gap — returning clients reuse their entry.
 const clientIdleTTL = 15 * time.Minute
 
 type clientAttrKey struct{ user, repository, connection string }
 
-// clientAttrs labels a measurement with the request's identity and nothing
-// else — no method, route or status. That is what keeps the per-client
-// instruments at a fixed handful of series per client-repository however
-// restic exercises the API, unlike the request counters which multiply by
-// route and status.
+// clientAttrs: identity only — no method/route/status — so per-client
+// instruments stay a fixed handful of series per client-repository.
 func clientAttrs(key clientAttrKey) otelmetric.MeasurementOption {
 	return otelmetric.WithAttributeSet(attribute.NewSet(
 		attribute.String("customerId", key.user),
@@ -31,13 +27,9 @@ func clientAttrs(key clientAttrKey) otelmetric.MeasurementOption {
 	))
 }
 
-// clientConcurrency is one client's outstanding-request accounting: cur is the
-// live count, peak the high-water mark since the last collection.
-//
-// The label set is built once and held here rather than in a cache of its own,
-// so it is reclaimed with the client on idle eviction. A separate cache keyed
-// by identity would instead grow with every client-repository pair the process
-// has ever seen.
+// clientConcurrency: cur = live count, peak = high-water since last collection.
+// The label set lives here (not a separate cache) so it's reclaimed on idle
+// eviction instead of growing with every pair ever seen.
 type clientConcurrency struct {
 	attrs    otelmetric.MeasurementOption
 	cur      atomic.Int64
@@ -45,15 +37,12 @@ type clientConcurrency struct {
 	lastSeen atomic.Int64 // unix nanos, stamped when a request finishes
 }
 
-// retired marks an entry a collection has taken out of service. It is a state
-// of cur rather than a separate flag so that closing the entry and observing it
-// idle are one atomic step — otherwise a request arriving between the two would
-// be accounted against an entry already on its way out of the map.
+// retired is a state of cur (not a separate flag) so close+observe-idle is one
+// atomic step; otherwise a racing request could land on an entry leaving the map.
 const retired = -1
 
-// enter accounts for a request starting, raising the high-water mark if this
-// request is the most concurrent one yet in the current window. It reports
-// false if the entry has been retired, leaving the caller to take a fresh one.
+// enter accounts a request start, raising the window high-water mark; false if
+// the entry is retired (caller takes a fresh one).
 func (c *clientConcurrency) enter() bool {
 	for {
 		cur := c.cur.Load()
@@ -91,12 +80,10 @@ type clientTracker struct {
 	states sync.Map // clientAttrKey -> *clientConcurrency
 }
 
-// enter loads before storing so the hot path is a single map read; the label
-// set is only built when a client is seen for the first time. Losing the race
-// against a collection that retired the entry costs one more iteration, after
-// which the replacement is what every later request shares — the client must
-// not end up split across an orphan and a successor, which would under-report
-// its concurrency.
+// enter loads before storing (hot path = one map read; labels built on first
+// sight). Losing the race with a retiring collection costs one iteration; all
+// later requests share the replacement — a split orphan/successor would
+// under-report concurrency.
 func (t *clientTracker) enter(key clientAttrKey) *clientConcurrency {
 	for {
 		v, ok := t.states.Load(key)
@@ -111,8 +98,8 @@ func (t *clientTracker) enter(key clientAttrKey) *clientConcurrency {
 	}
 }
 
-// newClientConcurrency stamps lastSeen so a brand-new entry cannot look idle to
-// a collection landing before its first request is accounted in.
+// newClientConcurrency stamps lastSeen so a fresh entry can't look idle before
+// its first request is accounted in.
 func newClientConcurrency(key clientAttrKey) *clientConcurrency {
 	state := &clientConcurrency{attrs: clientAttrs(key)}
 	state.lastSeen.Store(time.Now().UnixNano())
@@ -120,10 +107,8 @@ func newClientConcurrency(key clientAttrKey) *clientConcurrency {
 }
 
 // observe reports each client's high-water concurrency and arms the next
-// window. The peak resets to the CURRENT outstanding count rather than zero:
-// restic holds its connections open for a whole backup, so a client sitting at
-// N concurrent requests across several collection cycles would otherwise
-// report N once and 0 forever after.
+// window. Peak resets to CURRENT outstanding, not zero: restic holds N
+// connections a whole backup and would otherwise report N once then 0.
 func (t *clientTracker) observe(o otelmetric.Observer, gauge otelmetric.Int64ObservableGauge, now time.Time) {
 	t.states.Range(func(k, v any) bool {
 		key := k.(clientAttrKey)
@@ -132,9 +117,8 @@ func (t *clientTracker) observe(o otelmetric.Observer, gauge otelmetric.Int64Obs
 		cur := state.cur.Load()
 		peak := state.peak.Swap(cur)
 
-		// Retire before deleting, and delete only the entry that was retired: a
-		// request arriving in between either wins (retire fails, the entry stays)
-		// or is handed the replacement it swapped in.
+		// Retire before delete, delete only the retired entry: a racing request
+		// either wins (retire fails) or gets the replacement it swapped in.
 		if cur == 0 && peak == 0 && now.UnixNano()-state.lastSeen.Load() > int64(clientIdleTTL) {
 			if state.retire() {
 				t.states.CompareAndDelete(key, state)
@@ -147,19 +131,10 @@ func (t *clientTracker) observe(o otelmetric.Observer, gauge otelmetric.Int64Obs
 	})
 }
 
-// clientMetrics measures how each client drives the gateway, as opposed to how
-// the gateway performs per route.
-//
-// Parallelism comes from `seconds` by Little's Law: the rate of accumulated
-// request-seconds over a window IS the mean number of requests in flight, so
-// `rate(client.request.seconds)` reads directly as average concurrency without
-// any per-client state. Dividing it by the matching request rate from
-// `http.server.request.count` gives mean duration.
-//
-// `peak` covers what an average cannot — a client that saturates its
-// connection budget in bursts. Note it is per michael replica: a client whose
-// connections spread across replicas makes a summed peak an upper bound,
-// whereas the Little's Law average sums exactly.
+// clientMetrics measures how each client drives the gateway (vs per-route perf).
+// Little's Law: rate(client.request.seconds) = mean in-flight requests; divided
+// by request rate = mean duration. `peak` catches bursty saturation an average
+// hides; it is per replica (summed peak = upper bound, the average sums exactly).
 type clientMetrics struct {
 	seconds     otelmetric.Float64Counter
 	ttfbSeconds otelmetric.Float64Counter
@@ -174,9 +149,8 @@ func newClientMetrics(meter otelmetric.Meter) (*clientMetrics, error) {
 		return nil, fmt.Errorf("creating client.request.seconds counter: %w", err)
 	}
 
-	// Duration runs until the client has drained the body, so on large blobs it
-	// measures the client's link; TTFB isolates michael+RGW. Split per client so
-	// a slow customer is distinguishable from a slow backend.
+	// Duration includes body drain (client's link on large blobs); TTFB isolates
+	// michael+RGW. Per client: slow customer vs slow backend.
 	ttfbSeconds, err := meter.Float64Counter("client.request.ttfb_seconds",
 		otelmetric.WithDescription("Accumulated time-to-first-byte seconds per client"),
 		otelmetric.WithUnit("s"))

--- a/packages/michael/internal/metrics/client_test.go
+++ b/packages/michael/internal/metrics/client_test.go
@@ -15,9 +15,8 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-// observation is one ObserveInt64 call captured from a collection cycle. The
-// option is retained rather than decoded: each client's label set is built once
-// and held on its tracker entry, so it can be compared by identity.
+// observation is one captured ObserveInt64 call. The option is retained, not
+// decoded: each label set is built once per tracker entry, so identity-comparable.
 type observation struct {
 	value int64
 	opt   otelmetric.ObserveOption
@@ -57,8 +56,6 @@ func collect(t *testing.T, tr *clientTracker, now time.Time) []observation {
 	return obs.got
 }
 
-// peakFor returns the observed high-water mark for one client, matching on the
-// label set held by that client's tracker entry.
 func peakFor(t *testing.T, tr *clientTracker, got []observation, key clientAttrKey) int64 {
 	t.Helper()
 	v, ok := tr.states.Load(key)
@@ -95,9 +92,9 @@ func TestClientAttrsBuiltOncePerClient(t *testing.T) {
 	}
 }
 
-// TestClientAttrsReclaimedOnEviction is the memory bound: the label set lives on
-// the tracker entry, so an idle client leaves nothing behind. A cache keyed by
-// identity would instead retain every client-repository pair ever seen.
+// TestClientAttrsReclaimedOnEviction is the memory bound: label set lives on
+// the entry, so an idle client leaves nothing (an identity-keyed cache would
+// retain every pair ever seen).
 func TestClientAttrsReclaimedOnEviction(t *testing.T) {
 	tr := &clientTracker{}
 	now := time.Now()
@@ -197,9 +194,8 @@ func TestClientTrackerEvictsIdleClients(t *testing.T) {
 }
 
 // TestClientTrackerEvictionDoesNotSplitClient drives the eviction race by hand:
-// a request arrives after a collection has decided an entry is idle. The client
-// must end up on ONE entry — an orphan kept alive by the in-flight request while
-// later requests build a replacement would under-report its concurrency.
+// a request lands after a collection deems the entry idle. The client must end
+// on ONE entry — an orphan/replacement split would under-report concurrency.
 func TestClientTrackerEvictionDoesNotSplitClient(t *testing.T) {
 	tr := &clientTracker{}
 	key := clientAttrKey{"u1", "r1", "restic"}
@@ -241,13 +237,11 @@ func TestClientTrackerEvictionDoesNotSplitClient(t *testing.T) {
 	}
 }
 
-// TestClientTrackerEvictionKeepsRequestsAttached drives eviction and entry
-// against each other for real, with the clock always past the TTL so every
-// collection tries to evict. The invariant it checks is what the retire
-// handshake buys: an entry is only ever retired while idle, so a request that
-// is outstanding on a state must still find that state in the map. Deleting on
-// the idle read alone breaks this — the request is left updating an orphan
-// while later requests build a successor, splitting the client's concurrency.
+// TestClientTrackerEvictionKeepsRequestsAttached races eviction against enter
+// with the clock always past TTL. Invariant (what the retire handshake buys):
+// entries retire only while idle, so an outstanding request still finds its
+// state in the map. Deleting on the idle read alone would orphan it and split
+// the client's concurrency.
 func TestClientTrackerEvictionKeepsRequestsAttached(t *testing.T) {
 	tr := &clientTracker{}
 	key := clientAttrKey{"u1", "r1", "restic"}
@@ -359,8 +353,6 @@ func TestNewClientMetricsWithNoopMeter(t *testing.T) {
 	}
 }
 
-// TestMiddlewareTracksConcurrency drives the real middleware chain: CaptureAuth
-// must enter the tracker and Middleware must account the request back out.
 func TestMiddlewareTracksConcurrency(t *testing.T) {
 	m, err := NewMetrics(noop.NewMeterProvider().Meter("test"))
 	if err != nil {
@@ -399,10 +391,9 @@ func TestMiddlewareTracksConcurrency(t *testing.T) {
 	}
 }
 
-// TestMiddlewareAccountsOutOnPanic covers the path chi's Recoverer owns: it is
-// mounted outside this middleware, so a handler panic unwinds past us. Without
-// a deferred exit the request stays counted forever, pinning the client's peak
-// above zero and blocking idle eviction for the life of the process.
+// TestMiddlewareAccountsOutOnPanic: chi's Recoverer is mounted outside us, so a
+// handler panic unwinds past this middleware; without the deferred exit the
+// request stays counted forever, pinning peak >0 and blocking idle eviction.
 func TestMiddlewareAccountsOutOnPanic(t *testing.T) {
 	m, err := NewMetrics(noop.NewMeterProvider().Meter("test"))
 	if err != nil {
@@ -436,9 +427,8 @@ func TestMiddlewareAccountsOutOnPanic(t *testing.T) {
 	}
 }
 
-// TestMiddlewareSkipsUnauthenticated guards the tracker against unauthenticated
-// traffic, which has no identity to attribute and would otherwise accumulate
-// under an empty key.
+// TestMiddlewareSkipsUnauthenticated: unauthenticated traffic has no identity
+// and must not accumulate under an empty key.
 func TestMiddlewareSkipsUnauthenticated(t *testing.T) {
 	m, err := NewMetrics(noop.NewMeterProvider().Meter("test"))
 	if err != nil {

--- a/packages/michael/internal/metrics/metrics.go
+++ b/packages/michael/internal/metrics/metrics.go
@@ -23,10 +23,8 @@ import (
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 )
 
-// otelResource identifies this process to the collector. Without
-// service.instance.id every replica exports IDENTICAL series; the TSDB merges
-// them into one, interleaved cumulative counters read as resets, and rate()
-// reports ~1/replicas of the real traffic.
+// otelResource identifies this process. Without service.instance.id replicas
+// export identical series; merged counters read as resets and rate() reports ~1/replicas.
 func otelResource() *sdkresource.Resource {
 	host, _ := os.Hostname()
 	res, err := sdkresource.Merge(sdkresource.Default(), sdkresource.NewSchemaless(
@@ -55,18 +53,15 @@ type Metrics struct {
 	UnknownCluster  otelmetric.Int64Counter
 	client          *clientMetrics
 
-	// Traffic counters, labelled by the SOURCE NETWORK instead of the identity:
-	// the blobs.* family answers "which customer moved this", these answer
-	// "which network did it come from", including for requests that never
-	// authenticated.
+	// Traffic counters, labelled by SOURCE NETWORK (not identity) — covers
+	// requests that never authenticated; blobs.* answers "which customer".
 	TrafficUploadedBytes   otelmetric.Int64Counter
 	TrafficDownloadedBytes otelmetric.Int64Counter
 	TrafficRequests        otelmetric.Int64Counter
 }
 
-// durationBuckets replaces the SDK default histogram boundaries, which are
-// sized for milliseconds — recording seconds against them put every sub-5s
-// request in the first bucket.
+// durationBuckets replaces the ms-sized SDK defaults (seconds recorded against
+// them land every sub-5s request in the first bucket).
 var durationBuckets = []float64{
 	0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120,
 }
@@ -105,8 +100,7 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating request_duration histogram: %w", err)
 	}
 
-	// Duration includes streaming the body to the client, so for large blobs it
-	// measures client throughput; TTFB isolates michael+RGW latency.
+	// Duration includes streaming to the client; TTFB isolates michael+RGW latency.
 	requestTTFB, err := meter.Float64Histogram("http.server.request.ttfb",
 		otelmetric.WithDescription("Time from request start to first response byte"),
 		otelmetric.WithUnit("s"),
@@ -127,10 +121,8 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating request_errors counter: %w", err)
 	}
 
-	// Backend (RGW) storage-operation failures, split out from the generic HTTP
-	// error counter so a gateway write-error spike is directly visible and
-	// alertable — the signal that a client-facing 500 wave is the storage
-	// backend, not michael or auth.
+	// RGW failures, split from generic HTTP errors so a backend-caused 500 wave
+	// is directly alertable.
 	storageErrors, err := meter.Int64Counter("storage.backend.errors",
 		otelmetric.WithDescription("Backend S3 storage operation failures, by operation and blob type"))
 	if err != nil {
@@ -149,10 +141,8 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating auth_cache_misses counter: %w", err)
 	}
 
-	// A token naming a storage cluster this michael does not front means a
-	// routing/config mismatch between the API that minted the token and this
-	// deployment — every such request is rejected, so this must be alertable
-	// rather than buried in the generic 4xx count.
+	// Token naming a cluster we don't front = routing/config mismatch with the
+	// minting API; always rejected, so alertable rather than buried in 4xx.
 	unknownCluster, err := meter.Int64Counter("storage.cluster.unknown",
 		otelmetric.WithDescription("Requests rejected because the token named a storage cluster michael does not front"))
 	if err != nil {
@@ -173,8 +163,7 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("creating traffic_downloaded_bytes counter: %w", err)
 	}
 
-	// Byte counters alone hide the abuse case this is here to catch: a flood of
-	// rejected requests from one network moves almost no bytes.
+	// Catches abuse floods of rejected requests that move almost no bytes.
 	trafficRequests, err := meter.Int64Counter("traffic.requests",
 		otelmetric.WithDescription("Total HTTP requests received, by source autonomous system"))
 	if err != nil {
@@ -209,9 +198,8 @@ func NewMetrics(meter otelmetric.Meter) (*Metrics, error) {
 
 var clusterAttrCache sync.Map
 
-// ClusterOption labels a measurement with a storage cluster code. Cluster codes
-// are validated against a narrow charset before reaching here, so this stays
-// bounded even though the value originates in a token claim.
+// ClusterOption labels a measurement with a storage cluster code — charset-validated
+// upstream, so bounded despite originating in a token claim.
 func ClusterOption(code string) otelmetric.MeasurementOption {
 	if v, ok := clusterAttrCache.Load(code); ok {
 		return v.(otelmetric.MeasurementOption)
@@ -227,12 +215,9 @@ type asnAttrKey struct{ asn, org string }
 
 var asnAttrCache sync.Map
 
-// ASNOption labels a measurement with the source network of the request. The
-// AS number is the label that matters; the organization rides along because it
-// is a function of the number and so costs no extra series, and a board legend
-// reading "AS3320 Deutsche Telekom" beats one reading "AS3320". Address-level
-// attribution deliberately stays OUT of the labels — unbounded — and lives on
-// the access log line instead.
+// ASNOption labels a measurement with the request's source network. Org is a
+// function of the AS number (no extra series, nicer legends); address-level
+// attribution is unbounded and stays on the access log line, never in labels.
 func ASNOption(asn, org string) otelmetric.MeasurementOption {
 	key := asnAttrKey{asn, org}
 	if v, ok := asnAttrCache.Load(key); ok {
@@ -250,10 +235,9 @@ type storageErrAttrKey struct{ operation, blobType string }
 
 var storageErrAttrCache sync.Map
 
-// StorageErrorOption labels a backend storage failure by operation ("put",
-// "get", …) and blob type. Deliberately low-cardinality (no per-user labels):
-// this is a fleet-health/alerting signal, and the per-request identity is
-// already on the logged error line.
+// StorageErrorOption labels a backend failure by operation ("put", "get", …) and
+// blob type. Deliberately low-cardinality (no per-user labels — identity is on the
+// logged error line); this is a fleet-health/alerting signal.
 func StorageErrorOption(operation, blobType string) otelmetric.MeasurementOption {
 	key := storageErrAttrKey{operation, blobType}
 	if v, ok := storageErrAttrCache.Load(key); ok {
@@ -295,10 +279,8 @@ func SetupMeterProvider(cfg config.Config) (*sdkmetric.MeterProvider, error) {
 	return provider, nil
 }
 
-// --- Cached metric helpers (hot-path allocation avoidance) ---
-
-// connectionLabel bounds the label to the connection *type*; legacy tokens
-// without the claim report "unknown". Never label by connection instance id.
+// connectionLabel: connection *type* only, never instance id; legacy tokens
+// without the claim report "unknown".
 func connectionLabel(a auth.Auth) string {
 	if a.Connection == "" {
 		return "unknown"
@@ -325,9 +307,6 @@ func BlobMetricOption(a auth.Auth, blobType string) otelmetric.MeasurementOption
 	return opt
 }
 
-// BlobType returns the blob-category metric label for a request: the {type}
-// route param ("data", "index", ...), "config" for repository config
-// operations, "repo" for repository-level create/delete.
 func BlobType(r *http.Request) string {
 	if t := chi.URLParam(r, "type"); t != "" {
 		return t
@@ -371,9 +350,8 @@ type httpUserAttrKey struct {
 
 var httpUserAttrCache sync.Map
 
-// HttpUserMetricOption is HttpMetricOption plus the request's verified
-// identity. Used for the request count/error counters only — the duration and
-// TTFB histograms stay route-scoped to keep bucket-series cardinality down.
+// HttpUserMetricOption is HttpMetricOption plus verified identity. Count/error
+// counters only — histograms stay route-scoped to cap bucket-series cardinality.
 func HttpUserMetricOption(method, route string, status int, user, repository, connection string) otelmetric.MeasurementOption {
 	if user == "" {
 		return HttpMetricOption(method, route, status)
@@ -407,7 +385,6 @@ func cachedRoutePattern(rctx *chi.Context) string {
 	return result
 }
 
-// countingReader wraps an io.Reader and counts bytes read.
 type countingReader struct {
 	reader io.Reader
 	n      int64
@@ -419,7 +396,6 @@ func (cr *countingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// countingReadCloser wraps an io.ReadCloser and counts bytes read.
 type countingReadCloser struct {
 	io.ReadCloser
 	n int64
@@ -431,7 +407,6 @@ func (cr *countingReadCloser) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// countingWriter wraps an io.Writer and counts bytes written.
 type countingWriter struct {
 	writer io.Writer
 	n      int64
@@ -443,8 +418,6 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// ResponseWriter wraps http.ResponseWriter to count bytes written, track
-// status, and stamp when the response started (for TTFB).
 type ResponseWriter struct {
 	http.ResponseWriter
 	BytesWritten int64
@@ -496,7 +469,6 @@ func (w *ResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }
 
-// BlobMiddleware counts uploaded/downloaded bytes.
 // Must run after auth.Middleware so auth context is available, and after
 // Middleware so w is already a *ResponseWriter.
 func BlobMiddleware(m *Metrics) func(http.Handler) http.Handler {
@@ -535,13 +507,9 @@ func BlobMiddleware(m *Metrics) func(http.Handler) http.Handler {
 	}
 }
 
-// TrafficMiddleware counts requests and bytes per source network. Unlike
-// BlobMiddleware it wraps the WHOLE router and counts every outcome —
-// unauthenticated, rejected, errored — because "which network is sending this"
-// has to answer for traffic that never reached a repository.
-//
-// Must run after Middleware so w is already a *ResponseWriter, and after
-// geoip.Middleware so the source network is resolved.
+// TrafficMiddleware counts requests and bytes per source network. Wraps the
+// WHOLE router — every outcome counts, incl. unauthenticated/rejected/errored.
+// Must run after Middleware (*ResponseWriter) and geoip.Middleware (network resolved).
 func TrafficMiddleware(m *Metrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -569,26 +537,23 @@ func TrafficMiddleware(m *Metrics) func(http.Handler) http.Handler {
 	}
 }
 
-// authCapture carries the verified identity from the authed route group out to
-// Middleware, which wraps the whole router (it must observe auth failures too)
-// and therefore never sees the auth context on its own request.
+// authCapture carries the verified identity out to Middleware, which wraps the
+// whole router (must see auth failures too) and so never gets the auth context.
 type authCapture struct {
 	user       string
 	repository string
 	connection string
 
-	// Concurrency is tracked from the moment auth resolves rather than from the
-	// start of the request: before that there is no identity to attribute it to,
-	// and the unattributed prefix is a cache lookup.
+	// Concurrency tracked from auth resolution (no identity before then; the
+	// unattributed prefix is just a cache lookup).
 	tracker *clientTracker
 	state   *clientConcurrency
 }
 
 type authCaptureKey struct{}
 
-// CaptureAuth copies the request's verified identity into the holder injected
-// by Middleware so request count/error metrics can be labeled per user. Must
-// be mounted after auth.Middleware.
+// CaptureAuth copies the verified identity into Middleware's holder for
+// per-user count/error labels. Mount after auth.Middleware.
 func CaptureAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if h, _ := r.Context().Value(authCaptureKey{}).(*authCapture); h != nil {
@@ -604,7 +569,6 @@ func CaptureAuth(next http.Handler) http.Handler {
 	})
 }
 
-// Middleware records HTTP request metrics.
 func Middleware(m *Metrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -613,10 +577,8 @@ func Middleware(m *Metrics) func(http.Handler) http.Handler {
 			capture := &authCapture{tracker: m.client.tracker}
 			r = r.WithContext(context.WithValue(r.Context(), authCaptureKey{}, capture))
 
-			// Deferred: a handler panic unwinds straight past this middleware to
-			// chi's Recoverer, and an outstanding request never accounted back out
-			// would pin the client's concurrency above zero for the life of the
-			// process — inflating its reported peak and blocking idle eviction.
+			// Deferred: a panic unwinds past us to chi's Recoverer; a request never
+			// accounted out would pin concurrency >0 forever, blocking idle eviction.
 			defer func() {
 				if capture.state != nil {
 					capture.state.exit(time.Now())

--- a/packages/michael/internal/metrics/metrics_test.go
+++ b/packages/michael/internal/metrics/metrics_test.go
@@ -31,7 +31,6 @@ func TestCountingReader(t *testing.T) {
 		t.Fatalf("expected counter at 5, got %d", cr.n)
 	}
 
-	// Read remaining bytes into a larger buffer
 	buf2 := make([]byte, 32)
 	n, err = cr.Read(buf2)
 	if err != nil {
@@ -223,7 +222,6 @@ func TestResponseWriterDefaultStatus(t *testing.T) {
 	rec := &fakeResponseWriter{header: make(map[string][]string)}
 	mrw := &ResponseWriter{ResponseWriter: rec}
 
-	// Write without explicit WriteHeader should default to 200
 	if _, err := mrw.Write([]byte("data")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -279,7 +277,6 @@ func (ew *errWriter) Write(p []byte) (int, error) {
 	return 0, io.ErrClosedPipe
 }
 
-// fakeResponseWriter is a minimal http.ResponseWriter for testing.
 type fakeResponseWriter struct {
 	header map[string][]string
 	buf    bytes.Buffer
@@ -289,7 +286,6 @@ func (f *fakeResponseWriter) Header() http.Header         { return http.Header(f
 func (f *fakeResponseWriter) Write(p []byte) (int, error) { return f.buf.Write(p) }
 func (f *fakeResponseWriter) WriteHeader(int)             {}
 
-// readFromResponseWriter implements both http.ResponseWriter and io.ReaderFrom.
 type readFromResponseWriter struct {
 	header         map[string][]string
 	buf            bytes.Buffer
@@ -308,7 +304,6 @@ func TestBlobMetricOptionCacheHit(t *testing.T) {
 	a := auth.Auth{User: "u1", Repository: "r1"}
 	opt1 := BlobMetricOption(a, "data")
 	opt2 := BlobMetricOption(a, "data")
-	// Same pointer means the cache returned the same object.
 	if opt1 != opt2 {
 		t.Fatal("expected cached BlobMetricOption to return the same object")
 	}
@@ -327,7 +322,6 @@ func TestBlobMetricOptionDifferentKeys(t *testing.T) {
 }
 
 func TestHttpUserMetricOption(t *testing.T) {
-	// Empty user delegates to the route-scoped option.
 	anon := HttpUserMetricOption("GET", "/foo", 200, "", "", "immich")
 	if anon != HttpMetricOption("GET", "/foo", 200) {
 		t.Fatal("expected empty user to reuse the route-scoped option")
@@ -362,8 +356,7 @@ func TestHttpMetricOptionDifferentKeys(t *testing.T) {
 }
 
 func TestCachedRoutePattern(t *testing.T) {
-	// Build a chi router with a known route, then fire a request through it
-	// so that RoutePatterns is populated.
+	// RoutePatterns is only populated once a request has run through the router.
 	r := chi.NewRouter()
 	var captured string
 	r.Get("/api/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -379,7 +372,6 @@ func TestCachedRoutePattern(t *testing.T) {
 		t.Fatal("expected non-empty cached route pattern")
 	}
 
-	// Fire again — should hit cache and return same string.
 	var captured2 string
 	r2 := chi.NewRouter()
 	r2.Get("/api/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -415,8 +407,6 @@ func TestBlobMiddlewareUnwraps(t *testing.T) {
 	}
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// The writer passed through should be the outer ResponseWriter,
-		// not a second wrapper.
 		if _, ok := w.(*ResponseWriter); !ok {
 			t.Error("expected w to be *ResponseWriter, not a new wrapper")
 		}
@@ -427,7 +417,6 @@ func TestBlobMiddlewareUnwraps(t *testing.T) {
 
 	handler := BlobMiddleware(m)(inner)
 
-	// Wrap in a ResponseWriter (simulating Middleware).
 	rec := httptest.NewRecorder()
 	mrw := &ResponseWriter{ResponseWriter: rec}
 
@@ -443,7 +432,6 @@ func TestBlobMiddlewareUnwraps(t *testing.T) {
 }
 
 func TestBlobMetricOptionConnectionInCacheKey(t *testing.T) {
-	// Same user+repo but different connection types must not share a cache entry.
 	a := BlobMetricOption(auth.Auth{User: "u1", Repository: "r1", Connection: "immich"}, "data")
 	b := BlobMetricOption(auth.Auth{User: "u1", Repository: "r1", Connection: "restic"}, "data")
 	if a == b {

--- a/packages/michael/internal/metrics/otellog.go
+++ b/packages/michael/internal/metrics/otellog.go
@@ -12,7 +12,6 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
-// zerologLevel maps zerolog level strings to OTEL severity.
 var zerologLevel = map[string]otellog.Severity{
 	"trace": otellog.SeverityTrace,
 	"debug": otellog.SeverityDebug,
@@ -23,13 +22,11 @@ var zerologLevel = map[string]otellog.Severity{
 	"panic": otellog.SeverityFatal4,
 }
 
-// OTLPLogWriter is an io.Writer that forwards zerolog JSON lines to an OTEL log exporter.
 type OTLPLogWriter struct {
 	logger   otellog.Logger
 	provider *sdklog.LoggerProvider
 }
 
-// SetupLogProvider creates an OTEL LoggerProvider that exports via OTLP HTTP.
 func SetupLogProvider(cfg config.Config) (*sdklog.LoggerProvider, error) {
 	ctx := context.Background()
 
@@ -53,7 +50,6 @@ func SetupLogProvider(cfg config.Config) (*sdklog.LoggerProvider, error) {
 	return provider, nil
 }
 
-// NewOTLPLogWriter creates a writer that bridges zerolog JSON output to OTEL logs.
 func NewOTLPLogWriter(provider *sdklog.LoggerProvider) *OTLPLogWriter {
 	return &OTLPLogWriter{
 		logger:   provider.Logger("michael"),
@@ -61,7 +57,6 @@ func NewOTLPLogWriter(provider *sdklog.LoggerProvider) *OTLPLogWriter {
 	}
 }
 
-// Write parses a zerolog JSON line and emits it as an OTEL log record.
 func (w *OTLPLogWriter) Write(p []byte) (int, error) {
 	var entry map[string]interface{}
 	if err := json.Unmarshal(p, &entry); err != nil {
@@ -71,7 +66,6 @@ func (w *OTLPLogWriter) Write(p []byte) (int, error) {
 
 	var record otellog.Record
 
-	// Severity
 	if lvl, ok := entry["level"].(string); ok {
 		if sev, found := zerologLevel[lvl]; found {
 			record.SetSeverity(sev)
@@ -79,19 +73,16 @@ func (w *OTLPLogWriter) Write(p []byte) (int, error) {
 		}
 	}
 
-	// Timestamp
 	if ts, ok := entry["time"].(string); ok {
 		if t, err := time.Parse(time.RFC3339, ts); err == nil {
 			record.SetTimestamp(t)
 		}
 	}
 
-	// Message
 	if msg, ok := entry["message"].(string); ok {
 		record.SetBody(otellog.StringValue(msg))
 	}
 
-	// All other fields as attributes
 	attrs := make([]otellog.KeyValue, 0, len(entry))
 	for k, v := range entry {
 		switch k {
@@ -118,7 +109,6 @@ func (w *OTLPLogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Shutdown flushes and shuts down the log provider.
 func (w *OTLPLogWriter) Shutdown(ctx context.Context) error {
 	return w.provider.Shutdown(ctx)
 }

--- a/packages/michael/internal/metrics/otellog_test.go
+++ b/packages/michael/internal/metrics/otellog_test.go
@@ -11,7 +11,6 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
-// memoryExporter collects exported log records in memory for assertions.
 type memoryExporter struct {
 	mu      sync.Mutex
 	records []sdklog.Record
@@ -40,11 +39,9 @@ func TestOTLPLogWriter_InfoLog(t *testing.T) {
 	)
 	w := NewOTLPLogWriter(provider)
 
-	// Write a zerolog entry through the bridge
 	logger := zerolog.New(w).With().Timestamp().Logger()
 	logger.Info().Str("request_id", "abc-123").Str("user", "user-1").Msg("test message")
 
-	// Force flush
 	if err := provider.ForceFlush(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +53,6 @@ func TestOTLPLogWriter_InfoLog(t *testing.T) {
 
 	rec := records[0]
 
-	// Check severity
 	if rec.Severity() != otellog.SeverityInfo {
 		t.Errorf("expected SeverityInfo, got %v", rec.Severity())
 	}
@@ -64,17 +60,14 @@ func TestOTLPLogWriter_InfoLog(t *testing.T) {
 		t.Errorf("expected severity text 'info', got %q", rec.SeverityText())
 	}
 
-	// Check body
 	if rec.Body().AsString() != "test message" {
 		t.Errorf("expected body 'test message', got %q", rec.Body().AsString())
 	}
 
-	// Check timestamp is set and reasonable
 	if rec.Timestamp().IsZero() {
 		t.Error("expected non-zero timestamp")
 	}
 
-	// Check attributes contain our structured fields
 	attrs := map[string]string{}
 	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
 		attrs[kv.Key] = kv.Value.AsString()
@@ -216,7 +209,6 @@ func TestOTLPLogWriter_InvalidJSON(t *testing.T) {
 	)
 	w := NewOTLPLogWriter(provider)
 
-	// Write invalid JSON — should not panic or export anything
 	n, err := w.Write([]byte("not json at all"))
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -241,7 +233,6 @@ func TestOTLPLogWriter_Shutdown(t *testing.T) {
 	)
 	w := NewOTLPLogWriter(provider)
 
-	// Write a log, then shut down, and verify the record was flushed
 	logger := zerolog.New(w).With().Timestamp().Logger()
 	logger.Info().Msg("before shutdown")
 

--- a/packages/michael/internal/metrics/traffic_bench_test.go
+++ b/packages/michael/internal/metrics/traffic_bench_test.go
@@ -10,10 +10,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
-// Decomposes the per-request cost of source-network accounting: the attribute
-// lookup, then the three counter recordings the middleware performs. Compare
-// against geoip.BenchmarkResolve (the database side) to see which half of the
-// feature dominates.
+// Decomposes per-request cost of source-network accounting: attribute lookup,
+// then the three counter recordings. Compare geoip.BenchmarkResolve (DB side).
 
 func benchMeterMetrics(b *testing.B) *Metrics {
 	b.Helper()

--- a/packages/michael/internal/metrics/traffic_test.go
+++ b/packages/michael/internal/metrics/traffic_test.go
@@ -28,9 +28,8 @@ func TestASNOption(t *testing.T) {
 	}
 }
 
-// The middleware counts EVERY request, not just the authenticated 2xx ones the
-// blobs.* family covers: a rejected flood is exactly what a per-network view is
-// for, and it moves almost no bytes.
+// Counts EVERY request, not just authed 2xx (blobs.*): a rejected flood is the
+// per-network view's point, and it moves almost no bytes.
 func TestTrafficMiddlewareCountsRejectedRequests(t *testing.T) {
 	reader := metric.NewManualReader()
 	m, err := NewMetrics(metric.NewMeterProvider(metric.WithReader(reader)).Meter("test"))

--- a/packages/michael/internal/metrics/transport.go
+++ b/packages/michael/internal/metrics/transport.go
@@ -12,10 +12,8 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
-// TransportMetrics instruments the per-backend S3 HTTP transports: connection
-// churn (dials, reuse ratio), TLS handshake cost, and time-to-first-byte from
-// the gateway. These separate RGW latency from michael's own overhead and
-// prove out connection-pool tuning.
+// Instruments dials/reuse, TLS handshake cost, and gateway TTFB per backend,
+// separating RGW latency from michael overhead.
 type TransportMetrics struct {
 	dials       otelmetric.Int64Counter
 	conns       otelmetric.Int64Counter
@@ -60,9 +58,8 @@ func NewTransportMetrics(meter otelmetric.Meter) (*TransportMetrics, error) {
 	}, nil
 }
 
-// Wrap returns rt instrumented with per-request httptrace hooks, labeled with
-// the backend's address and the storage cluster it belongs to. The cluster
-// label is what keeps two clusters apart when their gateways share an address.
+// Wrap instruments rt with httptrace hooks, labeled cluster+backend; the
+// cluster label keeps clusters apart when gateways share an address.
 func (t *TransportMetrics) Wrap(cluster, backend string, rt http.RoundTripper) http.RoundTripper {
 	return &tracedTransport{tm: t, cluster: cluster, backend: backend, rt: rt}
 }
@@ -99,8 +96,6 @@ func (t *tracedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	return t.rt.RoundTrip(req.WithContext(httptrace.WithClientTrace(ctx, trace)))
 }
-
-// --- cached attribute options (hot path, same pattern as HttpMetricOption) ---
 
 type backendAttrKey struct{ cluster, backend string }
 

--- a/packages/michael/internal/storage/pool.go
+++ b/packages/michael/internal/storage/pool.go
@@ -11,25 +11,19 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// probeTimeout bounds a single health probe. Without it a probe against an
-// unreachable (blackholed, not refused) backend runs to the 30s dial timeout.
+// probeTimeout bounds a probe; a blackholed (not refused) backend otherwise
+// runs to the 30s dial timeout.
 const probeTimeout = 5 * time.Second
 
-// ErrNoBackends is returned when the pool has no backend to route a request to.
 var ErrNoBackends = errors.New("no S3 backends available")
 
-// Prober is implemented by backends that support an active liveness probe.
-// *S3Storage satisfies it; the reconciler skips probing for stores that don't.
+// The reconciler skips probing for stores that don't implement this.
 type Prober interface {
 	Probe(ctx context.Context, bucket string) error
 }
 
-// BackendFactory builds a Storage bound to a single endpoint. The production
-// factory wraps NewS3StorageForEndpoint; tests inject in-memory fakes.
 type BackendFactory func(endpoint string) (Storage, error)
 
-// BackendStat is a point-in-time snapshot of one backend, consumed by the
-// metrics layer to emit per-backend series.
 type BackendStat struct {
 	Endpoint        string
 	Healthy         bool
@@ -40,9 +34,8 @@ type BackendStat struct {
 	UploadedBytes   int64
 }
 
-// backend holds one endpoint's client plus lock-free counters. A *backend is
-// stable for its lifetime — reconcile swaps the Pool's slice but reuses the
-// same *backend for endpoints that persist, so its atomics survive.
+// backend holds one endpoint's client plus lock-free counters. reconcile swaps
+// the slice but reuses the same *backend for persisting endpoints, so atomics survive.
 type backend struct {
 	endpoint string
 	store    Storage
@@ -58,19 +51,15 @@ type backend struct {
 	uploadedBytes   atomic.Int64
 }
 
-// PoolConfig holds the tunables for a Pool.
 type PoolConfig struct {
 	EjectThreshold    int           // consecutive transport failures before ejection
 	ProbeBucket       string        // sentinel bucket name for active health probes
 	ReconcileInterval time.Duration // how often Run re-resolves and probes
 }
 
-// Pool implements Storage by load-balancing requests across a set of
-// interchangeable S3 gateway backends. It picks the backend with the fewest
-// outstanding requests, ejects backends after consecutive transport failures,
-// and actively probes to reinstate them. The pool never retries a failed
-// request — it records the failure and returns it, leaving retries to the
-// client (restic).
+// Pool implements Storage across interchangeable S3 gateways: least-outstanding
+// pick, ejection after consecutive transport failures, active probes to
+// reinstate. Never retries a failed request — restic retries.
 type Pool struct {
 	backends    atomic.Pointer[[]*backend]
 	factory     BackendFactory
@@ -84,8 +73,8 @@ type Pool struct {
 
 var _ Storage = (*Pool)(nil)
 
-// NewPool resolves the initial backend set, probes it, and returns a ready
-// pool. It errors if the source can't be resolved or yields no backends.
+// Probes the initial set; errors if the source can't be resolved or yields no
+// backends.
 func NewPool(cfg PoolConfig, factory BackendFactory, resolver Resolver, logger zerolog.Logger) (*Pool, error) {
 	p := &Pool{
 		factory:     factory,
@@ -115,7 +104,6 @@ func NewPool(cfg PoolConfig, factory BackendFactory, resolver Resolver, logger z
 
 func (p *Pool) snapshot() []*backend { return *p.backends.Load() }
 
-// Run drives Reconcile on a ticker until ctx is cancelled.
 func (p *Pool) Run(ctx context.Context) {
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
@@ -129,8 +117,7 @@ func (p *Pool) Run(ctx context.Context) {
 	}
 }
 
-// Reconcile re-resolves the backend set and probes every backend. Exported so
-// tests can drive it deterministically without timers.
+// Exported so tests can drive it deterministically without timers.
 func (p *Pool) Reconcile(ctx context.Context) error {
 	endpoints, err := p.resolver.Resolve(ctx)
 	switch {
@@ -148,10 +135,9 @@ func (p *Pool) Reconcile(ctx context.Context) error {
 	return err
 }
 
-// applyEndpoints diffs the desired endpoint set against the current backends,
-// reusing existing *backend objects (preserving their health/counters) and
-// constructing new ones for added endpoints. New backends start unhealthy; the
-// probe in this same reconcile promotes the live ones.
+// applyEndpoints diffs desired vs current, reusing existing *backend objects
+// (health/counters preserved). New backends start unhealthy until this
+// reconcile's probe promotes them.
 func (p *Pool) applyEndpoints(endpoints []string) {
 	current := p.snapshot()
 	byEndpoint := make(map[string]*backend, len(current))
@@ -191,11 +177,9 @@ func (p *Pool) applyEndpoints(endpoints []string) {
 	p.backends.Store(&next)
 }
 
-// probeAll actively checks every backend, ejecting those that fail the probe
-// and reinstating (clearing the passive failure streak of) those that pass.
-// Probes run concurrently with a per-probe timeout, so a reconcile costs
-// max(probe) rather than sum — N unreachable backends once serialized N×30s
-// dial timeouts into pool init and crash-looped startup.
+// probeAll probes every backend concurrently (eject on fail, reinstate + clear
+// streak on pass); reconcile costs max(probe) not sum — N unreachable backends
+// once serialized N×30s dials and crash-looped startup.
 func (p *Pool) probeAll(ctx context.Context) {
 	var wg sync.WaitGroup
 	for _, b := range p.snapshot() {
@@ -229,10 +213,8 @@ func (p *Pool) probeOne(ctx context.Context, b *backend) {
 	}
 }
 
-// pick selects the healthy backend with the fewest outstanding requests. Ties
-// are broken by a rotating offset so equal-load backends are used round-robin.
-// If nothing is healthy it fails open to the least-loaded backend overall,
-// degrading rather than refusing service.
+// pick selects the healthy backend with fewest outstanding requests (rotating
+// tie-break); if none healthy, fails open to least-loaded overall.
 func (p *Pool) pick() *backend {
 	bs := p.snapshot()
 	n := len(bs)
@@ -263,10 +245,9 @@ func (p *Pool) pick() *backend {
 	return fallback
 }
 
-// recordResult updates a backend's counters and passive-ejection state after a
-// completed operation. A transport failure increments the consecutive-failure
-// streak and ejects once it crosses the threshold; any non-transport outcome
-// (success, or a normal 4xx like a missing blob) proves liveness and resets it.
+// recordResult updates counters and passive ejection: transport failure bumps
+// the streak (eject at threshold); any non-transport outcome (incl. normal 4xx)
+// proves liveness and resets it.
 func (p *Pool) recordResult(b *backend, err error) {
 	b.requests.Add(1)
 	if isBackendFailure(err) {
@@ -280,8 +261,6 @@ func (p *Pool) recordResult(b *backend, err error) {
 	b.failures.Store(0)
 }
 
-// do runs an in-call operation (one that completes before returning) on a
-// picked backend, accounting inflight and recording the result.
 func (p *Pool) do(fn func(s Storage) error) error {
 	b := p.pick()
 	if b == nil {
@@ -294,7 +273,6 @@ func (p *Pool) do(fn func(s Storage) error) error {
 	return err
 }
 
-// Stats returns a per-backend snapshot for the metrics layer.
 func (p *Pool) Stats() []BackendStat {
 	bs := p.snapshot()
 	stats := make([]BackendStat, 0, len(bs))
@@ -311,8 +289,6 @@ func (p *Pool) Stats() []BackendStat {
 	}
 	return stats
 }
-
-// --- Storage interface ---
 
 func (p *Pool) CheckBucket(ctx context.Context, bucket string) (bool, error) {
 	var exists bool
@@ -357,8 +333,7 @@ func (p *Pool) PutObject(ctx context.Context, bucket, key string, body io.Reader
 	if b == nil {
 		return ErrNoBackends
 	}
-	// The body is fully consumed and uploaded before PutObject returns, so the
-	// upload — the large transfer — is accounted end-to-end here.
+	// Body fully uploads before return, so the transfer is accounted end-to-end.
 	b.inflight.Add(1)
 	err := b.store.PutObject(ctx, bucket, key, body, contentLength, writeOnce, sha256Hex)
 	b.inflight.Add(-1)
@@ -374,8 +349,7 @@ func (p *Pool) GetObject(ctx context.Context, bucket, key, rangeHeader string) (
 	if b == nil {
 		return nil, ErrNoBackends
 	}
-	// The SDK returns headers here but the body is streamed by the caller after
-	// we return, so inflight must stay counted until the body is closed.
+	// Caller streams the body after we return; inflight stays counted until Close.
 	b.inflight.Add(1)
 	obj, err := b.store.GetObject(ctx, bucket, key, rangeHeader)
 	if err != nil {
@@ -387,10 +361,8 @@ func (p *Pool) GetObject(ctx context.Context, bucket, key, rangeHeader string) (
 	return obj, nil
 }
 
-// poolBody wraps a GetObject body so that closing it releases the inflight slot,
-// records downloaded bytes, and reports any mid-stream read failure toward the
-// backend's health (a read error from a dead gateway has no HTTP status and so
-// counts as a transport failure).
+// poolBody: Close releases the inflight slot, records downloaded bytes, and
+// counts mid-stream read errors toward health (no HTTP status ⇒ transport failure).
 type poolBody struct {
 	io.ReadCloser
 	pool    *Pool

--- a/packages/michael/internal/storage/pool_test.go
+++ b/packages/michael/internal/storage/pool_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// --- fakes ---
-
-// fakeStore is an in-memory Storage used to drive the pool without real S3. It
-// can be toggled to fail operations (transport-style) and to fail probes.
 type fakeStore struct {
 	endpoint  string
 	opFail    atomic.Bool
@@ -117,8 +113,6 @@ func (e *errReadCloser) Read(p []byte) (int, error) {
 }
 func (e *errReadCloser) Close() error { return nil }
 
-// --- test harness ---
-
 type testResolver struct {
 	mu  sync.Mutex
 	eps []string
@@ -167,12 +161,9 @@ func backendByEndpoint(p *Pool, ep string) *backend {
 	return nil
 }
 
-// --- tests ---
-
 func TestPool_PickLeastOutstanding(t *testing.T) {
 	p, _, _ := newTestPool(t, []string{"a", "b", "c"}, 3)
 	bs := p.snapshot()
-	// Give them distinct inflight loads; pick must choose the minimum.
 	for _, b := range bs {
 		switch b.endpoint {
 		case "a":
@@ -191,7 +182,6 @@ func TestPool_PickLeastOutstanding(t *testing.T) {
 
 func TestPool_PickTiebreakRotates(t *testing.T) {
 	p, _, _ := newTestPool(t, []string{"a", "b", "c"}, 3)
-	// All equal load => tiebreak should rotate across backends.
 	seen := map[string]int{}
 	for range 30 {
 		seen[p.pick().endpoint]++
@@ -224,14 +214,12 @@ func TestPool_EjectAfterThresholdThenReinstate(t *testing.T) {
 		t.Fatal("backend should start healthy after initial probe")
 	}
 
-	// Two failures: still healthy (no immediate ejection).
 	reg["a"].opFail.Store(true)
 	p.HeadObject(context.Background(), "bucket", "k")
 	p.HeadObject(context.Background(), "bucket", "k")
 	if !b.healthy.Load() {
 		t.Error("ejected before reaching threshold")
 	}
-	// Third consecutive failure: ejected.
 	p.HeadObject(context.Background(), "bucket", "k")
 	if b.healthy.Load() {
 		t.Error("expected ejection after threshold failures")
@@ -240,7 +228,6 @@ func TestPool_EjectAfterThresholdThenReinstate(t *testing.T) {
 		t.Errorf("expected 3 recorded errors, got %d", b.errors.Load())
 	}
 
-	// Active probe reinstates once the backend recovers.
 	reg["a"].opFail.Store(false)
 	p.Reconcile(context.Background())
 	if !b.healthy.Load() {
@@ -255,9 +242,7 @@ func TestPool_AppErrorDoesNotEject(t *testing.T) {
 	p, _, reg := newTestPool(t, []string{"a"}, 1) // threshold 1: any transport failure ejects
 	b := backendByEndpoint(p, "a")
 
-	// Make GetObject return a 404-style app error (not a backend failure).
 	reg["a"].getErr = nil
-	// Simulate via recordResult directly with an HTTP 404 error.
 	p.recordResult(b, &httpError{statusCode: 404})
 	if !b.healthy.Load() {
 		t.Error("app-level 404 must not eject the backend")
@@ -322,7 +307,6 @@ func TestPool_ReconcileAddsAndRemoves(t *testing.T) {
 		t.Fatalf("expected 2 backends, got %d", len(p.snapshot()))
 	}
 
-	// Remove b, add c.
 	res.set([]string{"a", "c"}, nil)
 	p.Reconcile(context.Background())
 
@@ -333,11 +317,9 @@ func TestPool_ReconcileAddsAndRemoves(t *testing.T) {
 	if !eps["a"] || !eps["c"] || eps["b"] || len(eps) != 2 {
 		t.Errorf("after reconcile expected {a,c}, got %v", eps)
 	}
-	// 'a' must be reused (same pointer survives) and stay healthy.
 	if !backendByEndpoint(p, "a").healthy.Load() {
 		t.Error("surviving backend 'a' should remain healthy")
 	}
-	// 'c' is newly added and promoted by the probe in the same reconcile.
 	if !backendByEndpoint(p, "c").healthy.Load() {
 		t.Error("new backend 'c' should be probed healthy")
 	}
@@ -355,7 +337,6 @@ func TestPool_ReconcileEjectsViaProbe(t *testing.T) {
 		t.Error("'b' should remain healthy")
 	}
 
-	// Recovery: probe passes again, backend reinstated.
 	reg["a"].probeFail.Store(false)
 	p.Reconcile(context.Background())
 	if !backendByEndpoint(p, "a").healthy.Load() {
@@ -387,7 +368,6 @@ func TestPool_ConcurrentRequestsDuringReconcile(t *testing.T) {
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
 
-	// Hammer the hot path from several goroutines.
 	for range 8 {
 		wg.Go(func() {
 			for {
@@ -405,7 +385,6 @@ func TestPool_ConcurrentRequestsDuringReconcile(t *testing.T) {
 		})
 	}
 
-	// Concurrently churn the backend set and probe.
 	wg.Go(func() {
 		sets := [][]string{{"a", "b"}, {"a", "b", "c", "d"}, {"b", "c"}, {"a", "b", "c"}}
 		for i := range 200 {
@@ -427,7 +406,6 @@ func TestPool_ConcurrentRequestsDuringReconcile(t *testing.T) {
 
 func TestPool_StatsReflectActivity(t *testing.T) {
 	p, _, _ := newTestPool(t, []string{"a", "b"}, 3)
-	// Drive some successful ops.
 	for range 4 {
 		p.HeadObject(context.Background(), "bucket", "k")
 	}
@@ -458,9 +436,8 @@ func (s *slowProbeStore) Probe(ctx context.Context, _ string) error {
 	return ctx.Err()
 }
 
-// Probes must run concurrently and be bounded by probeTimeout: N unreachable
-// backends cost one timeout, not N — serial unbounded probes once pushed pool
-// init past the kubelet startup budget and crash-looped the deployment.
+// Probes run concurrently, bounded by probeTimeout: N unreachable backends cost
+// one timeout, not N (serial unbounded probes once crash-looped startup).
 func TestPool_ProbesConcurrentAndBounded(t *testing.T) {
 	const n = 8
 	eps := make([]string, n)

--- a/packages/michael/internal/storage/resolver.go
+++ b/packages/michael/internal/storage/resolver.go
@@ -11,20 +11,16 @@ import (
 	"strings"
 )
 
-// Resolver discovers the set of backend S3 endpoints the pool should balance
-// across. Resolve is called once at startup and again on every reconcile tick,
-// so implementations are expected to re-read their source each call (hot
-// reload). Each returned element is a full endpoint URL, e.g.
+// Resolve runs at startup and every reconcile tick — implementations re-read
+// their source each call (hot reload). Elements are full endpoint URLs, e.g.
 // "http://10.0.1.5:80".
 type Resolver interface {
 	Resolve(ctx context.Context) ([]string, error)
-	// Describe returns a short human-readable description of the source, for logs.
 	Describe() string
 }
 
-// FileResolver reads endpoints from a file, one per line. Blank lines and lines
-// beginning with '#' are ignored. The file is re-read on every Resolve call, so
-// editing it hot-reloads the backend set on the next reconcile tick.
+// FileResolver reads endpoints one per line (blank/'#' lines ignored),
+// re-reading every Resolve — edits hot-reload on the next tick.
 type FileResolver struct {
 	Path string
 }
@@ -57,11 +53,9 @@ func (r *FileResolver) Resolve(_ context.Context) ([]string, error) {
 	return dedupeSorted(endpoints), nil
 }
 
-// DNSResolver resolves a hostname to its A/AAAA records and templates each
-// resolved IP into an endpoint URL using Scheme and Port. This maps a headless
-// Kubernetes Service (e.g. the Ceph RGW pods) to one backend per pod, so the
-// pool balances across gateways directly instead of through a single Service
-// VIP. Re-resolved on every reconcile tick to track pod churn.
+// DNSResolver templates each A/AAAA record into Scheme://IP:Port — a headless
+// k8s Service (Ceph RGW pods) becomes one backend per pod, balanced directly
+// rather than via a Service VIP. Re-resolved each tick to track pod churn.
 type DNSResolver struct {
 	Host   string
 	Scheme string

--- a/packages/michael/internal/storage/resolver_test.go
+++ b/packages/michael/internal/storage/resolver_test.go
@@ -47,7 +47,6 @@ func TestFileResolver_HotReload(t *testing.T) {
 		t.Fatalf("first resolve: got %v", got)
 	}
 
-	// Rewrite the file: next Resolve must reflect the change.
 	if err := os.WriteFile(path, []byte("http://a:80\nhttp://b:80\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/packages/michael/internal/storage/s3.go
+++ b/packages/michael/internal/storage/s3.go
@@ -59,28 +59,19 @@ func NewS3Storage(cfg config.Config) *S3Storage {
 	return NewS3StorageForEndpoint(cfg, cfg.S3Endpoint)
 }
 
-// S3Options describes how to build one backend's S3 client.
 type S3Options struct {
-	// Endpoint is the BaseEndpoint the SDK uses for routing, the Host header,
-	// and SigV4 signing. This is the address the backend gateway must accept in
-	// its zonegroup hostname list.
+	// Endpoint drives SDK routing, Host header, and SigV4 signing; must be in
+	// the gateway's zonegroup hostname list.
 	Endpoint string
-	// DialAddr, when set, pins the underlying TCP connection to this host:port
-	// regardless of Endpoint's host. This lets michael sign with a fixed
-	// hostname (Endpoint) while load-balancing across specific gateway IPs —
-	// the job HAProxy used to do. Empty means dial Endpoint's host normally.
+	// DialAddr, when set, pins the TCP connection to this host:port while
+	// Endpoint keeps driving signing/Host — fixed-hostname signing with per-IP
+	// load-balancing (ex-HAProxy job). Empty = dial Endpoint's host.
 	DialAddr string
-	// TLSSkipVerify disables TLS certificate verification, for gateways behind a
-	// self-signed cert (matching HAProxy's `ssl verify none`).
+	// TLSSkipVerify: for self-signed gateway certs (HAProxy `ssl verify none` equivalent).
 	TLSSkipVerify bool
-	// Wrap, when set, wraps the backend's transport (e.g. with per-backend
-	// client metrics).
-	Wrap func(http.RoundTripper) http.RoundTripper
+	Wrap          func(http.RoundTripper) http.RoundTripper
 }
 
-// NewS3StorageForEndpoint builds an S3Storage bound to a specific endpoint,
-// reusing the credentials/region/path-style from cfg. The load-balancing pool
-// uses this to stamp out one client per backend gateway.
 func NewS3StorageForEndpoint(cfg config.Config, endpoint string) *S3Storage {
 	return NewS3StorageWithOptions(cfg, S3Options{
 		Endpoint:      endpoint,
@@ -88,16 +79,11 @@ func NewS3StorageForEndpoint(cfg config.Config, endpoint string) *S3Storage {
 	})
 }
 
-// NewS3StorageWithOptions builds an S3Storage for the default storage cluster
-// with explicit per-backend options (host-pinned dialing and/or TLS
-// skip-verify) layered on the cfg credentials.
 func NewS3StorageWithOptions(cfg config.Config, opts S3Options) *S3Storage {
 	return NewS3StorageForCluster(cfg.DefaultCluster(), opts)
 }
 
-// NewS3StorageForCluster builds an S3Storage against one storage cluster's
-// credentials, region, and path-style. Each cluster michael fronts has its own
-// object-user, so credentials cannot be shared across clusters.
+// Each cluster has its own object-user, so credentials can't be shared.
 func NewS3StorageForCluster(cc config.ClusterConfig, opts S3Options) *S3Storage {
 	s3opts := s3.Options{
 		Region: cc.S3Region,
@@ -113,16 +99,14 @@ func NewS3StorageForCluster(cc config.ClusterConfig, opts S3Options) *S3Storage 
 	return &S3Storage{client: s3.New(s3opts)}
 }
 
-// buildHTTPClient builds the HTTP client for one backend. Always custom (never
-// the SDK default), so connection pooling behaves identically across
-// dev/staging/prod regardless of pin-host or TLS settings.
+// Always custom (never the SDK default) so pooling behaves identically across
+// dev/staging/prod.
 func buildHTTPClient(opts S3Options) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
-	// Each transport serves a single gateway, and restic fans out far more
-	// concurrent requests than the default per-host idle cap of 2 — anything
-	// past that paid a fresh TCP+TLS handshake. Buffers sized for multi-MB
-	// pack transfers (defaults are 4KB).
+	// One gateway per transport; restic's fan-out blows past the default
+	// per-host idle cap of 2 (fresh TCP+TLS beyond it). Buffers sized for
+	// multi-MB packs (defaults 4KB).
 	transport.MaxIdleConns = 0
 	transport.MaxIdleConnsPerHost = 128
 	transport.IdleConnTimeout = 120 * time.Second
@@ -141,9 +125,8 @@ func buildHTTPClient(opts S3Options) *http.Client {
 		if base == nil {
 			base = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
 		}
-		// Ignore the address the SDK derived from the URL host and dial the
-		// pinned backend instead. The URL host still drives the Host header,
-		// SNI, and signature, so the gateway sees the expected hostname.
+		// Dial the pinned backend, not the URL host; the URL host still drives
+		// Host header, SNI, and signature.
 		transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
 			return base(ctx, network, opts.DialAddr)
 		}
@@ -156,13 +139,10 @@ func buildHTTPClient(opts S3Options) *http.Client {
 	return &http.Client{Transport: rt}
 }
 
-// Probe performs a cheap liveness check against the backend gateway. It issues a
-// HeadBucket on a sentinel bucket: any HTTP response (even 404/403, meaning the
-// bucket is absent or access-denied) proves the gateway is serving, so only a
-// transport-level failure (dial refused, timeout, 5xx) is treated as unhealthy.
+// Probe: HeadBucket on a sentinel bucket. Any HTTP response (even 404/403)
+// proves the gateway serves; only transport failure/5xx is unhealthy.
 func (s *S3Storage) Probe(ctx context.Context, bucket string) error {
-	// Single-shot: a probe must not be silently retried by the SDK, or a dead
-	// gateway would look slow-but-alive and add latency to every reconcile.
+	// Single-shot: SDK retries would make a dead gateway look slow-but-alive.
 	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}, func(o *s3.Options) {
@@ -183,7 +163,6 @@ func (s *S3Storage) CheckBucket(ctx context.Context, bucket string) (bool, error
 		if errors.As(err, &notFound) {
 			return false, nil
 		}
-		// Also check for 404 in the operation error
 		var noSuchBucket *types.NoSuchBucket
 		if errors.As(err, &noSuchBucket) {
 			return false, nil
@@ -269,14 +248,11 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 		input.IfNoneMatch = aws.String("*")
 	}
 
-	// Use unsigned payload so the SDK doesn't need to seek the body for signing.
-	// RetryMaxAttempts=1 (no SDK retry): the body is restic's non-seekable
-	// proxied stream, so any retry would try to rewind it and fail with "failed
-	// to rewind transport stream for retry, request stream is not seekable" —
-	// masking the real backend error and, under load, stalling clients on a
-	// large fraction of PUTs. With retries off, a transient gateway error
-	// surfaces cleanly and restic retries the pack itself (its body IS
-	// seekable). See TestPutObject_NonSeekableBodyOn503_NoRewindRetry.
+	// Unsigned payload: no body seek needed for signing. RetryMaxAttempts=1:
+	// the body is restic's non-seekable proxied stream — an SDK retry fails with
+	// "failed to rewind transport stream", masking the real error and stalling
+	// PUTs under load; restic retries the pack itself (its body IS seekable).
+	// See TestPutObject_NonSeekableBodyOn503_NoRewindRetry.
 	_, err := s.client.PutObject(ctx, input, s3.WithAPIOptions(
 		v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
 	), func(o *s3.Options) {
@@ -301,7 +277,6 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 	return nil
 }
 
-// sha256Writer wraps a hash.Hash for use with io.TeeReader.
 type sha256Writer struct {
 	hash interface {
 		Write(p []byte) (n int, err error)
@@ -313,11 +288,9 @@ func (w *sha256Writer) Write(p []byte) (n int, err error) {
 	return w.hash.Write(p)
 }
 
-// ListObjects streams every object under prefix to fn as pages arrive, instead
-// of buffering the whole listing — restic's REST protocol has no pagination, so
-// a large repo is one response and TTFB otherwise waits on every ListObjectsV2
-// page (1000 keys each). Names are full object keys; callers strip what they
-// need. An fn error aborts the walk.
+// ListObjects streams each page to fn instead of buffering: restic's REST
+// protocol has no pagination, so a large repo is one response and TTFB would
+// otherwise wait on every 1000-key page. Names are full keys; fn error aborts.
 func (s *S3Storage) ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error {
 	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
@@ -351,8 +324,6 @@ func (s *S3Storage) DeleteObject(ctx context.Context, bucket, key string) error 
 	return nil
 }
 
-// IsNotFound reports whether err is an S3 404 — the object (or bucket) does
-// not exist, as opposed to a storage failure.
 func IsNotFound(err error) bool {
 	var notFound *types.NotFound
 	if errors.As(err, &notFound) {
@@ -371,7 +342,6 @@ func IsNotFound(err error) bool {
 	return false
 }
 
-// isPreconditionFailed checks if an S3 error is a 412 Precondition Failed.
 func isPreconditionFailed(err error) bool {
 	// aws-sdk-go-v2 wraps HTTP status in the operation error
 	var apiErr interface {
@@ -383,19 +353,15 @@ func isPreconditionFailed(err error) bool {
 	return false
 }
 
-// isBackendFailure reports whether err indicates the S3 backend (gateway) is
-// unhealthy, as opposed to a normal application-level response. A 4xx status
-// (404 missing, 403 denied, 409 conflict, 412 precondition, …) means the
-// gateway responded correctly and is NOT a health failure. A 5xx status, or an
-// error carrying no HTTP status at all (dial refused, timeout, connection
-// reset, unexpected EOF), is a transport/backend failure.
+// isBackendFailure reports gateway unhealth: 4xx = gateway responded fine (not
+// a health failure); 5xx or no HTTP status (dial refused, timeout, reset,
+// unexpected EOF) = transport/backend failure.
 func isBackendFailure(err error) bool {
 	if err == nil {
 		return false
 	}
-	// A cancelled/expired context is the caller giving up (e.g. the restic
-	// client disconnected mid-stream), not a backend health signal — don't let
-	// it eject an otherwise-healthy gateway.
+	// Cancelled/expired context = caller gave up (client disconnect), not a
+	// backend health signal — must not eject a healthy gateway.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
@@ -404,9 +370,8 @@ func isBackendFailure(err error) bool {
 	}
 	if errors.As(err, &apiErr) {
 		code := apiErr.HTTPStatusCode()
-		// A transport failure (dial refused, timeout, reset) is surfaced by the
-		// SDK as a ResponseError with StatusCode 0 — no response ever reached
-		// us, so treat it as a backend failure alongside real 5xx responses.
+		// SDK surfaces transport failures as ResponseError with StatusCode 0 —
+		// no response reached us; treat like 5xx.
 		return code == 0 || code >= 500
 	}
 	// No HTTP status at all: the request never got a response from the gateway.

--- a/packages/michael/internal/storage/s3_test.go
+++ b/packages/michael/internal/storage/s3_test.go
@@ -15,10 +15,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-// readOnly hides any io.Seeker the underlying reader implements, so the value
-// handed to the S3 SDK is a plain, non-seekable stream — exactly what michael
-// proxies in production (restic's r.Body, further wrapped in an io.TeeReader
-// for hashing). The SDK cannot rewind it to retry.
+// readOnly hides io.Seeker so the SDK gets a plain non-seekable stream — what
+// michael proxies in prod (restic's r.Body wrapped in a TeeReader for hashing).
+// The SDK cannot rewind it to retry.
 type readOnly struct{ r io.Reader }
 
 func (ro readOnly) Read(p []byte) (int, error) { return ro.r.Read(p) }
@@ -99,9 +98,8 @@ func TestIsNotFound(t *testing.T) {
 }
 
 func TestListObjects_PaginatesAllPages(t *testing.T) {
-	// Restic's REST listing has no pagination, so ListObjects must walk every
-	// ListObjectsV2 page — a repo past 1000 keys otherwise gets silently
-	// truncated and restic reports the tail packs as missing.
+	// Restic's REST listing has no pagination: ListObjects must walk every
+	// ListObjectsV2 page or a >1000-key repo silently truncates (tail packs "missing").
 	var tokens []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := r.URL.Query().Get("continuation-token")
@@ -152,7 +150,6 @@ func TestListObjects_PaginatesAllPages(t *testing.T) {
 }
 
 func TestListObjects_EmptyListing(t *testing.T) {
-	// An empty listing completes without invoking the callback.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
 		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
@@ -177,18 +174,13 @@ func TestListObjects_EmptyListing(t *testing.T) {
 	}
 }
 
-// TestPutObject_NonSeekableBodyOn503_NoRewindRetry reproduces the production
-// throughput collapse: michael streams restic's non-seekable pack body straight
-// into S3 PutObject, and when the gateway returns a retryable 5xx the SDK's
-// default retryer tries to rewind the body to resend it — which fails with
-// "failed to rewind transport stream for retry, request stream is not seekable"
-// and surfaces as an opaque 500 to restic. Under load this hit ~28% of requests
-// and stalled the whole fleet.
-//
-// The desired behaviour (asserted here) is: no rewind is ever attempted, exactly
-// one upload is made, and the caller gets the clean underlying backend error —
-// which restic retries at the pack level (its own body IS seekable). RED before
-// the s3.go RetryMaxAttempts=1 fix, GREEN after.
+// TestPutObject_NonSeekableBodyOn503_NoRewindRetry reproduces the prod
+// throughput collapse: on a retryable 5xx the SDK retryer rewound restic's
+// non-seekable pack body — "failed to rewind transport stream for retry" —
+// surfacing as an opaque 500 (~28% of requests under load, fleet stalled).
+// Asserts: no rewind attempted, exactly one upload, clean underlying backend
+// error (restic retries the pack; its body IS seekable). RED before the s3.go
+// RetryMaxAttempts=1 fix, GREEN after.
 func TestPutObject_NonSeekableBodyOn503_NoRewindRetry(t *testing.T) {
 	var puts int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -267,7 +259,6 @@ func TestProbe_UnhealthyOn503(t *testing.T) {
 }
 
 func TestProbe_UnhealthyOnConnRefused(t *testing.T) {
-	// Start a server then close it so the port refuses connections.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	url := srv.URL
 	srv.Close()
@@ -279,10 +270,9 @@ func TestProbe_UnhealthyOnConnRefused(t *testing.T) {
 }
 
 func TestNewS3StorageWithOptions_PinsDialAndPreservesHost(t *testing.T) {
-	// A stand-in gateway. We point DialAddr at it but give the SDK an
-	// unresolvable signing host — if the request arrives, the pin worked, and
-	// the recorded Host proves signing/Host used the signing endpoint, not the
-	// dial IP. This is exactly the HAProxy-replacement behavior.
+	// Stand-in gateway: DialAddr points here, the signing host is unresolvable —
+	// arrival proves the pin; the recorded Host proves signing used the
+	// endpoint, not the dial IP (HAProxy-replacement behavior).
 	var gotHost string
 	hit := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -316,7 +306,6 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 	defer srv.Close()
 	dialAddr := srv.Listener.Addr().String()
 
-	// Without skip-verify, the self-signed cert must fail the probe.
 	noSkip := NewS3StorageWithOptions(probeConfig(), S3Options{
 		Endpoint: "https://s3.signing-host.invalid",
 		DialAddr: dialAddr,
@@ -325,7 +314,6 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 		t.Error("expected TLS verification failure without skip-verify")
 	}
 
-	// With skip-verify, it must succeed (gateway answered 404 = alive).
 	skip := NewS3StorageWithOptions(probeConfig(), S3Options{
 		Endpoint:      "https://s3.signing-host.invalid",
 		DialAddr:      dialAddr,
@@ -335,8 +323,6 @@ func TestNewS3StorageWithOptions_TLSSkipVerify(t *testing.T) {
 		t.Errorf("Probe with skip-verify against self-signed gateway: %v", err)
 	}
 }
-
-// test helpers
 
 type genericError struct {
 	msg string

--- a/packages/michael/main.go
+++ b/packages/michael/main.go
@@ -49,10 +49,9 @@ func main() {
 	log.Logger = zerolog.New(output).With().Timestamp().Caller().Logger()
 	zerolog.SetGlobalLevel(cfg.LogLevel)
 
-	// Bind the listener BEFORE the (potentially slow) backend pool init, so the
-	// kubelet's tcpSocket startup probe sees the process as alive while probes
-	// run. With the port bound late, N unreachable backends once pushed init
-	// past the startup budget and crash-looped the deployment.
+	// Bind the listener BEFORE slow pool init so the kubelet tcpSocket startup
+	// probe sees us alive — late binding once crash-looped the deployment when
+	// N unreachable backends pushed init past the startup budget.
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -98,10 +97,8 @@ func main() {
 		}
 	}
 
-	// A missing or unreadable ASN database is NOT fatal: source-network labels
-	// are an observability nicety, and failing the backup data plane over them
-	// would be the wrong trade. The nil database resolves every public address
-	// to "unknown", so the series stay continuous either way.
+	// Missing/unreadable ASN DB is NOT fatal — don't fail the backup data plane
+	// over an observability nicety; nil DB resolves public addresses to "unknown".
 	asnDB, err := geoip.Open(cfg.ASNDatabasePath)
 	if err != nil {
 		log.Warn().Err(err).Msg("ASN database unavailable; traffic will not be attributed to source networks")
@@ -119,11 +116,9 @@ func main() {
 		Handler: srv.Handler(),
 	}
 
-	// Graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Drive each backend pool's reconcile/probe loop until shutdown.
 	for _, pool := range pools {
 		go pool.Run(ctx)
 	}
@@ -164,11 +159,7 @@ func main() {
 	log.Info().Msg("shutdown complete")
 }
 
-// buildClusters builds one Storage per storage cluster michael fronts, keyed by
-// cluster code, plus the subset of those that are load-balancing pools (returned
-// concretely so the caller can register their metrics and run their reconcile
-// loops). A single-cluster deployment yields exactly one entry, under
-// cfg.S3DefaultCluster.
+// The pools are returned concretely for metrics registration + reconcile loops.
 func buildClusters(cfg config.Config, tm *metrics.TransportMetrics) (map[string]storage.Storage, map[string]*storage.Pool) {
 	stores := make(map[string]storage.Storage, len(cfg.Clusters))
 	pools := make(map[string]*storage.Pool)
@@ -183,10 +174,6 @@ func buildClusters(cfg config.Config, tm *metrics.TransportMetrics) (map[string]
 	return stores, pools
 }
 
-// buildStorage returns the Storage for one cluster. With no backend source
-// configured it is a single S3 client (legacy behavior) and pool is nil. With
-// source=file or source=dns it is a load-balancing Pool, also returned
-// concretely so the caller can register its metrics and run its reconcile loop.
 func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storage.Storage, *storage.Pool) {
 	if cc.S3BackendSource == "" {
 		return storage.NewS3StorageForCluster(cc, storage.S3Options{
@@ -210,11 +197,9 @@ func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storag
 	return pool, pool
 }
 
-// backendFactory builds the per-backend Storage constructor for the pool. In
-// pin-host mode each resolved backend is a gateway IP that michael dials
-// directly while still signing/Host-ing with the cluster endpoint (replacing the
-// HAProxy hop); otherwise the resolved endpoint is used as the S3 endpoint
-// as-is.
+// backendFactory builds the pool's per-backend Storage constructor. Pin-host
+// mode dials each resolved gateway IP directly while signing/Host-ing with the
+// cluster endpoint (replaces HAProxy); otherwise the resolved endpoint is used as-is.
 func backendFactory(cc config.ClusterConfig, tm *metrics.TransportMetrics) storage.BackendFactory {
 	if !cc.S3BackendPinHost {
 		return func(endpoint string) (storage.Storage, error) {
@@ -247,8 +232,6 @@ func backendFactory(cc config.ClusterConfig, tm *metrics.TransportMetrics) stora
 	}
 }
 
-// transportWrap returns the metrics wrapper for one backend's transport, or
-// nil when metrics are disabled.
 func transportWrap(tm *metrics.TransportMetrics, cluster, backend string) func(http.RoundTripper) http.RoundTripper {
 	if tm == nil {
 		return nil

--- a/packages/yuctl/cmd/bench-agent/main.go
+++ b/packages/yuctl/cmd/bench-agent/main.go
@@ -1,11 +1,9 @@
-// Command bench-agent is the remote half of `yuctl tools bench` and
-// `yuctl tools bench-do`. In bench mode (no args) it reads a bench.Config as
-// JSON on stdin, executes the benchmark phases, and streams JSON events on
-// stdout. In loadgen mode (--loadgen [config-path]) it reads a
-// bench.LoadgenConfig — from the file, which it deletes after reading, or
-// from stdin when no path is given — and either supervises the detached
-// continuous load or runs the synchronous repo cleanup. The orchestrator
-// pushes it over ssh; it is embedded into yuctl by the build task.
+// Command bench-agent is the remote half of `yuctl tools bench`/`bench-do`.
+// Bench mode (no args): bench.Config JSON on stdin, phases executed, JSON
+// events on stdout. Loadgen mode (--loadgen [config-path]): bench.LoadgenConfig
+// from the file (deleted after reading) or stdin, supervising the detached load
+// or running the synchronous repo cleanup. Pushed over ssh by the orchestrator;
+// embedded into yuctl by the build task.
 package main
 
 import (

--- a/packages/yuctl/internal/adminapi/allowlist.go
+++ b/packages/yuctl/internal/adminapi/allowlist.go
@@ -20,7 +20,6 @@ type AllowlistEntry struct {
 	CreatedAt    string  `json:"createdAt"`
 }
 
-// allowlistPage is the paginated envelope returned by GET /api/allowlist.
 type allowlistPage struct {
 	Items      []AllowlistEntry `json:"items"`
 	NextCursor *string          `json:"nextCursor"`
@@ -96,7 +95,6 @@ func (c *Client) AddAllowlistEntry(ctx context.Context, email string, staged boo
 	return &out.Entry, nil
 }
 
-// RemoveAllowlistEntry removes an email from the allowlist.
 func (c *Client) RemoveAllowlistEntry(ctx context.Context, email string) error {
 	return c.deleteReq(ctx, "/api/allowlist/"+url.PathEscape(email))
 }

--- a/packages/yuctl/internal/adminapi/cache.go
+++ b/packages/yuctl/internal/adminapi/cache.go
@@ -9,9 +9,8 @@ import (
 	yctx "yuctl/internal/context"
 )
 
-// tokenCachePath returns the per-partition token cache file inside the yuctl
-// config dir. Partition-scoped because each partition has its own primary
-// region / admin-api.
+// tokenCachePath: per-partition token cache in the yuctl config dir (each
+// partition has its own primary region / admin-api).
 func tokenCachePath(partition string) (string, error) {
 	dir, err := yctx.Dir()
 	if err != nil {

--- a/packages/yuctl/internal/adminapi/features.go
+++ b/packages/yuctl/internal/adminapi/features.go
@@ -16,7 +16,6 @@ type FeatureFlag struct {
 	Overrides   int    `json:"overrides"`
 }
 
-// FeatureOverride mirrors FeatureOverrideDto.
 type FeatureOverride struct {
 	Flag      string  `json:"flag"`
 	Value     bool    `json:"value"`
@@ -25,13 +24,11 @@ type FeatureOverride struct {
 	UpdatedAt string  `json:"updatedAt"`
 }
 
-// UserFeatures mirrors UserFeaturesResponseDto.
 type UserFeatures struct {
 	Features  map[string]bool   `json:"features"`
 	Overrides []FeatureOverride `json:"overrides"`
 }
 
-// FeatureUser mirrors FeatureUserDto.
 type FeatureUser struct {
 	UserID    string  `json:"userId"`
 	Email     string  `json:"email"`
@@ -41,7 +38,6 @@ type FeatureUser struct {
 	UpdatedAt string  `json:"updatedAt"`
 }
 
-// ListFeatures returns the flag registry with override counts.
 func (c *Client) ListFeatures(ctx context.Context) ([]FeatureFlag, error) {
 	var out struct {
 		Flags []FeatureFlag `json:"flags"`
@@ -52,7 +48,6 @@ func (c *Client) ListFeatures(ctx context.Context) ([]FeatureFlag, error) {
 	return out.Flags, nil
 }
 
-// GetUserFeatures returns a user's resolved flags and raw overrides.
 func (c *Client) GetUserFeatures(ctx context.Context, userID string) (*UserFeatures, error) {
 	var out UserFeatures
 	if err := c.getJSON(ctx, "/api/user/"+url.PathEscape(userID)+"/features", nil, &out); err != nil {
@@ -61,7 +56,6 @@ func (c *Client) GetUserFeatures(ctx context.Context, userID string) (*UserFeatu
 	return &out, nil
 }
 
-// SetUserFeature sets a per-user override for a flag.
 func (c *Client) SetUserFeature(ctx context.Context, userID, flag string, value bool, reason string) (*FeatureOverride, error) {
 	body := map[string]any{"value": value}
 	if reason != "" {
@@ -75,12 +69,10 @@ func (c *Client) SetUserFeature(ctx context.Context, userID, flag string, value 
 	return &out, nil
 }
 
-// ClearUserFeature removes a per-user override (reverting to the registry default).
 func (c *Client) ClearUserFeature(ctx context.Context, userID, flag string) error {
 	return c.deleteReq(ctx, "/api/user/"+url.PathEscape(userID)+"/features/"+url.PathEscape(flag))
 }
 
-// ListFeatureUsers returns the users holding an override for a flag.
 func (c *Client) ListFeatureUsers(ctx context.Context, flag string) ([]FeatureUser, error) {
 	var out struct {
 		Items []FeatureUser `json:"items"`
@@ -103,7 +95,6 @@ func (c *Client) EnableFeatureBatch(ctx context.Context, flag string, count int)
 	return out.Enabled, nil
 }
 
-// Connection mirrors the admin-api ConnectionAdminDto.
 type Connection struct {
 	ID         string  `json:"id"`
 	UserID     string  `json:"userId"`
@@ -113,7 +104,6 @@ type Connection struct {
 	LastSeenAt *string `json:"lastSeenAt"`
 }
 
-// GetUserConnections lists a user's connection instances.
 func (c *Client) GetUserConnections(ctx context.Context, userID string) ([]Connection, error) {
 	var out struct {
 		Connections []Connection `json:"connections"`

--- a/packages/yuctl/internal/adminapi/http.go
+++ b/packages/yuctl/internal/adminapi/http.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 )
 
-// getJSON GETs path (with optional query) and decodes the JSON response.
 func (c *Client) getJSON(ctx context.Context, path string, query url.Values, out any) error {
 	u := c.baseURL + path
 	if enc := query.Encode(); enc != "" {
@@ -39,8 +38,6 @@ func (c *Client) getJSON(ctx context.Context, path string, query url.Values, out
 	return nil
 }
 
-// putJSON PUTs a JSON body to path and decodes the JSON response into out
-// (out may be nil).
 func (c *Client) putJSON(ctx context.Context, path string, body, out any) error {
 	u := c.baseURL + path
 	b, err := json.Marshal(body)

--- a/packages/yuctl/internal/adminapi/login.go
+++ b/packages/yuctl/internal/adminapi/login.go
@@ -1,14 +1,11 @@
-// Package adminapi authenticates against the yucca-admin-api via its CLI
-// loopback login flow and queries its REST endpoints.
-//
-// Login never touches the IdP directly and needs no client secret: yuctl
-// starts a listener on 127.0.0.1:<random port>, opens the browser at the
-// admin-api's /api/auth/cli/login with a state nonce and an S256 code
-// challenge, and the admin-api (which owns the confidential OIDC client) runs
-// the normal browser OIDC dance. The callback redirects the browser to the
-// loopback listener with a one-time code, which yuctl exchanges — together
-// with the plaintext verifier that never left this process — for a
-// admin-api-minted ES256 session JWT sent as `Authorization: Bearer`.
+// Package adminapi authenticates against yucca-admin-api via its CLI loopback
+// login flow and queries its REST endpoints. Login never touches the IdP and
+// needs no client secret: yuctl listens on 127.0.0.1:<random port>, opens the
+// browser at /api/auth/cli/login with a state nonce + S256 code challenge; the
+// admin-api (owner of the confidential OIDC client) runs the browser OIDC
+// dance and redirects a one-time code to the loopback, which yuctl exchanges —
+// with the verifier that never left this process — for an admin-api-minted
+// ES256 session JWT sent as `Authorization: Bearer`.
 package adminapi
 
 import (
@@ -32,12 +29,10 @@ type Token struct {
 	Expiry      time.Time `json:"expiry"`
 }
 
-// Valid reports whether the cached token is present and not expired.
 func (t *Token) Valid() bool {
 	return t != nil && t.AccessToken != "" && t.Sub != "" && time.Now().Before(t.Expiry)
 }
 
-// loginTimeout bounds the wait for the operator to finish the browser flow.
 const loginTimeout = 5 * time.Minute
 
 type cliTokenResponse struct {
@@ -46,10 +41,9 @@ type cliTokenResponse struct {
 	Sub         string `json:"sub"`
 }
 
-// BrowserLogin runs the loopback login flow against adminURL. promptFn
-// receives the URL the operator must open (already attempted via openFn when
-// non-nil; the prompt is always shown as fallback). Returns the minted session
-// token.
+// BrowserLogin runs the loopback flow against adminURL. promptFn gets the URL
+// to open (openFn attempted first when non-nil; prompt always shown as
+// fallback). Returns the minted session token.
 func BrowserLogin(ctx context.Context, hc *http.Client, adminURL string, openFn func(url string) error, promptFn func(url string)) (*Token, error) {
 	verifier := randB64(32)
 	challenge := base64.RawURLEncoding.EncodeToString(func() []byte { s := sha256.Sum256([]byte(verifier)); return s[:] }())

--- a/packages/yuctl/internal/adminapi/settings.go
+++ b/packages/yuctl/internal/adminapi/settings.go
@@ -42,14 +42,12 @@ func (c *Client) SetSettings(ctx context.Context, scope string, value map[string
 	return &out.Entry, nil
 }
 
-// DeleteSettings removes every override stored for scope.
 func (c *Client) DeleteSettings(ctx context.Context, scope string) error {
 	return c.deleteReq(ctx, "/api/settings/"+scope)
 }
 
-// doJSON is the generic JSON round-trip: like postJSON, but with an explicit
-// method and with the response body included in non-2xx errors so admin-api
-// validation messages reach the operator.
+// doJSON: generic JSON round-trip — explicit method, and non-2xx errors include
+// the response body so admin-api validation messages reach the operator.
 func (c *Client) doJSON(ctx context.Context, method, path string, body, out any) error {
 	u := c.baseURL + path
 	var reader io.Reader

--- a/packages/yuctl/internal/adminapi/users.go
+++ b/packages/yuctl/internal/adminapi/users.go
@@ -19,13 +19,11 @@ type User struct {
 	Disabled bool   `json:"disabled"`
 }
 
-// userPage is the paginated envelope returned by GET /api/user.
 type userPage struct {
 	Items      []User  `json:"items"`
 	NextCursor *string `json:"nextCursor"`
 }
 
-// Client talks to one admin-api instance using a CLI session JWT.
 type Client struct {
 	baseURL string
 	http    *http.Client
@@ -45,8 +43,6 @@ func (c *Client) setAuth(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.token.AccessToken)
 }
 
-// GetAuth verifies the session against GET /api/auth and returns the
-// authenticated subject.
 func (c *Client) GetAuth(ctx context.Context) (string, error) {
 	u := c.baseURL + "/api/auth"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
@@ -133,7 +129,6 @@ func (c *Client) listUserPage(ctx context.Context, cursor string, limit int) (*u
 	return &page, nil
 }
 
-// ParseLimit validates a user-supplied --limit page size for the admin-api.
 func ParseLimit(s string) (int, error) {
 	if s == "" {
 		return 0, nil

--- a/packages/yuctl/internal/bench/agent.go
+++ b/packages/yuctl/internal/bench/agent.go
@@ -11,8 +11,6 @@ import (
 	"time"
 )
 
-// Agent executes the benchmark phases on the management host and streams
-// Events back to the orchestrator.
 type Agent struct {
 	cfg  Config
 	emit func(Event)
@@ -318,7 +316,6 @@ func (a *Agent) progressFn(phase string, conns int, total int64) func(delta int6
 	}
 }
 
-// statusFn adapts restic --json status messages into throttled progress events.
 func (a *Agent) statusFn(phase string, conns int, doneKey, totalKey string) func(map[string]any) {
 	var last time.Time
 	start := time.Now()

--- a/packages/yuctl/internal/bench/config.go
+++ b/packages/yuctl/internal/bench/config.go
@@ -12,9 +12,8 @@ const (
 
 var DefaultPhases = []string{PhaseGenerate, PhaseBackup, PhaseIncremental, PhaseCheck, PhaseRestore}
 
-// Config is the full agent instruction set, sent over the ssh session's stdin
-// so the repository URL (which embeds the JWT) and password never appear in
-// argv or shell history on the management host.
+// Config is the full agent instruction set, sent over ssh stdin so the repo
+// URL (embeds the JWT) and password never hit argv or shell history.
 type Config struct {
 	Repo     string `json:"repo"`
 	Password string `json:"password"`

--- a/packages/yuctl/internal/bench/dataset.go
+++ b/packages/yuctl/internal/bench/dataset.go
@@ -26,9 +26,8 @@ type Manifest struct {
 
 const manifestName = "manifest.json"
 
-// fileKey derives the ChaCha8 key for one file's content in one round. Random
-// (incompressible, dedup-proof) yet fully reproducible from (seed, index,
-// round).
+// fileKey derives the ChaCha8 key for one file's content in one round: random
+// (incompressible, dedup-proof) yet reproducible from (seed, index, round).
 func fileKey(seed uint64, index, round int) [32]byte {
 	var b [24]byte
 	binary.LittleEndian.PutUint64(b[0:], seed)

--- a/packages/yuctl/internal/bench/fetch.go
+++ b/packages/yuctl/internal/bench/fetch.go
@@ -25,14 +25,10 @@ var resticSHA256 = map[string]string{
 	"darwin_arm64": "7be0a144ccc377880f294204aa271d76e4b79554b42a751151d425ce6ebac143",
 }
 
-// EnsureResticLinux returns the pinned linux/amd64 restic to push to a
-// management host.
 func EnsureResticLinux(ctx context.Context) (string, error) {
 	return ensureRestic(ctx, "linux_amd64")
 }
 
-// EnsureResticLocal returns the pinned restic for the machine yuctl is running
-// on (--from-here runs).
 func EnsureResticLocal(ctx context.Context) (string, error) {
 	return ensureRestic(ctx, runtime.GOOS+"_"+runtime.GOARCH)
 }

--- a/packages/yuctl/internal/bench/loadgen.go
+++ b/packages/yuctl/internal/bench/loadgen.go
@@ -14,28 +14,24 @@ import (
 	"yuctl/internal/netdev"
 )
 
-// Loadgen is the bench-do agent mode: a supervisor that runs one continuous
-// restic backup loop per client until the duration elapses, the droplet's
-// transfer cap is hit, or it is killed. Unlike the bench mode it is built to
-// run detached (nohup) on a droplet: progress goes to a status file the
-// orchestrator samples over ssh, not to a live event stream.
+// Loadgen is the bench-do agent mode: a supervisor looping one continuous
+// restic backup per client until duration elapses, the droplet's transfer cap
+// hits, or it is killed. Runs detached (nohup): progress goes to a status file
+// sampled over ssh, not a live event stream.
 
-// LoadgenOps.
 const (
 	LoadgenOpLoad    = "load"
 	LoadgenOpCleanup = "cleanup"
 )
 
-// LoadgenClient is one restic identity on the droplet.
 type LoadgenClient struct {
 	Name     string `json:"name"`
 	Repo     string `json:"repo"`
 	Password string `json:"password"`
 }
 
-// LoadgenConfig is the full instruction set for one droplet's agent. It is
-// written to a 0600 file the agent deletes after reading (load) or piped over
-// stdin (cleanup) — the repo URLs embed JWTs and must never hit argv.
+// LoadgenConfig: one droplet's full instruction set — a 0600 file the agent
+// deletes after reading (load) or stdin (cleanup); repo URLs embed JWTs, never argv.
 type LoadgenConfig struct {
 	Op      string          `json:"op"` // load (default) | cleanup
 	Clients []LoadgenClient `json:"clients"`
@@ -111,7 +107,6 @@ type LoadgenStatus struct {
 	Clients         []LoadgenClientStatus `json:"clients"`
 }
 
-// LoadgenClientStatus is one client loop's progress.
 type LoadgenClientStatus struct {
 	Name         string `json:"name"`
 	Phase        string `json:"phase"` // init | generate | backup | idle
@@ -150,7 +145,6 @@ func (s *loadgenState) write(path string) error {
 	return os.Rename(tmp, path)
 }
 
-// physicalTX reads the droplet's cumulative physical-NIC TX bytes.
 func physicalTX() (int64, bool) {
 	b, err := os.ReadFile("/proc/net/dev")
 	if err != nil {
@@ -159,9 +153,8 @@ func physicalTX() (int64, bool) {
 	return int64(netdev.PhysicalTotals(netdev.Parse(string(b))).TX), true
 }
 
-// RunLoadgen supervises the client loops. It returns nil on a clean end
-// (duration elapsed or cap hit — both are recorded in the status file) and an
-// error only for setup failures.
+// RunLoadgen supervises the client loops; nil on a clean end (duration/cap —
+// recorded in the status file), error only for setup failures.
 func RunLoadgen(ctx context.Context, cfg LoadgenConfig) error {
 	if err := cfg.defaults(); err != nil {
 		return err
@@ -251,9 +244,9 @@ func RunLoadgen(ctx context.Context, cfg LoadgenConfig) error {
 	return state.write(cfg.StatusPath)
 }
 
-// clientLoop is one client's endless generate→backup cycle. Every cycle uses
-// a fresh seed so nothing dedups against earlier uploads; errors back off and
-// retry rather than killing the whole droplet's load.
+// clientLoop: one client's endless generate→backup cycle, fresh seed each pass
+// (nothing dedups against earlier uploads); errors back off and retry, never
+// kill the droplet's load.
 func clientLoop(ctx context.Context, cfg LoadgenConfig, idx int, cl LoadgenClient, state *loadgenState) {
 	dataDir := filepath.Join(cfg.Workdir, cl.Name, "data")
 	r := &Restic{
@@ -276,9 +269,8 @@ func clientLoop(ctx context.Context, cfg LoadgenConfig, idx int, cl LoadgenClien
 		}
 	}
 
-	// Init retries for as long as the run does: a load-test client giving up
-	// on transient server errors (e.g. 500s under the very load being
-	// generated) would silently thin the fleet. fail() paces the retries.
+	// Init retries as long as the run does: giving up on transient 500s (under
+	// the very load being generated) would silently thin the fleet; fail() paces.
 	for {
 		_, err := r.EnsureInit(ctx)
 		if err == nil {
@@ -344,9 +336,9 @@ func clientLoop(ctx context.Context, cfg LoadgenConfig, idx int, cl LoadgenClien
 	}
 }
 
-// RunLoadgenCleanup forgets and prunes every bench-do snapshot in each
-// client's repository, streaming bench Events (it runs synchronously over the
-// orchestrator's ssh session, unlike the detached load mode).
+// RunLoadgenCleanup forgets+prunes every bench-do snapshot per client,
+// streaming bench Events (synchronous over the orchestrator's ssh, unlike
+// the detached load mode).
 func RunLoadgenCleanup(ctx context.Context, cfg LoadgenConfig, emit func(Event)) error {
 	if err := cfg.defaults(); err != nil {
 		return err

--- a/packages/yuctl/internal/bench/orchestrator.go
+++ b/packages/yuctl/internal/bench/orchestrator.go
@@ -19,7 +19,6 @@ const RemoteBinDir = ".cache/yuctl-bench/bin"
 
 const remoteDir = RemoteBinDir
 
-// RunOpts drives one remote benchmark run from the dev machine.
 type RunOpts struct {
 	Host        string // ssh destination for the management host
 	SSHIdentity string // ssh private key file ("" = ssh defaults/agent)
@@ -28,8 +27,6 @@ type RunOpts struct {
 	Out         string // local results path ("" = don't save)
 }
 
-// Run pushes the agent + pinned restic to the host, streams the run, and
-// returns the collected result.
 func Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 	agentBin, cleanup, err := AgentBinary(opts.AgentBin)
 	if err != nil {
@@ -55,8 +52,6 @@ func Run(ctx context.Context, opts RunOpts) (*RunResult, error) {
 	return finish(result, opts.Out)
 }
 
-// RunHere executes the benchmark on the local machine — no ssh, the agent
-// library runs in-process against a locally pinned restic.
 func RunHere(ctx context.Context, opts RunOpts) (*RunResult, error) {
 	resticBin, err := EnsureResticLocal(ctx)
 	if err != nil {
@@ -204,7 +199,6 @@ func drive(ctx context.Context, identity, host string, cfg Config) (*RunResult, 
 	return sink.result, nil
 }
 
-// eventSink renders agent events as log lines and captures the terminal ones.
 type eventSink struct {
 	result *RunResult
 	fatal  string
@@ -236,7 +230,6 @@ func (s *eventSink) handle(ev Event) {
 	}
 }
 
-// EmitJSON is the agent-side event sink: one JSON object per stdout line.
 func EmitJSON(w io.Writer) func(Event) {
 	enc := json.NewEncoder(w)
 	return func(ev Event) {

--- a/packages/yuctl/internal/bench/restic.go
+++ b/packages/yuctl/internal/bench/restic.go
@@ -76,7 +76,6 @@ func tail(s string, n int) string {
 	return s
 }
 
-// num pulls a numeric field out of a decoded JSON message.
 func num(m map[string]any, key string) float64 {
 	v, _ := m[key].(float64)
 	return v
@@ -98,7 +97,6 @@ func (r *Restic) Version(ctx context.Context) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// EnsureInit initializes the repository unless it already exists.
 func (r *Restic) EnsureInit(ctx context.Context) (created bool, err error) {
 	if err := r.command(ctx, "cat", "config").Run(); err == nil {
 		return false, nil

--- a/packages/yuctl/internal/bench/sizes.go
+++ b/packages/yuctl/internal/bench/sizes.go
@@ -1,7 +1,6 @@
-// Package bench drives restic end-to-end benchmarks against michael: an
-// orchestrator on the dev machine pushes an agent (yucca-bench itself, built
-// for linux) plus a pinned restic binary to a management host, runs
-// write/incremental/restore phases there, and reports results locally.
+// Package bench drives restic e2e benchmarks against michael: the orchestrator
+// pushes an agent (yucca-bench built for linux) + pinned restic to a management
+// host, runs write/incremental/restore there, reports locally.
 package bench
 
 import (

--- a/packages/yuctl/internal/benchwide/benchwide_test.go
+++ b/packages/yuctl/internal/benchwide/benchwide_test.go
@@ -16,9 +16,9 @@ func TestDropletName(t *testing.T) {
 	}
 }
 
-// The kill patterns must match the processes they target but never the shell
-// running the kill script itself (whose command line contains the pattern
-// text) — a self-match SIGTERMs the exec. Same bracket trick as warp.
+// Kill patterns must match their targets but never the kill script's own shell
+// (its command line contains the pattern) — self-match SIGTERMs the exec. Same
+// bracket trick as warp.
 func TestKillScriptNoSelfMatch(t *testing.T) {
 	re := regexp.MustCompile(`bench-agent --[l]oadgen`)
 	if !re.MatchString("/root/.cache/yuctl-bench/bin/bench-agent --loadgen /var/tmp/yucca-bench-do/loadgen.json") {
@@ -86,10 +86,9 @@ func TestStartOptionsDefaults(t *testing.T) {
 	}
 }
 
-// prep and launch must stay separate execs: prep runs the kill patterns, and
-// launch's command line contains "bench-agent --loadgen" verbatim — combined,
-// the pkill would match its own shell and SIGTERM it mid-script (config
-// written, agent never started). Guard both halves of that invariant.
+// prep and launch must stay separate execs: combined, prep's pkill would match
+// launch's verbatim "bench-agent --loadgen" on its own shell and SIGTERM it
+// mid-script (config written, agent never started). Guard both halves.
 func TestPrepAndLaunchScriptsSeparated(t *testing.T) {
 	prep, launch := prepScript(), launchScript()
 	if !strings.Contains(prep, "cat > "+configPath) {

--- a/packages/yuctl/internal/benchwide/deploy.go
+++ b/packages/yuctl/internal/benchwide/deploy.go
@@ -55,10 +55,9 @@ func (s *Session) dropletName(n int) string {
 	return fmt.Sprintf("yucca-bench-%s-%02d", s.slug(), n)
 }
 
-// Deploy converges the fleet: creates missing droplets (confirmed, with the
-// hourly cost and transfer pool spelled out), trims surplus ones, files
-// everything under the yucca-bench project, waits for ssh, and pushes the
-// bench agent + pinned restic everywhere.
+// Deploy converges the fleet: creates missing droplets (confirmed, hourly cost
+// + transfer pool spelled out), trims surplus, files under yucca-bench, waits
+// for ssh, pushes bench agent + pinned restic.
 func (s *Session) Deploy(ctx context.Context, opts DeployOptions) error {
 	opts.defaults(s.Provider.Defaults())
 
@@ -243,10 +242,9 @@ func (s *Session) ensureKey(ctx context.Context) (string, error) {
 	return keyID, s.SaveState()
 }
 
-// waitSSH retries a no-op ssh until the droplet accepts the fleet key. Fresh
-// droplets take a little while between "active" and sshd+key readiness.
-// Single-shot probes (the loop is the retry) with the latest failure surfaced
-// periodically, so a stuck droplet is visible instead of a silent hang.
+// waitSSH retries a no-op ssh until the fleet key is accepted (fresh droplets
+// lag between "active" and sshd+key readiness). Single-shot probes — the loop
+// is the retry — with the latest failure surfaced periodically, not a silent hang.
 func (s *Session) waitSSH(ctx context.Context, d provider.Host, timeout time.Duration) error {
 	start := time.Now()
 	deadline := start.Add(timeout)
@@ -275,7 +273,6 @@ func (s *Session) waitSSH(ctx context.Context, d provider.Host, timeout time.Dur
 	}
 }
 
-// pushBinaries scps the agent and restic into RemoteBinDir on the droplet.
 func (s *Session) pushBinaries(ctx context.Context, ip, agentBin, resticBin string) error {
 	if _, err := s.sshRun(ctx, ip, "mkdir -p "+bench.RemoteBinDir, nil); err != nil {
 		return err
@@ -302,9 +299,9 @@ func (s *Session) pushBinaries(ctx context.Context, ip, agentBin, resticBin stri
 	return err
 }
 
-// Undeploy destroys the whole fleet: droplets by tag, the DO ssh key, and the
-// local key/known_hosts/state files. Repositories (and their data) persist —
-// run `bench-do cleanup` first to prune them while the droplets still exist.
+// Undeploy destroys the fleet: droplets by tag, DO ssh key, local
+// key/known_hosts/state. Repositories persist — `bench-do cleanup` first,
+// while the droplets still exist.
 func (s *Session) Undeploy(ctx context.Context, force bool) error {
 	droplets, err := s.Droplets(ctx)
 	if err != nil {
@@ -341,8 +338,6 @@ func (s *Session) Undeploy(ctx context.Context, force bool) error {
 	return nil
 }
 
-// anyLoadRunning reports whether any host still has an agent or restic
-// process alive.
 func (s *Session) anyLoadRunning(ctx context.Context, droplets []provider.Host) (bool, error) {
 	running := false
 	err := eachDroplet(droplets, func(d provider.Host) error {

--- a/packages/yuctl/internal/benchwide/run.go
+++ b/packages/yuctl/internal/benchwide/run.go
@@ -23,15 +23,13 @@ import (
 	"yuctl/internal/provider"
 )
 
-// RepoMinter is the slice of the admin-api client Start needs: repository
-// creation and restic-URL minting (URLs embed short-lived JWTs, so they are
-// re-minted on every start, never persisted).
+// RepoMinter: the admin-api slice Start needs — repo creation + restic-URL
+// minting (URLs embed short-lived JWTs; re-minted each start, never persisted).
 type RepoMinter interface {
 	CreateRepository(ctx context.Context, name string, worm bool, opts adminapi.CreateRepositoryOptions) (*adminapi.Repository, error)
 	RepositoryURL(ctx context.Context, id string) (string, error)
 }
 
-// StartOptions shape the load each droplet runs.
 type StartOptions struct {
 	ClientsPerDroplet int           // default 1
 	CycleSize         int64         // dataset per client per cycle (default 8GiB)
@@ -78,18 +76,15 @@ func (o *StartOptions) defaults() {
 	}
 }
 
-// killScript stops the loadgen everywhere it can respawn from: the agent
-// supervisor first, then any in-flight restic. The [b]racket keeps the pkill
-// pattern from matching this very script's command line.
+// killScript stops loadgen everywhere it respawns from: supervisor first, then
+// restic. The [b]racket keeps pkill from matching this script's own command line.
 const killScript = `pkill -f 'bench-agent --[l]oadgen' 2>/dev/null; sleep 1; pkill -x restic 2>/dev/null; true`
 
-// prepScript and launchScript are one droplet's start, as two SEPARATE ssh
-// execs. They must not be merged: prep runs the kill patterns, and launch's
-// command line spells out "bench-agent --loadgen" verbatim — in one script
-// the pkill would match its own shell's command line and SIGTERM it mid-run
-// (same trap warp's split kill/launch avoids). Neither script carries
-// secrets — they ride ssh argv, visible in remote ps; the config travels
-// over prep's stdin into a 0600 file the agent deletes after reading.
+// prepScript and launchScript must stay two SEPARATE ssh execs: merged, prep's
+// pkill would match launch's verbatim "bench-agent --loadgen" on its own
+// shell's command line and SIGTERM it mid-run (same trap warp's split avoids).
+// Neither carries secrets (they ride argv, visible in remote ps); the config
+// travels over prep's stdin into a 0600 file the agent deletes after reading.
 func prepScript() string {
 	return fmt.Sprintf("umask 077; mkdir -p %s; cat > %s; %s; rm -f %s",
 		Workdir, configPath, killScript, statusPath)
@@ -101,10 +96,9 @@ func launchScript() string {
 		bench.RemoteBinDir, configPath, agentLog)
 }
 
-// Start (re)launches the load on every droplet: ensures one repository per
-// client via the admin-api, re-mints restic URLs, and hands each droplet a
-// LoadgenConfig over ssh stdin (secrets never in argv). A second start is a
-// graceful restart with new parameters.
+// Start (re)launches load on every droplet: one repo per client via admin-api,
+// re-minted restic URLs, LoadgenConfig over ssh stdin (secrets never in argv).
+// A second start = graceful restart with new parameters.
 func (s *Session) Start(ctx context.Context, minter RepoMinter, opts StartOptions) error {
 	opts.defaults()
 	if opts.PackSizeMiB < 4 || opts.PackSizeMiB > 128 {
@@ -291,9 +285,8 @@ func (s *Session) Stop(ctx context.Context) (*Result, error) {
 	return res, nil
 }
 
-// Result is the fleet-aggregated outcome of a run, written to a local JSON on
-// stop. Client numbers are restic's post-dedup data_added; droplet wire TX is
-// what the transfer allowance actually saw.
+// Result: fleet-aggregated run outcome, written to local JSON on stop. Client
+// numbers = restic post-dedup data_added; droplet wire TX = what the allowance saw.
 type Result struct {
 	Label          string            `json:"label"`
 	Partition      string            `json:"partition"`
@@ -308,7 +301,6 @@ type Result struct {
 	TotalErrors    int               `json:"totalErrors"`
 }
 
-// DropletResult is one droplet's final tallies.
 type DropletResult struct {
 	Name        string                      `json:"name"`
 	Region      string                      `json:"region"`
@@ -357,7 +349,6 @@ func (s *Session) collect(ctx context.Context, droplets []provider.Host) (*Resul
 	return res, nil
 }
 
-// DropletStatus is one droplet's live sample.
 type DropletStatus struct {
 	Name, Region, IP        string
 	Reachable               bool
@@ -367,7 +358,6 @@ type DropletStatus struct {
 	Status                  *bench.LoadgenStatus
 }
 
-// StatusReport is what status/watch render.
 type StatusReport struct {
 	Run         *RunInfo
 	TransferCap int64 // per droplet
@@ -487,8 +477,6 @@ func (s *Session) Cleanup(ctx context.Context, minter RepoMinter, force bool) er
 	})
 }
 
-// streamCleanup runs the agent cleanup op over a live ssh session, logging
-// its event stream.
 func (s *Session) streamCleanup(ctx context.Context, d provider.Host, cfg []byte) error {
 	cmd := exec.CommandContext(ctx, "ssh",
 		s.sshArgs(s.Provider.SSHUser()+"@"+d.PublicIP, "$HOME/"+bench.RemoteBinDir+"/bench-agent --loadgen")...)

--- a/packages/yuctl/internal/benchwide/session.go
+++ b/packages/yuctl/internal/benchwide/session.go
@@ -1,13 +1,11 @@
-// Package benchwide deploys and drives a fleet of cloud VMs — across
-// providers (DigitalOcean, Hetzner, …; see internal/provider) — running real
-// restic clients against michael, the external-user data path over the public
-// internet. It is the VM-shaped sibling of internal/warp (fleet lifecycle:
-// deploy/start/status/stop/cleanup/undeploy) built on the bench agent's
-// loadgen mode: every host runs a detached supervisor looping seeded
-// generate→backup cycles per client, hard-capped at the host's transfer
-// allowance so a forgotten run cannot burn into paid overage. Each provider is
-// a separate, independently-addressable fleet (state keyed by partition ×
-// provider), so multiple providers can load michael concurrently.
+// Package benchwide drives a fleet of cloud VMs (DigitalOcean, Hetzner, …; see
+// internal/provider) running real restic clients against michael — the
+// external-user path over the public internet. VM-shaped sibling of
+// internal/warp (deploy/start/status/stop/cleanup/undeploy), built on the
+// bench agent's loadgen mode: each host loops seeded generate→backup cycles
+// under a detached supervisor, hard-capped at the host's transfer allowance so
+// a forgotten run can't burn into paid overage. State is keyed partition ×
+// provider — independent fleets, providers can load michael concurrently.
 package benchwide
 
 import (
@@ -44,9 +42,8 @@ const (
 	tagPrefix = "yuctl-bench-"
 )
 
-// Client is one restic identity: its admin-api repository and password,
-// pinned to a droplet by name. Passwords are generated once and persisted —
-// without them the repos can never be reopened (cleanup, restarts).
+// Client is one restic identity (admin-api repo + password), pinned to a
+// droplet by name. Passwords persist — repos are unreopenable without them.
 type Client struct {
 	Name     string `json:"name"`    // <droplet>-c<n>
 	Droplet  string `json:"droplet"` // droplet name it runs on
@@ -55,18 +52,15 @@ type Client struct {
 	Password string `json:"password"`
 }
 
-// RunInfo records the parameters of the last `start` for status displays and
-// the results file.
 type RunInfo struct {
 	StartedAt time.Time         `json:"startedAt"`
 	Label     string            `json:"label"`
 	Params    map[string]string `json:"params"`
 }
 
-// State is the local fleet record (0600 — it holds repo passwords). Host
-// existence itself is never trusted from here: the provider's tag listing is
-// the source of truth, so fleets survive yuctl crashes and state loss only
-// costs repo passwords, not orphaned hosts.
+// State is the local fleet record (0600 — holds repo passwords). Host
+// existence is never trusted from here: the provider tag listing is truth, so
+// state loss costs only repo passwords, never orphaned hosts.
 type State struct {
 	Partition     string    `json:"partition"`
 	Provider      string    `json:"provider"`
@@ -80,8 +74,6 @@ type State struct {
 	Run           *RunInfo  `json:"run,omitempty"`
 }
 
-// Session is the resolved handle for one bench-wide command invocation,
-// scoped to one provider × partition fleet.
 type Session struct {
 	Partition string
 	Provider  provider.Provider
@@ -115,14 +107,12 @@ func NewSession(ctx context.Context, partition, providerName string) (*Session, 
 // slug is the provider×partition key used in the tag and local filenames.
 func (s *Session) slug() string { return s.providerName + "-" + s.Partition }
 
-// Tag is the fleet's provider tag/label.
 func (s *Session) Tag() string { return tagPrefix + s.slug() }
 
 func (s *Session) statePath() string {
 	return filepath.Join(s.dir, "fleet-"+s.slug()+".json")
 }
 
-// PrivateKeyPath is where the fleet's ephemeral ssh private key lives.
 func (s *Session) PrivateKeyPath() string {
 	return filepath.Join(s.dir, "id_ed25519-"+s.slug())
 }
@@ -165,10 +155,9 @@ func (s *Session) SaveState() error {
 	return os.Rename(tmp, p)
 }
 
-// clearFleetState drops everything droplet-bound (ssh key material, run
-// info) but keeps the client records when repos exist: their passwords are
-// the only way to ever reopen those repos (e.g. `tools bench --repo-id` with
-// a re-minted URL to prune them later).
+// clearFleetState drops droplet-bound bits (ssh keys, run info) but keeps
+// client records while repos exist — their passwords are the only way to
+// reopen them (`tools bench --repo-id` + re-minted URL to prune later).
 func (s *Session) clearFleetState() error {
 	os.Remove(s.PrivateKeyPath())
 	os.Remove(s.knownHostsPath())
@@ -183,14 +172,11 @@ func (s *Session) clearFleetState() error {
 	return s.SaveState()
 }
 
-// sshArgs are the fleet ssh options: the ephemeral identity, a per-fleet
-// known_hosts (droplet IPs get recycled across deployments — the global file
-// would scream host-key-changed), TOFU on first contact, and connection
-// multiplexing. Multiplexing matters beyond latency: status/watch/start
-// otherwise open a fresh port-22 TCP flow per droplet per command, a burst
-// pattern that trips ssh-targeted rate limiting on some paths (observed as
-// flapping per-IP port-22 SYN drops while ICMP and other ports stay fine).
-// One persistent master per droplet keeps the flow count flat.
+// sshArgs: ephemeral identity, per-fleet known_hosts (recycled droplet IPs
+// would trip host-key-changed in the global file), TOFU, and multiplexing.
+// Multiplexing is load-bearing: a fresh port-22 flow per droplet per command
+// trips ssh-targeted rate limiting on some paths (flapping per-IP SYN drops
+// while ICMP stays fine); one persistent master keeps the flow count flat.
 func (s *Session) sshArgs(extra ...string) []string {
 	args := []string{
 		"-o", "BatchMode=yes",
@@ -208,12 +194,10 @@ func (s *Session) sshArgs(extra ...string) []string {
 	return append(args, extra...)
 }
 
-// sshRun executes script on the droplet, returning combined stdout. stdin may
-// be nil. The script travels as the ssh command argument (visible in remote
-// ps — it must never contain secrets); secret payloads go through stdin.
-// Connection-level failures (ssh exit 255: banner timeouts, resets — common
-// when tens of sessions open against fresh droplets) are retried; remote
-// command failures are not, ssh reports those as the command's own exit code.
+// sshRun executes script (combined stdout; stdin may be nil). The script rides
+// ssh argv — visible in remote ps, NEVER secrets; secrets go via stdin.
+// Connection failures (exit 255: banner timeouts/resets, common on fresh
+// droplets) are retried; remote command failures (own exit code) are not.
 func (s *Session) sshRun(ctx context.Context, ip, script string, stdin []byte) (string, error) {
 	var lastOut string
 	var lastErr error
@@ -236,9 +220,8 @@ func (s *Session) sshRun(ctx context.Context, ip, script string, stdin []byte) (
 	return lastOut, lastErr
 }
 
-// sshRunOnce is a single ssh attempt with no retry — used by callers that
-// implement their own retry cadence (waitSSH), where nesting retries would
-// multiply the delays.
+// sshRunOnce: single attempt, no retry — for callers with their own cadence
+// (waitSSH); nested retries would multiply delays.
 func (s *Session) sshRunOnce(ctx context.Context, ip, script string, stdin []byte) (string, error) {
 	cmd := exec.CommandContext(ctx, "ssh", s.sshArgs(s.Provider.SSHUser()+"@"+ip, script)...)
 	if stdin != nil {
@@ -267,9 +250,8 @@ func (s *Session) Droplets(ctx context.Context) ([]provider.Host, error) {
 	return s.Provider.List(ctx, s.Tag())
 }
 
-// eachDroplet runs fn against every host in parallel — staggered by 150ms each
-// so a big fleet doesn't fire all its port-22 SYNs in one burst (see sshArgs)
-// — and returns the first error (all hosts are still attempted).
+// eachDroplet runs fn on every host in parallel, staggered 150ms apiece to
+// avoid one port-22 SYN burst (see sshArgs); first error returned, all attempted.
 func eachDroplet(hosts []provider.Host, fn func(d provider.Host) error) error {
 	var wg sync.WaitGroup
 	errs := make([]error, len(hosts))

--- a/packages/yuctl/internal/ceph/ceph.go
+++ b/packages/yuctl/internal/ceph/ceph.go
@@ -16,7 +16,6 @@ import (
 	"yuctl/internal/state"
 )
 
-// HealthResult summarizes a probe.
 type HealthResult struct {
 	Endpoint   string
 	StatusCode int
@@ -24,14 +23,10 @@ type HealthResult struct {
 	Detail     string
 }
 
-// CheckHealth issues an HTTPS GET against the cluster's RGW S3 endpoint. A
-// reachable gateway answers an anonymous/credentialed root GET with a 2xx
-// (bucket listing) or an auth-style 4xx (AccessDenied/Forbidden) — either proves
-// it is serving. Only a transport failure or a 5xx is treated as unhealthy.
-//
-// When health_cred_ref is set it is resolved via `op read` and sent as HTTP
-// basic auth (`access:secret` if it contains a colon, otherwise as a bearer
-// token), so credentialed dashboard/health endpoints work too.
+// CheckHealth: HTTPS GET on the RGW S3 endpoint. A 2xx or auth-style 4xx
+// (AccessDenied/Forbidden) proves it's serving; only transport failure or 5xx
+// is unhealthy. health_cred_ref, when set, is `op read` and sent as basic auth
+// (`access:secret` if it has a colon) or bearer — credentialed endpoints work too.
 func CheckHealth(ctx context.Context, cc state.CephCluster, insecureTLS bool) (*HealthResult, error) {
 	endpoint := cc.RGWS3Endpoint
 	if endpoint == "" {

--- a/packages/yuctl/internal/cli/adminauth.go
+++ b/packages/yuctl/internal/cli/adminauth.go
@@ -19,7 +19,6 @@ import (
 	"yuctl/internal/discovery"
 )
 
-// adminFlags is the shared flag set for commands that talk to the admin-api.
 type adminFlags struct {
 	adminURL  string
 	insecure  bool
@@ -44,11 +43,10 @@ func (f *adminFlags) httpClient() *http.Client {
 	return hc
 }
 
-// deriveAdminURL builds the admin-api origin for the partition's primary
-// region from its k8s discovery payload: the Talos API endpoint lives at
-// kube.<cluster>.<region>.<provider>.yucca.futo.network, and the admin-api is
-// published on the same NetBird overlay zone as admin.<...> (the
-// YUCCA_ADMIN_HOST cluster-setting follows the same convention).
+// deriveAdminURL builds the primary region's admin-api origin from its k8s
+// payload: Talos API = kube.<cluster>.<region>.<provider>.yucca.futo.network;
+// admin-api = admin.<same NetBird overlay zone> (YUCCA_ADMIN_HOST follows the
+// same convention).
 func deriveAdminURL(topo *discovery.Topology, partition, region string) (string, error) {
 	k8s := topo.Kubernetes(partition, region)
 	if k8s == nil || k8s.APIEndpoint == "" {
@@ -81,9 +79,8 @@ func (f *adminFlags) resolveAdminURL(topo *discovery.Topology, cc *yctx.Context)
 	return deriveAdminURL(topo, cc.Partition, primary)
 }
 
-// adminLogin returns an authenticated admin-api client, reusing the cached
-// per-partition session when valid and running the browser loopback flow
-// otherwise.
+// adminLogin returns an authed admin-api client: cached per-partition session
+// when valid, else the browser loopback flow.
 func (f *adminFlags) adminLogin(ctx context.Context, cmd *cobra.Command, cc *yctx.Context, topo *discovery.Topology) (*adminapi.Client, *adminapi.Token, error) {
 	adminURL, err := f.resolveAdminURL(topo, cc)
 	if err != nil {
@@ -117,7 +114,6 @@ func (f *adminFlags) adminLogin(ctx context.Context, cmd *cobra.Command, cc *yct
 	return adminapi.NewClient(adminURL, token, hc), &token, nil
 }
 
-// openBrowser opens url in the OS default browser, best-effort.
 func openBrowser(url string) error {
 	switch runtime.GOOS {
 	case "darwin":

--- a/packages/yuctl/internal/cli/benchwide.go
+++ b/packages/yuctl/internal/cli/benchwide.go
@@ -19,7 +19,6 @@ import (
 	"yuctl/internal/provider"
 )
 
-// benchDoFlags are shared by every bench-wide subcommand.
 type benchDoFlags struct {
 	yes      bool
 	provider string
@@ -44,7 +43,6 @@ func (f *benchDoFlags) session(ctx context.Context) (*benchwide.Session, string,
 	return s, cc.Partition + " · " + s.Tag(), nil
 }
 
-// minter runs the admin-api login flow and returns the repo-minting client.
 func (f *benchDoFlags) minter(ctx context.Context, cmd *cobra.Command, admin *adminFlags) (benchwide.RepoMinter, error) {
 	cc, err := requireContext()
 	if err != nil {

--- a/packages/yuctl/internal/cli/benchwideui.go
+++ b/packages/yuctl/internal/cli/benchwideui.go
@@ -108,7 +108,6 @@ func (v *benchDoView) render(r *benchwide.StatusReport, sampledAt time.Time, sam
 	}
 	b.WriteString("\n")
 
-	// Clients: loop progress per restic identity.
 	cnameW := 6
 	for _, d := range r.Droplets {
 		if d.Status == nil {

--- a/packages/yuctl/internal/cli/ceph.go
+++ b/packages/yuctl/internal/cli/ceph.go
@@ -118,7 +118,6 @@ func truncate(s string, n int) string {
 	return s[:n] + "…"
 }
 
-// sortedKeys of the ceph cluster map.
 func cephClusterNames[T any](m map[string]T) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/packages/yuctl/internal/cli/config.go
+++ b/packages/yuctl/internal/cli/config.go
@@ -13,10 +13,9 @@ import (
 	"yuctl/internal/adminapi"
 )
 
-// newConfigCmd builds the `config` subtree: scoped mutable configuration
-// (global / per-site / per-cluster overrides of restic_pack_size_mib,
-// connections_math, ...) stored by yucca-admin-api and served to clients via
-// GET /api/meta.
+// newConfigCmd builds the `config` subtree: scoped mutable config (global/site/
+// cluster overrides of restic_pack_size_mib, connections_math, …) stored by
+// yucca-admin-api, served via GET /api/meta.
 func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
@@ -29,7 +28,6 @@ func newConfigCmd() *cobra.Command {
 	return cmd
 }
 
-// scopeFlags resolves --site/--cluster into a settings scope string.
 type scopeFlags struct {
 	site    string
 	cluster string

--- a/packages/yuctl/internal/cli/root.go
+++ b/packages/yuctl/internal/cli/root.go
@@ -1,7 +1,6 @@
-// Package cli wires the yuctl command tree (spf13/cobra). cobra is a documented
-// divergence from michael's stdlib-only style, justified by yuctl's nested
-// subcommand surface (select / ceph / infra / users). Logging matches michael
-// (rs/zerolog).
+// Package cli wires the yuctl command tree (spf13/cobra — documented divergence
+// from michael's stdlib-only style, justified by the nested subcommand surface).
+// Logging matches michael (rs/zerolog).
 package cli
 
 import (
@@ -23,7 +22,6 @@ var (
 	flagRefreshDiscovery bool
 )
 
-// NewRootCmd builds the root command and registers every subcommand.
 func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "yuctl",
@@ -76,11 +74,9 @@ func setupLogging() error {
 	return nil
 }
 
-// resolveTopology returns the cached topology when fresh (see
-// discovery.LoadCachedTopology; TTL 1h, YUCTL_DISCOVERY_TTL to override,
-// --refresh-discovery to bypass), otherwise builds the discovery client,
-// resolves live from S3 state, and refreshes the cache. Shared by every command
-// that needs to read state.
+// resolveTopology: cached topology when fresh (TTL 1h; YUCTL_DISCOVERY_TTL
+// overrides, --refresh-discovery bypasses), else live resolve from S3 state +
+// cache refresh. Shared by every state-reading command.
 func resolveTopology(ctx context.Context) (*discovery.Topology, error) {
 	if !flagRefreshDiscovery {
 		if topo, ok := discovery.LoadCachedTopology(log.Logger); ok {

--- a/packages/yuctl/internal/cli/select.go
+++ b/packages/yuctl/internal/cli/select.go
@@ -9,7 +9,6 @@ import (
 	yctx "yuctl/internal/context"
 )
 
-// parseTarget splits the human form `partition@region`.
 func parseTarget(s string) (partition, region string, err error) {
 	p, r, ok := strings.Cut(s, "@")
 	if !ok || p == "" || r == "" {
@@ -52,7 +51,6 @@ func newSelectCmd() *cobra.Command {
 	}
 }
 
-// requireContext loads the persisted context, erroring if nothing is selected.
 func requireContext() (*yctx.Context, error) {
 	c, err := yctx.Load()
 	if err != nil {

--- a/packages/yuctl/internal/cli/tools.go
+++ b/packages/yuctl/internal/cli/tools.go
@@ -135,10 +135,9 @@ func newBenchCleanupCmd() *cobra.Command {
 	return cmd
 }
 
-// runBench resolves the context (host from discovery, repository via admin-api
-// unless supplied) and drives the run. Context/topology are resolved lazily so
-// a --from-here run with an explicit --repo needs neither state creds nor a
-// selected context (e.g. yuctl invoked directly on a mgmt host).
+// runBench resolves context (host from discovery, repo via admin-api unless
+// supplied) and drives the run. Lazy resolution: --from-here + explicit --repo
+// needs neither state creds nor a selected context (yuctl on a mgmt host).
 func (f *benchFlags) runBench(cmd *cobra.Command, defaultPhases []string) error {
 	ctx := cmd.Context()
 
@@ -161,7 +160,6 @@ func (f *benchFlags) runBench(cmd *cobra.Command, defaultPhases []string) error 
 	case f.fromHere && f.host != "":
 		return fmt.Errorf("--from-here and --host are mutually exclusive")
 	case f.fromHere:
-		// no remote host: the agent runs in-process on this machine
 	case f.host != "":
 		host = f.host
 	default:
@@ -185,9 +183,9 @@ func (f *benchFlags) runBench(cmd *cobra.Command, defaultPhases []string) error 
 	}
 
 	if cfg.Repo == "" {
-		// Topology is only needed to derive the admin URL; an explicit
-		// --admin-url / $YUCTL_ADMIN_API_URL skips state access entirely
-		// (the context file alone names the token-cache partition).
+		// Topology only derives the admin URL; explicit --admin-url /
+		// $YUCTL_ADMIN_API_URL skips state access (context file alone names
+		// the token-cache partition).
 		if f.admin.adminURL == "" && os.Getenv("YUCTL_ADMIN_API_URL") == "" {
 			if err := loadTopo(); err != nil {
 				return err

--- a/packages/yuctl/internal/cli/users.go
+++ b/packages/yuctl/internal/cli/users.go
@@ -14,7 +14,6 @@ import (
 	"yuctl/internal/adminapi"
 )
 
-// newUsersCmd builds the `users` subtree.
 func newUsersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "users",
@@ -28,7 +27,6 @@ func newUsersCmd() *cobra.Command {
 	return cmd
 }
 
-// newUsersFeaturesCmd builds `users features`: per-user feature-flag overrides.
 func newUsersFeaturesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "features",
@@ -153,7 +151,6 @@ func newUsersFeaturesClearCmd() *cobra.Command {
 	return c
 }
 
-// newUsersConnectionsCmd builds `users connections`.
 func newUsersConnectionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connections",
@@ -311,8 +308,6 @@ func newUsersListCmd() *cobra.Command {
 	return c
 }
 
-// newUsersAllowlistCmd builds the `users allowlist` subtree (beta email
-// allowlist + invites).
 func newUsersAllowlistCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "allowlist",
@@ -491,7 +486,6 @@ func newAllowlistInviteBatchCmd() *cobra.Command {
 	return c
 }
 
-// resolveUserID turns an --user email into a user id via the admin-api.
 func resolveUserID(ctx context.Context, client *adminapi.Client, email string) (string, error) {
 	users, err := client.ListUsers(ctx, 0)
 	if err != nil {

--- a/packages/yuctl/internal/cli/warp.go
+++ b/packages/yuctl/internal/cli/warp.go
@@ -15,8 +15,6 @@ import (
 	"yuctl/internal/warp"
 )
 
-// warpFlags are shared by every warp subcommand: how to reach the cluster and
-// which ceph cluster's RGW fleet to target. Everything else is derived.
 type warpFlags struct {
 	namespace   string
 	kubeconfig  string

--- a/packages/yuctl/internal/cli/warpui.go
+++ b/packages/yuctl/internal/cli/warpui.go
@@ -108,7 +108,6 @@ func (v *warpView) render(r *warp.StatusReport, sampledAt time.Time, sampleSec i
 		b.WriteString("\n")
 	}
 
-	// Pods: process liveness and log error counts.
 	podW := 3
 	for _, p := range r.Pods {
 		podW = max(podW, len(p.Name))
@@ -161,7 +160,6 @@ func padGbps(bps float64) string {
 	return fmt.Sprintf("%11s", fmtGbps(bps))
 }
 
-// meter renders a horizontal bar of width w, filled to value/scale.
 func meter(value, scale float64, w int) string {
 	filled := 0
 	if scale > 0 {
@@ -171,8 +169,6 @@ func meter(value, scale float64, w int) string {
 	return strings.Repeat("█", filled) + strings.Repeat("░", w-filled)
 }
 
-// sparkline renders the last len(vals) samples with block glyphs, scaled to
-// the window maximum, downsampled to at most w points.
 func sparkline(vals []float64, w int) string {
 	if len(vals) > w {
 		vals = vals[len(vals)-w:]

--- a/packages/yuctl/internal/context/context.go
+++ b/packages/yuctl/internal/context/context.go
@@ -1,7 +1,6 @@
 // Package context persists the operator's selected topology to
-// ${XDG_CONFIG_HOME:-~/.config}/yuctl/context.json. It is the small bit of
-// sticky state that lets `yuctl select prod@htz-fsn1` be followed by
-// `yuctl ceph get health` without re-specifying the target each time.
+// ${XDG_CONFIG_HOME:-~/.config}/yuctl/context.json — the sticky state letting
+// `yuctl select prod@htz-fsn1` be followed by `yuctl ceph get health`.
 package context
 
 import (
@@ -11,8 +10,7 @@ import (
 	"path/filepath"
 )
 
-// Context is the selected partition/region (+ optional ceph cluster). An empty
-// CephCluster means none is selected.
+// An empty CephCluster means none is selected.
 type Context struct {
 	Partition   string `json:"partition"`
 	Region      string `json:"region"`
@@ -33,7 +31,6 @@ func Dir() (string, error) {
 	return filepath.Join(base, "yuctl"), nil
 }
 
-// Path returns the full path to context.json.
 func Path() (string, error) {
 	dir, err := Dir()
 	if err != nil {
@@ -42,9 +39,8 @@ func Path() (string, error) {
 	return filepath.Join(dir, "context.json"), nil
 }
 
-// Load reads the persisted context. A missing file is not an error: it returns
-// a zero Context and (nil), so commands can detect "nothing selected" via
-// Context.Partition == "".
+// Load reads the persisted context. Missing file = zero Context, nil error;
+// "nothing selected" is Context.Partition == "".
 func Load() (*Context, error) {
 	p, err := Path()
 	if err != nil {
@@ -90,7 +86,6 @@ func Save(c *Context) error {
 	return nil
 }
 
-// Selected reports whether a partition/region is currently selected.
 func (c *Context) Selected() bool {
 	return c != nil && c.Partition != "" && c.Region != ""
 }

--- a/packages/yuctl/internal/discovery/cache.go
+++ b/packages/yuctl/internal/discovery/cache.go
@@ -11,11 +11,9 @@ import (
 	yctx "yuctl/internal/context"
 )
 
-// The resolved topology is cached on disk so repeat invocations skip the
-// 1Password credential reads and the per-stack S3 state fetches entirely. The
-// discovery contract only ever carries `op://` reference strings (never secret
-// values), so caching it in the config dir is safe; 0600 matches the token
-// cache convention anyway.
+// Topology is cached on disk so repeat invocations skip the 1P credential
+// reads and per-stack S3 fetches. The contract only carries `op://` refs
+// (never secret values), so config-dir caching is safe; 0600 matches the token cache.
 const (
 	cacheFileName   = "discovery-cache.json"
 	defaultCacheTTL = time.Hour
@@ -24,7 +22,6 @@ const (
 	cacheTTLEnvVar = "YUCTL_DISCOVERY_TTL"
 )
 
-// cacheEnvelope is the on-disk shape: the topology plus when it was resolved.
 type cacheEnvelope struct {
 	FetchedAt time.Time `json:"fetched_at"`
 	Topology  *Topology `json:"topology"`
@@ -47,9 +44,8 @@ func cacheTTL() time.Duration {
 	return defaultCacheTTL
 }
 
-// LoadCachedTopology returns the cached topology when one exists and is younger
-// than the TTL. Any problem (missing, unreadable, corrupt, expired) is a cache
-// miss, never an error — callers fall back to a live resolve.
+// LoadCachedTopology returns the cache when younger than TTL. Any problem
+// (missing/corrupt/expired) is a miss, never an error — callers resolve live.
 func LoadCachedTopology(logger zerolog.Logger) (*Topology, bool) {
 	p, err := cachePath()
 	if err != nil {

--- a/packages/yuctl/internal/discovery/discovery.go
+++ b/packages/yuctl/internal/discovery/discovery.go
@@ -1,13 +1,10 @@
-// Package discovery resolves the live yucca topology by reading Terraform state
-// objects directly from the shared `yucca-tf-state` S3 bucket and parsing each
-// stack's `discovery` output (see internal/state). It never shells out to
-// `terragrunt output`, so it works without a checkout, provider plugins, or
-// `terragrunt init`.
-//
-// Stack enumeration is auto-detected: it prefers walking a local
-// `tf/deployment` tree (cheap, offline, and authoritative for *which* stacks
-// exist), and falls back to a `ListObjectsV2` sweep of the bucket. Either way,
-// live values come from a `GetObject` on each `terraform.tfstate`.
+// Package discovery resolves the live yucca topology by reading Terraform
+// state straight from the shared `yucca-tf-state` S3 bucket and parsing each
+// stack's `discovery` output (see internal/state) — never `terragrunt output`,
+// so no checkout, provider plugins, or init needed. Stack enumeration prefers
+// walking a local `tf/deployment` tree (cheap, offline, authoritative for
+// WHICH stacks exist), falling back to a ListObjectsV2 sweep; live values
+// always come from GetObject on each terraform.tfstate.
 package discovery
 
 import (
@@ -41,14 +38,12 @@ const (
 	s3Endpoint = "https://s3.eu-west-par.io.cloud.ovh.net/"
 	s3Region   = "eu-west-par"
 
-	// Default 1Password references for the state-bucket credentials. These match
-	// the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY lines in tf/.env. Overridable
-	// via the env vars below for `op run` / CI contexts.
+	// Default 1P refs for the state-bucket creds (match the AWS_* lines in
+	// tf/.env); overridable via the env vars below for `op run`/CI.
 	defaultAccessKeyRef = "op://yucca_tf/TF_STATE_S3_ACCESS_KEY/password"
 	defaultSecretKeyRef = "op://yucca_tf/TF_STATE_S3_SECRET_KEY/password"
 )
 
-// Stack identifies one Terraform stack and its state object key.
 type Stack struct {
 	Partition string
 	Region    string
@@ -56,27 +51,22 @@ type Stack struct {
 	Key       string // full S3 object key
 }
 
-// ResolvedStack is a Stack with its parsed discovery envelope.
 type ResolvedStack struct {
 	Stack
 	Discovery state.Discovery
 }
 
-// Topology is every resolved stack across the bucket.
 type Topology struct {
 	Stacks []ResolvedStack
 }
 
-// Client reads state from S3.
 type Client struct {
 	s3  *s3.Client
 	log zerolog.Logger
 }
 
-// NewClient builds the S3 client. Credentials come from AWS_ACCESS_KEY_ID /
-// AWS_SECRET_ACCESS_KEY when already present (e.g. under `op run`), otherwise
-// they are resolved from 1Password via `op read` (refs overridable through
-// YUCTL_TF_STATE_ACCESS_KEY_REF / YUCTL_TF_STATE_SECRET_KEY_REF).
+// NewClient builds the S3 client: AWS_ACCESS_KEY_ID/SECRET when present (op
+// run), else `op read` (refs overridable via YUCTL_TF_STATE_{ACCESS,SECRET}_KEY_REF).
 func NewClient(ctx context.Context, logger zerolog.Logger) (*Client, error) {
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
@@ -121,14 +111,11 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-// resolveConcurrency bounds the parallel GetObject fan-out in Resolve.
 const resolveConcurrency = 8
 
-// Resolve discovers stacks (local tree preferred, else bucket listing), reads
-// each state object, and returns the populated topology. Stacks whose state has
-// no `discovery` output yet are skipped with a debug log. State objects are
-// fetched concurrently; results keep the (sorted) enumeration order so the
-// topology stays deterministic.
+// Resolve discovers stacks (local tree preferred, else bucket listing) and
+// fetches states concurrently; stacks without a `discovery` output are skipped
+// (debug log). Results keep sorted enumeration order — deterministic topology.
 func (c *Client) Resolve(ctx context.Context) (*Topology, error) {
 	stacks, src, err := c.enumerate(ctx)
 	if err != nil {
@@ -175,7 +162,6 @@ func (c *Client) Resolve(ctx context.Context) (*Topology, error) {
 	return topo, nil
 }
 
-// enumerate returns candidate stacks, preferring a local tf/deployment tree.
 func (c *Client) enumerate(ctx context.Context) ([]Stack, string, error) {
 	if dir := findDeploymentDir(); dir != "" {
 		stacks, err := enumerateLocal(dir)
@@ -193,8 +179,6 @@ func (c *Client) enumerate(ctx context.Context) ([]Stack, string, error) {
 	return stacks, "bucket", nil
 }
 
-// findDeploymentDir walks up from the working directory looking for a
-// `tf/deployment` directory, returning its absolute path or "".
 func findDeploymentDir() string {
 	if override := os.Getenv("YUCTL_TF_DEPLOYMENT_DIR"); override != "" {
 		if isDir(override) {
@@ -223,9 +207,8 @@ func isDir(p string) bool {
 	return err == nil && info.IsDir()
 }
 
-// enumerateLocal walks tf/deployment finding every directory that contains a
-// terragrunt.hcl and sits at depth >= 2 (partition/region/<stack...>). The root
-// terragrunt.hcl (depth 0) is ignored.
+// enumerateLocal walks tf/deployment for terragrunt.hcl dirs at depth >= 2
+// (partition/region/<stack...>); the root terragrunt.hcl is ignored.
 func enumerateLocal(root string) ([]Stack, error) {
 	var stacks []Stack
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -257,7 +240,6 @@ func enumerateLocal(root string) ([]Stack, error) {
 	return stacks, nil
 }
 
-// enumerateBucket lists every `*/terraform.tfstate` under the yucca/ prefix.
 func (c *Client) enumerateBucket(ctx context.Context) ([]Stack, error) {
 	var stacks []Stack
 	p := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
@@ -283,7 +265,6 @@ func (c *Client) enumerateBucket(ctx context.Context) ([]Stack, error) {
 	return stacks, nil
 }
 
-// stackFromSegments builds a Stack from path segments [partition, region, sub...].
 func stackFromSegments(segs []string) Stack {
 	partition, region := segs[0], segs[1]
 	sub := strings.Join(segs[2:], "/")
@@ -295,7 +276,6 @@ func stackFromSegments(segs []string) Stack {
 	}
 }
 
-// stackFromKey parses `yucca/<partition>/<region>/<stack...>/terraform.tfstate`.
 func stackFromKey(key string) (Stack, bool) {
 	trimmed := strings.TrimPrefix(key, KeyPrefix)
 	trimmed = strings.TrimSuffix(trimmed, "/terraform.tfstate")
@@ -332,9 +312,6 @@ func sortStacks(s []Stack) {
 	})
 }
 
-// ---- Topology queries -------------------------------------------------------
-
-// Regions returns the distinct partition@region pairs present in the topology.
 func (t *Topology) Regions() []string {
 	seen := map[string]struct{}{}
 	var out []string
@@ -352,7 +329,6 @@ func (t *Topology) Regions() []string {
 	return out
 }
 
-// HasRegion reports whether any stack exists for partition@region.
 func (t *Topology) HasRegion(partition, region string) bool {
 	for _, s := range t.Stacks {
 		if s.Partition == partition && s.Region == region {
@@ -362,7 +338,6 @@ func (t *Topology) HasRegion(partition, region string) bool {
 	return false
 }
 
-// Kubernetes returns the region's single k8s/talos discovery payload, or nil.
 func (t *Topology) Kubernetes(partition, region string) *state.Kubernetes {
 	for _, s := range t.Stacks {
 		if s.Partition == partition && s.Region == region && s.Discovery.Kubernetes != nil {

--- a/packages/yuctl/internal/do/do.go
+++ b/packages/yuctl/internal/do/do.go
@@ -1,7 +1,6 @@
-// Package do wraps the DigitalOcean API (godo) for the bench-do droplet
-// fleet: token resolution via 1Password, the yucca-bench project, ephemeral
-// SSH keys, and tagged droplet lifecycle. Nothing here knows about restic or
-// michael — it is pure fleet plumbing.
+// Package do wraps godo for the bench-do droplet fleet: 1P token resolution,
+// the yucca-bench project, ephemeral SSH keys, tagged droplet lifecycle. Pure
+// fleet plumbing — knows nothing of restic or michael.
 package do
 
 import (
@@ -27,7 +26,6 @@ const (
 	ProjectName = "yucca-bench"
 )
 
-// Client is a thin godo wrapper scoped to bench-do's needs.
 type Client struct {
 	do *godo.Client
 }
@@ -51,8 +49,6 @@ func NewClient(ctx context.Context) (*Client, error) {
 	return &Client{do: godo.NewFromToken(token)}, nil
 }
 
-// EnsureProject returns the ProjectName project's ID, creating the project if
-// the account does not have it yet.
 func (c *Client) EnsureProject(ctx context.Context) (string, error) {
 	opt := &godo.ListOptions{PerPage: 200}
 	for {
@@ -83,7 +79,6 @@ func (c *Client) EnsureProject(ctx context.Context) (string, error) {
 	return p.ID, nil
 }
 
-// AssignDroplets files droplets under the project.
 func (c *Client) AssignDroplets(ctx context.Context, projectID string, dropletIDs []int) error {
 	if len(dropletIDs) == 0 {
 		return nil
@@ -139,25 +134,21 @@ func (c *Client) DeleteKey(ctx context.Context, id int) error {
 	return nil
 }
 
-// Size describes one droplet size the fleet can use.
 type Size struct {
 	Slug        string
 	VCPUs       int
 	MemoryMB    int
 	DiskGB      int
 	PriceHourly float64
-	// TransferTB is DO's included outbound transfer for the size. DO markets
-	// it as "TB"; we bill the cap conservatively as decimal TB (1e12 bytes)
-	// so the auto-stop errs on the early side.
+	// TransferTB: DO's included outbound transfer. Marketed as "TB"; billed
+	// conservatively as decimal TB (1e12 bytes) so auto-stop errs early.
 	TransferTB float64
 }
 
-// TransferBytes is the conservative byte value of the size's allowance.
 func (s Size) TransferBytes() int64 {
 	return int64(s.TransferTB * 1e12)
 }
 
-// GetSize resolves a size slug to its pricing and transfer allowance.
 func (c *Client) GetSize(ctx context.Context, slug string) (*Size, error) {
 	opt := &godo.ListOptions{PerPage: 200}
 	for {
@@ -185,7 +176,6 @@ func (c *Client) GetSize(ctx context.Context, slug string) (*Size, error) {
 	return nil, fmt.Errorf("unknown DO size slug %q", slug)
 }
 
-// Droplet is the subset of droplet state bench-do tracks.
 type Droplet struct {
 	ID       int
 	Name     string
@@ -245,7 +235,6 @@ func (c *Client) CreateDroplets(ctx context.Context, names []string, region, siz
 	return out, nil
 }
 
-// ListByTag returns every droplet carrying the fleet tag, sorted by name.
 func (c *Client) ListByTag(ctx context.Context, tag string) ([]Droplet, error) {
 	var out []Droplet
 	opt := &godo.ListOptions{PerPage: 200}
@@ -293,7 +282,6 @@ func (c *Client) DeleteByTag(ctx context.Context, tag string) error {
 	}
 }
 
-// DeleteDroplet destroys a single droplet by ID (used to trim surplus).
 func (c *Client) DeleteDroplet(ctx context.Context, id int) error {
 	if _, err := c.do.Droplets.Delete(ctx, id); err != nil {
 		return fmt.Errorf("delete droplet %d: %w", id, err)
@@ -301,8 +289,6 @@ func (c *Client) DeleteDroplet(ctx context.Context, id int) error {
 	return nil
 }
 
-// WaitActive polls the tagged fleet until every droplet is active with a
-// public IPv4, returning the refreshed listing.
 func (c *Client) WaitActive(ctx context.Context, tag string, want int, timeout time.Duration) ([]Droplet, error) {
 	deadline := time.Now().Add(timeout)
 	lastReady := -1

--- a/packages/yuctl/internal/k8s/talos.go
+++ b/packages/yuctl/internal/k8s/talos.go
@@ -15,19 +15,14 @@ import (
 	"yuctl/internal/state"
 )
 
-// UpgradeOptions controls a talos upgrade run.
 type UpgradeOptions struct {
-	// Image, when set, is passed as `--image` (the target installer image).
-	Image string
-	// DryRun prints the talosctl commands instead of executing them.
+	Image  string
 	DryRun bool
-	// Nodes overrides the control-plane node IPs from discovery (optional).
-	Nodes []string
+	Nodes  []string
 }
 
-// TalosUpgrade resolves the talosconfig referenced by the kubernetes payload and
-// runs `talosctl upgrade` against each control-plane node. The temp talosconfig
-// is removed on return. With DryRun the commands are only logged.
+// TalosUpgrade resolves the payload's talosconfig and runs `talosctl upgrade`
+// per control-plane node; temp talosconfig removed on return, DryRun only logs.
 func TalosUpgrade(ctx context.Context, k state.Kubernetes, opts UpgradeOptions, logger zerolog.Logger) error {
 	nodes := opts.Nodes
 	if len(nodes) == 0 {
@@ -72,8 +67,7 @@ func TalosUpgrade(ctx context.Context, k state.Kubernetes, opts UpgradeOptions, 
 	return nil
 }
 
-// endpointHost strips a scheme/port from an api_endpoint so it can be used as a
-// talosctl --endpoints host. talosctl wants the host, not a URL.
+// talosctl --endpoints wants a bare host, not a URL.
 func endpointHost(endpoint string) string {
 	host := endpoint
 	for _, p := range []string{"https://", "http://"} {
@@ -81,11 +75,9 @@ func endpointHost(endpoint string) string {
 			host = host[len(p):]
 		}
 	}
-	// drop any path
 	if i := indexByte(host, '/'); i >= 0 {
 		host = host[:i]
 	}
-	// drop any port
 	if i := indexByte(host, ':'); i >= 0 {
 		host = host[:i]
 	}

--- a/packages/yuctl/internal/netdev/netdev.go
+++ b/packages/yuctl/internal/netdev/netdev.go
@@ -1,7 +1,6 @@
-// Package netdev parses /proc/net/dev counter snapshots. Shared by everything
-// that measures NIC throughput from that file — the warp status sampler and
-// the bench-do agent/orchestrator — so virtual-interface filtering stays in
-// one place.
+// Package netdev parses /proc/net/dev snapshots — shared by the warp status
+// sampler and bench-do agent/orchestrator so virtual-interface filtering stays
+// in one place.
 package netdev
 
 import (
@@ -9,10 +8,8 @@ import (
 	"strings"
 )
 
-// Counters is one interface's cumulative RX/TX byte counters.
 type Counters struct{ RX, TX uint64 }
 
-// Parse decodes the text of /proc/net/dev into per-interface counters.
 func Parse(text string) map[string]Counters {
 	res := map[string]Counters{}
 	for line := range strings.SplitSeq(text, "\n") {
@@ -45,7 +42,6 @@ func Virtual(name string) bool {
 	return false
 }
 
-// PhysicalTotals sums the counters of every non-virtual interface.
 func PhysicalTotals(m map[string]Counters) Counters {
 	var t Counters
 	for name, c := range m {

--- a/packages/yuctl/internal/op/op.go
+++ b/packages/yuctl/internal/op/op.go
@@ -1,8 +1,7 @@
-// Package op is a thin wrapper around the 1Password CLI (`op`). It resolves
-// `op://vault/item/field` references to their secret values, matching the
-// repo-wide `op run` convention (interactive desktop unlock or a service-account
-// token via OP_SERVICE_ACCOUNT_TOKEN). yuctl never embeds secrets; the discovery
-// contract only ever carries `op://` reference strings, resolved here on demand.
+// Package op thinly wraps the 1Password CLI: resolves `op://vault/item/field`
+// refs on demand, matching the repo-wide `op run` convention (desktop unlock
+// or OP_SERVICE_ACCOUNT_TOKEN). yuctl never embeds secrets; the discovery
+// contract only carries `op://` refs.
 package op
 
 import (
@@ -59,9 +58,8 @@ func Read(ctx context.Context, ref string) (string, error) {
 	return out.String(), nil
 }
 
-// ReadToTempFile resolves a reference and writes the value to a freshly created
-// 0600 temp file, returning its path. Used for kubeconfig/talosconfig that
-// downstream tools (talosctl, kubectl) need on disk. The caller owns cleanup.
+// ReadToTempFile resolves a ref into a fresh 0600 temp file (kubeconfig/
+// talosconfig for talosctl/kubectl); the caller owns cleanup.
 func ReadToTempFile(ctx context.Context, ref, pattern string) (string, error) {
 	val, err := Read(ctx, ref)
 	if err != nil {

--- a/packages/yuctl/internal/provider/do.go
+++ b/packages/yuctl/internal/provider/do.go
@@ -8,9 +8,7 @@ import (
 	"yuctl/internal/do"
 )
 
-// doProvider adapts the DigitalOcean client (internal/do) to Provider. It owns
-// no logic of its own — just the Host/Size translation and the int⇄string id
-// bridging Provider's opaque ids require.
+// Host/Size translation plus the int⇄string id bridging opaque ids require.
 type doProvider struct{ c *do.Client }
 
 func newDO(ctx context.Context) (Provider, error) {

--- a/packages/yuctl/internal/provider/hetzner.go
+++ b/packages/yuctl/internal/provider/hetzner.go
@@ -26,8 +26,7 @@ const hetznerTokenRef = "op://yucca_tf_prod/HCLOUD_API_TOKEN/password"
 const fleetLabel = "yuctl-fleet"
 
 // hetznerProvider talks to the Hetzner Cloud API (https://api.hetzner.cloud/v1)
-// over plain net/http — the surface bench-wide needs is small enough that a
-// full SDK dependency isn't worth it.
+// over plain net/http — bench-wide's surface is too small to warrant an SDK.
 type hetznerProvider struct {
 	token string
 	http  *http.Client
@@ -104,7 +103,6 @@ func (p *hetznerProvider) req(ctx context.Context, method, path string, body, ou
 	return nil
 }
 
-// hServer is the subset of a Hetzner server object we read.
 type hServer struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`

--- a/packages/yuctl/internal/provider/provider.go
+++ b/packages/yuctl/internal/provider/provider.go
@@ -1,11 +1,9 @@
-// Package provider abstracts the cloud that hosts a bench-wide fleet so the
-// fleet lifecycle (deploy/start/status/stop/cleanup/undeploy) is identical
-// across providers. Each provider is pure VM plumbing — create/list/destroy
-// tagged hosts, upload an ephemeral ssh key, resolve a size's price and
-// transfer allowance — and knows nothing about restic or michael.
-//
-// Implementations live beside this file (do.go, hetzner.go); New resolves a
-// provider by name. OVH slots in as another implementation + New case.
+// Package provider abstracts the cloud hosting a bench-wide fleet so the
+// lifecycle (deploy/start/status/stop/cleanup/undeploy) is provider-identical.
+// Each provider is pure VM plumbing (create/list/destroy tagged hosts,
+// ephemeral ssh key, size price + transfer allowance), restic/michael-agnostic.
+// Implementations live beside this file (do.go, hetzner.go); New resolves by
+// name — OVH slots in as another implementation + New case.
 package provider
 
 import (
@@ -14,7 +12,6 @@ import (
 	"time"
 )
 
-// Host is the subset of a provider VM's state the fleet tracks.
 type Host struct {
 	ID       string // provider-native id, as a string (DO int, Hetzner int, …)
 	Name     string
@@ -44,13 +41,11 @@ type Defaults struct {
 	Image   string
 }
 
-// Provider is one cloud's fleet plumbing. Everything is keyed on an opaque
-// fleet tag so a yuctl crash never orphans billable hosts — the provider's own
-// tag/label listing is the source of truth, not local state.
+// Provider is one cloud's fleet plumbing, keyed on an opaque fleet tag — the
+// provider's tag listing is truth, so a yuctl crash never orphans billable hosts.
 type Provider interface {
-	// Name is the stable provider slug (do, hetzner, ovh) — part of the fleet
-	// tag and the local state filename, so fleets on different providers (and
-	// partitions) coexist in one account without undeploy crossing streams.
+	// Name: stable slug (do, hetzner, ovh) — part of the fleet tag and state
+	// filename, so per-provider/partition fleets coexist without undeploy crossing streams.
 	Name() string
 	// SSHUser is the login the provider's default image ships (root, ubuntu…).
 	SSHUser() string
@@ -63,31 +58,26 @@ type Provider interface {
 	EnsureKey(ctx context.Context, name, publicKey string) (keyID string, err error)
 	DeleteKey(ctx context.Context, keyID string) error
 
-	// Create makes the named hosts in one region with the fleet tag + ssh key.
-	// (DO multi-creates per region; Hetzner creates one per call — both honour
-	// the same signature.)
+	// Create makes the named hosts in one region with the fleet tag + ssh key
+	// (DO multi-creates per region; Hetzner one per call — same signature).
 	Create(ctx context.Context, names []string, region, size, image, tag, keyID string) ([]Host, error)
 	// List returns every host carrying the tag, sorted by name.
 	List(ctx context.Context, tag string) ([]Host, error)
 	// WaitActive blocks until want hosts are running with a public IPv4.
 	WaitActive(ctx context.Context, tag string, want int, timeout time.Duration) ([]Host, error)
-	// DeleteHost destroys a single host (surplus trim during converge).
 	DeleteHost(ctx context.Context, h Host) error
 	// DeleteByTag destroys every host carrying the tag and waits for the
 	// listing to empty.
 	DeleteByTag(ctx context.Context, tag string) error
 
-	// AssignProject files the fleet under a provider-native grouping
-	// (DO project). Best-effort and provider-specific; a no-op returning nil
-	// where the concept does not exist.
+	// AssignProject files the fleet under a provider-native grouping (DO
+	// project); best-effort, no-op nil where the concept doesn't exist.
 	AssignProject(ctx context.Context, hosts []Host) error
 }
 
-// Names lists the registered provider slugs (for CLI help / validation).
 func Names() []string { return []string{"do", "hetzner"} }
 
-// New resolves a provider by slug, building its API client (token via env or
-// 1Password). OVH will be added here.
+// Builds the provider's API client; token via env or 1Password.
 func New(ctx context.Context, name string) (Provider, error) {
 	switch name {
 	case "do", "digitalocean", "":

--- a/packages/yuctl/internal/state/contract.go
+++ b/packages/yuctl/internal/state/contract.go
@@ -1,9 +1,7 @@
-// Package state defines the Go view of the Terraform "discovery" output
-// contract (Workstream 1.5) and parses it out of raw terraform.tfstate objects.
-//
-// Every stack emits a single non-sensitive top-level output named `discovery`
-// with a common envelope and a stack-typed payload. Secrets are ALWAYS `op://`
-// reference strings (resolved later via the op package), never literal values.
+// Package state is the Go view of the Terraform `discovery` output contract
+// (Workstream 1.5), parsed from raw terraform.tfstate. Each stack emits one
+// non-sensitive top-level `discovery` output: common envelope + stack-typed
+// payload; secrets are ALWAYS `op://` refs (resolved via the op package), never literal.
 package state
 
 import (
@@ -11,9 +9,9 @@ import (
 	"fmt"
 )
 
-// Discovery is the decoded `.outputs.discovery.value` envelope plus the union of
-// every stack-typed payload. Exactly one payload group is populated per stack
-// (talos → Kubernetes, ceph → CephClusters, etc.); the rest stay nil/empty.
+// Discovery is the decoded `.outputs.discovery.value` envelope plus the union
+// of stack-typed payloads; exactly one group is populated per stack (talos →
+// Kubernetes, ceph → CephClusters, …), the rest stay nil/empty.
 type Discovery struct {
 	// Envelope — present on every stack.
 	SchemaVersion int        `json:"schema_version"`
@@ -63,7 +61,6 @@ type CephCluster struct {
 	BootstrapHost    string            `json:"bootstrap_host"`
 }
 
-// DNS is the dns stack payload.
 type DNS struct {
 	Provider    string   `json:"provider"`
 	Zone        string   `json:"zone"`
@@ -82,7 +79,6 @@ type Netbird struct {
 	SetupKeyItemTitles map[string]string `json:"setup_key_item_titles"`
 }
 
-// ClusterCIDR is one fabric cluster's public/private CIDR pair.
 type ClusterCIDR struct {
 	Public  string `json:"public"`
 	Private string `json:"private"`
@@ -95,7 +91,6 @@ type MgmtHost struct {
 	PublicIP string `json:"public_ip"`
 }
 
-// Fabric is the fabric stack payload.
 type Fabric struct {
 	SiteID       *int                   `json:"site_id"`
 	KubeCIDR     string                 `json:"kube_cidr"`
@@ -104,9 +99,8 @@ type Fabric struct {
 	MgmtHosts    []MgmtHost             `json:"mgmt_hosts,omitempty"`
 }
 
-// tfState is the minimal slice of a terraform.tfstate JSON document we care
-// about: the `outputs.discovery.value` envelope. We deliberately ignore the
-// rest of the (potentially large, sensitive) state body.
+// tfState: minimal slice of terraform.tfstate — just `outputs.discovery.value`;
+// the (large, sensitive) rest is deliberately ignored.
 type tfState struct {
 	Outputs struct {
 		Discovery struct {
@@ -115,10 +109,9 @@ type tfState struct {
 	} `json:"outputs"`
 }
 
-// ParseDiscovery extracts and decodes `.outputs.discovery.value` from a raw
-// terraform.tfstate document. It returns (nil, nil) when the state has no
-// `discovery` output (e.g. a stack that predates the contract), so callers can
-// skip such stacks rather than treat them as errors.
+// ParseDiscovery decodes `.outputs.discovery.value` from raw tfstate. Returns
+// (nil, nil) when there is no `discovery` output (stack predates the contract)
+// so callers skip rather than error.
 func ParseDiscovery(raw []byte) (*Discovery, error) {
 	var st tfState
 	if err := json.Unmarshal(raw, &st); err != nil {

--- a/packages/yuctl/internal/state/contract_test.go
+++ b/packages/yuctl/internal/state/contract_test.go
@@ -67,7 +67,6 @@ func TestParseDiscovery_Ceph(t *testing.T) {
 }
 
 func TestParseDiscovery_NoOutput(t *testing.T) {
-	// A pre-contract stack: no discovery output. Should return (nil, nil).
 	d, err := ParseDiscovery([]byte(`{"version":4,"outputs":{}}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/packages/yuctl/internal/warp/cleanup.go
+++ b/packages/yuctl/internal/warp/cleanup.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// CleanupOptions control the bucket purge.
 type CleanupOptions struct {
 	Prefixes   []string // bucket-name prefixes to purge (default yuctl-warp-)
 	Legacy     bool     // also purge the pre-yuctl soak prefixes (warp-lt-, warp-loadtest-)
@@ -27,10 +26,9 @@ type CleanupOptions struct {
 	Timeout    time.Duration
 }
 
-// Cleanup purges warp test buckets via a hostNetwork Job running `mc` inside
-// the cluster — the RGW IPs are fabric-internal, so the deletes must run from
-// the worker vantage, with the same creds secret the runners use. Note a mass
-// delete is itself a load event (RGW GC churns afterwards).
+// Cleanup purges warp buckets via a hostNetwork `mc` Job in-cluster — RGW IPs
+// are fabric-internal, so deletes run from the worker vantage with the runners'
+// creds secret. A mass delete is itself a load event (RGW GC churns after).
 func (s *Session) Cleanup(ctx context.Context, opts CleanupOptions) error {
 	if len(opts.Prefixes) == 0 {
 		opts.Prefixes = []string{"yuctl-warp-"}
@@ -144,7 +142,6 @@ echo cleanup done`, mci, target.Endpoint, strings.Join(patterns, "|"), strings.J
 	return nil
 }
 
-// jobLogs concatenates the logs of the job's pods (best effort).
 func (s *Session) jobLogs(ctx context.Context, job string) string {
 	pods, err := s.client.CoreV1().Pods(s.Namespace).List(ctx, metav1.ListOptions{LabelSelector: "job-name=" + job})
 	if err != nil {

--- a/packages/yuctl/internal/warp/deploy.go
+++ b/packages/yuctl/internal/warp/deploy.go
@@ -66,10 +66,9 @@ func (o *DeployOptions) defaults() {
 	}
 }
 
-// Deploy creates (or converges) the loadtest namespace, the creds secret
-// (copied from the product's RGW credentials), and the hostNetwork runner
-// Deployment sized from the discovered workers. Idempotent: every manifest is
-// server-side applied, then the rollout is awaited.
+// Deploy converges the loadtest namespace, creds secret (copied from the
+// product's RGW credentials), and hostNetwork runner Deployment sized from
+// discovered workers. Idempotent: server-side apply, then rollout awaited.
 func (s *Session) Deploy(ctx context.Context, opts DeployOptions) error {
 	opts.defaults()
 
@@ -154,10 +153,9 @@ func (s *Session) Deploy(ctx context.Context, opts DeployOptions) error {
 	return nil
 }
 
-// rebalance heals a skewed spread: node drains (e.g. rolling reboots) evict
-// runners onto the remaining workers and nothing moves them back — the spread
-// constraint only acts at scheduling time. Surplus pods on overloaded workers
-// are deleted so the scheduler respreads them onto the underloaded ones.
+// rebalance heals a skewed spread: drains evict runners and nothing moves them
+// back (the spread constraint acts only at scheduling time) — surplus pods on
+// overloaded workers are deleted so the scheduler respreads them.
 func (s *Session) rebalance(ctx context.Context, workers []Worker, podsPerNode int, replicas int32) error {
 	pods, err := s.RunnerPods(ctx)
 	if err != nil {
@@ -194,9 +192,8 @@ func (s *Session) rebalance(ctx context.Context, workers []Worker, podsPerNode i
 	return s.waitRollout(ctx, replicas)
 }
 
-// waitRollout polls the Deployment until every replica is updated and ready,
-// logging progress whenever the ready count changes (and periodically so long
-// waits — image pulls, scheduling — never look hung).
+// waitRollout polls until every replica is updated+ready, logging on
+// ready-count change and periodically so long waits never look hung.
 func (s *Session) waitRollout(ctx context.Context, replicas int32) error {
 	start := time.Now()
 	lastReady := int32(-1)

--- a/packages/yuctl/internal/warp/run.go
+++ b/packages/yuctl/internal/warp/run.go
@@ -51,17 +51,14 @@ func (o *StartOptions) defaults() {
 	}
 }
 
-// killScript terminates the loop wrappers first so they cannot respawn warp,
-// then the warp processes. The [b]racket trick keeps each pattern from
-// matching the `sh -c` process running this very script (whose command line
-// contains the pattern text) — a self-match SIGTERMs the exec and fails it
-// with exit 143. Trailing `true` absorbs pkill's exit 1 on no-match.
+// killScript kills loop wrappers first (no respawn), then warp. The [b]racket
+// keeps patterns from matching this script's own `sh -c` line (self-match
+// SIGTERMs the exec, exit 143); trailing `true` absorbs pkill's no-match exit 1.
 const killScript = `pkill -f 'warp-[p]ut-loop' 2>/dev/null; pkill -f 'warp-[g]et-loop' 2>/dev/null; sleep 1; ` +
 	`pkill -f '/warp [p]ut' 2>/dev/null; pkill -f '/warp [g]et' 2>/dev/null; true`
 
-// Start launches (or gracefully relaunches) the load on every runner pod. Any
-// warp processes already running are killed first, so start is idempotent and
-// doubles as "restart with new parameters".
+// Start (re)launches load on every runner pod, killing running warp first —
+// idempotent, doubles as "restart with new parameters".
 func (s *Session) Start(ctx context.Context, opts StartOptions) error {
 	opts.defaults()
 
@@ -132,9 +129,8 @@ func (s *Session) Start(ctx context.Context, opts StartOptions) error {
 				`--objects=%d --obj.size=%s --duration=%s --concurrent=%d --noclear --no-color >> /tmp/warp-get.log 2>&1`,
 				hostList, tlsFlags, opts.BucketPrefix, pod.Name, opts.GetObjects, opts.GetObjSize, runDuration, get)
 
-			// Kill and launch are separate execs: the launch script's literal
-			// "/warp put ..." text would otherwise match the kill patterns in
-			// the same command line and SIGTERM the script itself.
+			// Separate execs: launch's literal "/warp put ..." would otherwise
+			// match the kill patterns in the same command line and SIGTERM the script.
 			if _, err := s.podExec(ctx, pod.Name, killScript); err != nil {
 				if s.podGone(ctx, pod.Name) {
 					log.Warn().Str("pod", pod.Name).Msg("pod terminated mid-start; skipping it")
@@ -281,14 +277,12 @@ func (s *Session) anyLoadRunning(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-// StatusReport is the full picture status renders from.
 type StatusReport struct {
 	Config map[string]string // run metadata; nil when no run is recorded
 	Pods   []PodStatus
 	Nodes  []NodeThroughput
 }
 
-// PodStatus is one runner's process and log state.
 type PodStatus struct {
 	Name, Node           string
 	PutProcs, GetProcs   int
@@ -377,9 +371,9 @@ func (s *Session) Status(ctx context.Context, sampleSeconds int) (*StatusReport,
 	return report, nil
 }
 
-// sampleNode reads /proc/net/dev twice and returns the busiest physical
-// interface's rates. Virtual interfaces (CNI veth/lxc/cilium, loopback,
-// tunnels) are excluded so the number reflects the host NIC / bond.
+// sampleNode reads /proc/net/dev twice, returning the busiest physical
+// interface's rates; virtual ifaces (veth/lxc/cilium, lo, tunnels) excluded so
+// the number reflects the host NIC/bond.
 func (s *Session) sampleNode(ctx context.Context, pod RunnerPod, seconds int) (*NodeThroughput, error) {
 	out, err := s.podExec(ctx, pod.Name,
 		fmt.Sprintf(`cat /proc/net/dev; sleep %d; echo ---SAMPLE---; cat /proc/net/dev`, seconds))

--- a/packages/yuctl/internal/warp/session.go
+++ b/packages/yuctl/internal/warp/session.go
@@ -1,12 +1,9 @@
 // Package warp deploys and drives a MinIO warp S3 load-test fleet on the
-// selected region's K8s cluster, targeting the region's Ceph RGW fleet. All
-// topology (worker nodes, CPU sizing, RGW endpoints) is resolved at runtime
-// from discovery and the live cluster; nothing region-specific is hardcoded.
-//
-// The proven shape (father, 2026-07-22, ~250Gbps combined): hostNetwork runner
-// pods (2 per worker), 16MiB objects, per-pod concurrency 167 PUT / 17 GET,
-// every request round-robined over an explicit RGW IP list — DNS round-robin
-// alone pins one gateway per process.
+// region's K8s cluster against its Ceph RGW fleet; all topology is resolved at
+// runtime from discovery + live cluster, nothing region-specific hardcoded.
+// Proven shape (father, 2026-07-22, ~250Gbps combined): hostNetwork runners
+// (2/worker), 16MiB objects, 167 PUT / 17 GET per pod, requests round-robined
+// over an explicit RGW IP list — DNS round-robin alone pins one gateway per process.
 package warp
 
 import (
@@ -35,7 +32,6 @@ import (
 	"yuctl/internal/state"
 )
 
-// fieldManager identifies this tool's server-side applies.
 const fieldManager = "yuctl-warp"
 
 //go:embed manifests/*.yaml
@@ -48,7 +44,6 @@ var manifestTmpl = template.Must(template.New("").
 	}}).
 	ParseFS(manifestFS, "manifests/*.yaml"))
 
-// renderManifest renders one embedded manifest template to YAML bytes.
 func renderManifest(name string, data any) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := manifestTmpl.ExecuteTemplate(&buf, name, data); err != nil {
@@ -57,7 +52,6 @@ func renderManifest(name string, data any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Session holds the resolved cluster access for one warp command invocation.
 type Session struct {
 	Namespace string
 	K8s       state.Kubernetes
@@ -120,14 +114,13 @@ func (s *Session) podExec(ctx context.Context, pod, script string) (string, erro
 	return out.String(), nil
 }
 
-// Worker is one schedulable (non-control-plane) node.
 type Worker struct {
 	Name     string
 	CPUCores int
 }
 
-// Workers lists the cluster's Ready, schedulable, non-control-plane nodes with
-// their allocatable CPU. This is the fleet the runners spread across.
+// Ready, schedulable, non-control-plane nodes with their allocatable CPU — the
+// fleet the runners spread across.
 func (s *Session) Workers(ctx context.Context) ([]Worker, error) {
 	nodes, err := s.client.CoreV1().Nodes().List(ctx, listAll)
 	if err != nil {
@@ -169,9 +162,9 @@ type S3Target struct {
 	IPs      []string
 }
 
-// ResolveS3 resolves the ceph cluster's RGW endpoint to its full A-record set.
-// The endpoint's DNS is public even where the IPs are fabric-internal, so
-// resolution happens here; reachability is probed from inside the cluster.
+// ResolveS3 resolves the RGW endpoint to its full A-record set. DNS is public
+// even where the IPs are fabric-internal, so resolve here; reachability is
+// probed in-cluster.
 func (s *Session) ResolveS3(ctx context.Context, override string) (*S3Target, error) {
 	endpoint := s.Ceph.RGWS3Endpoint
 	if override != "" {
@@ -201,9 +194,8 @@ func (s *Session) ResolveS3(ctx context.Context, override string) (*S3Target, er
 	return &S3Target{Endpoint: endpoint, Host: u.Hostname(), Port: port, IPs: ips}, nil
 }
 
-// ProbeIPs filters the roster to gateways that accept TCP connects, probed from
-// inside pod (the vantage the load actually runs from). It degrades gracefully:
-// with neither bash nor nc in the image, the unprobed roster is returned.
+// ProbeIPs filters to gateways accepting TCP connects, probed from inside a
+// pod (the load's vantage). Degrades gracefully: no bash/nc in image → unprobed roster.
 func (s *Session) ProbeIPs(ctx context.Context, pod string, t *S3Target) []string {
 	log.Info().Int("endpoints", len(t.IPs)).Str("from", pod).Msg("probing RGW endpoints for liveness")
 	tool, err := s.podExec(ctx, pod,
@@ -250,8 +242,6 @@ func (s *Session) ProbeIPs(ctx context.Context, pod string, t *S3Target) []strin
 	return healthy
 }
 
-// RunnerPods lists the runner pods (Running only), sorted by name, with the
-// node each landed on.
 func (s *Session) RunnerPods(ctx context.Context) ([]RunnerPod, error) {
 	pods, err := s.client.CoreV1().Pods(s.Namespace).List(ctx, listByApp(deploymentName))
 	if err != nil {
@@ -273,7 +263,6 @@ func (s *Session) RunnerPods(ctx context.Context) ([]RunnerPod, error) {
 	return out, nil
 }
 
-// RunnerPod is one running warp runner.
 type RunnerPod struct {
 	Name string
 	Node string

--- a/packages/yuctl/internal/warp/warp_test.go
+++ b/packages/yuctl/internal/warp/warp_test.go
@@ -124,9 +124,8 @@ func TestRenderSecretAndNamespace(t *testing.T) {
 	}
 }
 
-// The kill patterns must never match the `sh -c <killScript>` process itself
-// (its command line contains the pattern text) — a self-match SIGTERMs the
-// exec with code 143. This is why they use the [b]racket trick.
+// Kill patterns must never match the `sh -c <killScript>` process itself (its
+// command line contains the pattern; self-match = exit 143) — hence the [b]racket trick.
 func TestKillScriptNoSelfMatch(t *testing.T) {
 	patterns := regexp.MustCompile(`-f '([^']+)'`).FindAllStringSubmatch(killScript, -1)
 	if len(patterns) != 4 {


### PR DESCRIPTION
Comment-only pass over `packages/michael` and `packages/yuctl`. Comment lines 1,295 -> 979 in the final sweep (\~24% on top of two earlier passes).

**Deleted:** \~170 doc comments restating their exported name (`// Tag is the fleet's provider tag/label.`), all 18 numbered steps in `integration_test.go` (each already spelled out in the adjacent `t.Fatalf`), route comments duplicating the router registration, every section divider, and package docs that only described what the identifiers say.

**Kept:**

- The non-seekable-body retry gotcha in `s3.go` (`RetryMaxAttempts=1`) in full -- it records a production throughput collapse and its RED/GREEN test.
- Fail-closed rationale in `resolveCluster`/`clusterMiddleware`, WORM denial reasons, rightmost-XFF trust in `geoip.ClientAddr`.
- Metric-cardinality constraints, including the Little's Law note (peak resets to current outstanding, not zero).
- restic protocol facts invisible in code: the 16-way hex fanout in `listBlobs`, "REST listing has no pagination".
- yuctl operational safety: SYN-rate-limit/ssh-multiplexing, the transfer-cap auto-stop and tag-listing-is-truth billing guards, discovery-contract semantics, and the proven benchmark shapes with their dates and numbers (father, 2026-07-22, \~250Gbps).
- Trailing decoders (`// unix nanos`, `// \"\" | \"file\" | \"dns\"`) -- units and value domains are not recoverable from the code.

**Verification:** `gofmt -l` clean; `go build ./...` and `go vet ./...` pass in both packages, plus `-tags e2e`, `-tags integration` (michael) and `-tags embedagent` (yuctl). The only non-comment lines in the diff are gofmt struct-field realignment where a removed field comment let alignment groups merge. No `//go:build`, `//go:embed`, `//nolint` or release-please marker appears in the diff.

- `main` <!-- branch-stack -->
  - \#455 :point\_left:
