### PR TITLE
chore(packages): trim narration from comments

### DIFF
--- a/packages/common/src/otel/init.ts
+++ b/packages/common/src/otel/init.ts
@@ -15,12 +15,10 @@ const SpanProcessor = otelEnv.NODE_ENV === 'development' ? tracing.SimpleSpanPro
 const LogProcessor = otelEnv.NODE_ENV === 'development' ? logs.SimpleLogRecordProcessor : logs.BatchLogRecordProcessor;
 
 const otelSDK = new NodeSDK({
-  // Without service.instance.id every replica exports IDENTICAL series; the
-  // TSDB merges them and rate() reads ~1/replicas of the real traffic. The SDK
-  // merges this with its detected resource (service.name via OTEL_SERVICE_NAME).
+  // Without service.instance.id replicas export identical series — the TSDB merges them and rate() reads
+  // ~1/replicas of real traffic. The SDK merges this with its detected resource (service.name via OTEL_SERVICE_NAME).
   resource: resourceFromAttributes({ 'service.instance.id': hostname() }),
 
-  // metrics
   metricReader: new metrics.PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter({
       url: otelEnv.OTEL_METRICS,
@@ -29,7 +27,6 @@ const otelSDK = new NodeSDK({
     exportIntervalMillis: 1000,
   }),
 
-  // tracing
   sampler:
     otelEnv.NODE_ENV === 'development' || otelEnv.OTEL_SAMPLE_RATE == 1
       ? new tracing.AlwaysOnSampler()
@@ -49,7 +46,6 @@ const otelSDK = new NodeSDK({
     }),
   ),
 
-  // logging
   logRecordProcessors: [
     new LogProcessor(
       new OTLPLogExporter({

--- a/packages/common/src/otel/logging.interceptor.ts
+++ b/packages/common/src/otel/logging.interceptor.ts
@@ -22,10 +22,8 @@ export class LoggingInterceptor implements NestInterceptor {
     });
   }
 
-  // Counts every request (log lines are sampled, the counter is not). The
-  // handler label is Controller.method — bounded, unlike the raw path which
-  // embeds resource ids. customerId/repositoryId come from the wide context
-  // when the request authenticated.
+  // Counts every request (log lines are sampled, the counter is not). handler = Controller.method — bounded,
+  // unlike the raw path which embeds resource ids. customerId/repositoryId come from wide context when authenticated.
   private recordRequest(handler: string, method: string, event: Record<string, unknown>) {
     const attributes: Attributes = { handler, method, status: event.status_code as number };
     if (typeof event.customerId === 'string') {

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,40 +1,23 @@
 {
-  // Visit https://aka.ms/tsconfig to read more about this file
   "compilerOptions": {
-    // File Layout
     "rootDir": "./src",
     "outDir": "./dist",
 
-    // Environment Settings
-    // See also https://aka.ms/tsconfig/module
     "module": "commonjs",
     "target": "esnext",
-    // For nodejs:
     "lib": ["esnext"],
     "types": ["node"],
-    // and npm install -D @types/node
 
-    // Other Outputs
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
 
-    // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-
-    // Style Options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
 
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
 
-    // Recommended Options
     "esModuleInterop": true,
     "strict": true,
     "jsx": "react-jsx",

--- a/packages/restic-api/src/utils/s3.ts
+++ b/packages/restic-api/src/utils/s3.ts
@@ -38,13 +38,7 @@ export function attachMeterToS3GetObject(
   };
 }
 
-/**
- * Process S3 object as web response
- *
- * References:
- * http#ServeContent
- * https://pkg.go.dev/net/http#ServeContent
- */
+// Modeled on Go's http#ServeContent: https://pkg.go.dev/net/http#ServeContent
 export function respondWithObject({ stream, object }: S3RemoteObject, request: Request, response: Response) {
   if (request.headers['if-none-match'] === object.ETag) {
     return response.send(HttpStatus.NOT_MODIFIED);

--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -1,23 +1,10 @@
-# web Docker image
-# Built on/for Alpine Linux
-#
-# mise is used as a command runner only
-# node.js & pnpm pinned in image =(
-#   (node.js 26 will remove yarn v1 fixing corepack install)
-#
-# References:
-# ===========
-# https://mise.jdx.dev/mise-cookbook/docker.html
-# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md
-# https://pnpm.io/cli/deploy
+# mise is a command runner only; node.js & pnpm pinned in-image (node 26 removes yarn v1, fixing corepack install).
 
 ARG ALPINE_VERSION=3.23
-# Pinned alpine runtime base. NOTE: this digest is alpine:3.23's, so it must NOT
-# be appended to the node/golang base tags (which reuse ${ALPINE_VERSION}).
+# NOTE: this digest is alpine:3.23's — do NOT append it to the node/golang base tags (they reuse ${ALPINE_VERSION}).
 ARG ALPINE_IMAGE=alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Manifest stage: keep only package.jsons + workspace files so the pnpm-install
-# layer is cached on lockfile/manifest changes only (not every src edit).
+# Manifest stage: only package.jsons + workspace files survive, so the pnpm-install layer caches on manifest changes.
 FROM ${ALPINE_IMAGE} AS manifests
 WORKDIR /src
 COPY . ./
@@ -35,11 +22,9 @@ WORKDIR /app
 RUN apk add --no-cache bash && npm install -g pnpm@10.28.1
 ENV NODE_ENV="development"
 
-# 1. Install deps — cached unless lockfile or any package.json changes
 COPY --from=manifests /src ./
 RUN pnpm install --frozen-lockfile
 
-# 2. Copy sources and pre-build the workspace libs web consumes
 COPY . ./
 # NOTE: filter by published package names (renamed under @futo-org/*); a stale
 # filter silently matches nothing (pnpm exits 0), leaving web's SSR deps unbuilt.

--- a/packages/web/playwright.k3d.config.ts
+++ b/packages/web/playwright.k3d.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
-// Web e2e against the LOCAL k3d stack (web port-forwarded to :36033). Unlike the
-// default config there is no webServer block — web is already served by the
-// cluster. host-resolver-rules lets the browser reach the in-cluster OIDC issuer
-// host (yucca-mock-oidc) via the kubectl port-forward on localhost. Driven by
+// Web e2e against the LOCAL k3d stack (web port-forwarded to :36033), so no webServer block. host-resolver-rules
+// maps the in-cluster OIDC issuer host (yucca-mock-oidc) to the kubectl port-forward on localhost. Driven by
 // packages/e2e/k3d/run.sh (mise test:e2e:k3d).
 export default defineConfig({
   testDir: 'e2e',

--- a/packages/web/src/app.d.ts
+++ b/packages/web/src/app.d.ts
@@ -1,14 +1,6 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
 declare global {
-  namespace App {
-    // interface Error {}
-    // interface Locals {}
-    // interface PageData {}
-    // interface PageState {}
-    // interface Platform {}
-  }
+  namespace App {}
 }
 
-// eslint-disable-next-line
+// eslint-disable-next-line unicorn/require-module-specifiers
 export {};

--- a/packages/web/src/lib/index.ts
+++ b/packages/web/src/lib/index.ts
@@ -1,2 +1,1 @@
-// place files you want to import through the `$lib` alias in this folder.
-// eslint-disable-next-line
+// eslint-disable-next-line unicorn/no-empty-file

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -3,14 +3,9 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  // Consult https://svelte.dev/docs/kit/integrations
-  // for more information about preprocessors
   preprocess: vitePreprocess(),
 
   kit: {
-    // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-    // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-    // See https://svelte.dev/docs/kit/adapters for more information about adapters.
     adapter: adapter(),
   },
 };

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -13,9 +13,4 @@
     "moduleResolution": "bundler",
     "noImplicitAny": true
   }
-  // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
-  // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
-  //
-  // To make changes to top-level options such as include and exclude, we recommend extending
-  // the generated config; see https://svelte.dev/docs/kit/configuration#typescript
 }

--- a/packages/yucca-admin-api/Dockerfile
+++ b/packages/yucca-admin-api/Dockerfile
@@ -1,24 +1,10 @@
-# yucca-admin-api Docker image
-# Built on/for Alpine Linux
-#
-# mise is used as a command runner only
-# node.js & pnpm pinned in image =(
-#   (node.js 26 will remove yarn v1 fixing corepack install)
-#
-# References:
-# ===========
-# https://docs.nestjs.com/deployment
-# https://mise.jdx.dev/mise-cookbook/docker.html
-# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md
-# https://pnpm.io/cli/deploy
+# mise is a command runner only; node.js & pnpm pinned in-image (node 26 removes yarn v1, fixing corepack install).
 
 ARG ALPINE_VERSION=3.23
-# Pinned alpine runtime base. NOTE: this digest is alpine:3.23's, so it must NOT
-# be appended to the node/golang base tags (which reuse ${ALPINE_VERSION}).
+# NOTE: this digest is alpine:3.23's — do NOT append it to the node/golang base tags (they reuse ${ALPINE_VERSION}).
 ARG ALPINE_IMAGE=alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Manifest stage: strips everything except package.jsons + workspace files so
-# the pnpm-install layer below is cached on lockfile/manifest changes only.
+# Manifest stage: only package.jsons + workspace files survive, so the pnpm-install layer caches on manifest changes.
 FROM ${ALPINE_IMAGE} AS manifests
 WORKDIR /src
 COPY . ./
@@ -36,11 +22,9 @@ WORKDIR /app
 RUN apk add --no-cache bash && npm install -g pnpm@10.28.1
 ENV NODE_ENV="development"
 
-# 1. Install deps — cached unless lockfile or any package.json changes
 COPY --from=manifests /src ./
 RUN pnpm install --frozen-lockfile
 
-# 2. Copy sources, build workspace libs yucca-admin-api imports at runtime
 COPY . ./
 RUN pnpm --filter @common/server build
 

--- a/packages/yucca-admin-api/src/app.module.ts
+++ b/packages/yucca-admin-api/src/app.module.ts
@@ -39,8 +39,7 @@ export const imports = [
   JwtModule.register({
     global: true,
     privateKey: env.JWT_PRIVATE_KEY,
-    // Verification key derived from the signing key: CLI session JWTs are
-    // minted and validated by this same service.
+    // Verification key derived from the signing key: CLI session JWTs are minted and validated by this service.
     publicKey: createPublicKey(env.JWT_PRIVATE_KEY).export({ type: 'spki', format: 'pem' }).toString(),
     signOptions: { algorithm: 'ES256', expiresIn: env.JWT_EXPIRES_IN },
     verifyOptions: { algorithms: ['ES256'] },

--- a/packages/yucca-admin-api/src/controllers/auth.controller.ts
+++ b/packages/yucca-admin-api/src/controllers/auth.controller.ts
@@ -44,11 +44,9 @@ export class AuthController {
     response.redirect(redirectTo);
   }
 
-  // Loopback login for yuctl: the CLI opens this in a browser with its
-  // listener port, a state nonce, and an S256 code challenge; the normal OIDC
-  // dance runs, and the callback redirects to 127.0.0.1:<port> with a one-time
-  // code the CLI exchanges at /auth/cli/token. The CLI params ride along in
-  // their own short-lived cookie, mirroring how state/verifier already travel.
+  // yuctl loopback login: CLI opens this with listener port, state nonce, S256 code challenge; the OIDC callback
+  // redirects to 127.0.0.1:<port> with a one-time code exchanged at /auth/cli/token. CLI params ride their own
+  // short-lived cookie, like state/verifier.
   @Get('/cli/login')
   @ApiQuery({ name: 'port', type: Number })
   @ApiQuery({ name: 'state', type: String })
@@ -101,12 +99,10 @@ export class AuthController {
       maxAge: Duration.fromObject({ days: 7 }).toMillis(),
     });
 
-    // CLI loopback flow: hand the browser back to the local yuctl listener
-    // with a one-time code instead of the admin UI.
+    // CLI loopback flow: redirect to the local yuctl listener with a one-time code instead of the admin UI.
     const cliCookie = parse(request.headers.cookie ?? '')[CookieName.CliLogin];
     if (cliCookie) {
-      // Re-validate: the cookie is client-controlled, and the values are
-      // interpolated into the loopback redirect.
+      // Re-validate: the cookie is client-controlled and its values are interpolated into the loopback redirect.
       const raw = JSON.parse(cliCookie) as CliLoginParams;
       const { port, state, codeChallenge } = this.auth.parseCliLoginParams(
         String(raw.port),

--- a/packages/yucca-admin-api/src/controllers/settings.controller.ts
+++ b/packages/yucca-admin-api/src/controllers/settings.controller.ts
@@ -15,9 +15,8 @@ export class SettingsController {
     return this.settings.list();
   }
 
-  // The body is deliberately taken raw (not a validated DTO): the service
-  // validates against the strict settings registry so unknown keys are
-  // rejected instead of silently stripped by the whitelist pipe.
+  // Body deliberately raw (not a validated DTO): the service validates against the strict settings registry, so
+  // unknown keys are rejected instead of silently stripped by the whitelist pipe.
   @Put('/:scope')
   @AuthRoute()
   @ApiBody({ type: SettingsValueDto })

--- a/packages/yucca-admin-api/src/env.ts
+++ b/packages/yucca-admin-api/src/env.ts
@@ -20,9 +20,8 @@ const schema = z.object({
     .default('24h')
     .transform((value): StringValue => value as StringValue),
 
-  // Restic repository tokens (POST /repository/:id/url): signed with
-  // yucca-api's key so michael accepts them. Optional — the endpoint returns
-  // 501 until configured.
+  // Restic repository tokens (POST /repository/:id/url), signed with yucca-api's key so michael accepts them.
+  // Optional — the endpoint returns 501 until configured.
   RESTIC_JWT_PRIVATE_KEY: z.string().optional(),
   RESTIC_JWT_EXPIRES_IN: z
     .string()

--- a/packages/yucca-admin-api/src/services/allowlist.service.ts
+++ b/packages/yucca-admin-api/src/services/allowlist.service.ts
@@ -72,8 +72,7 @@ export class AllowlistService {
     try {
       return await this.allowlist.create({ email, inviteCode: generateInviteCode(), invited });
     } catch (error) {
-      // A generated code colliding with an existing one is astronomically
-      // unlikely (~50 bits) — retry once, then let the error propagate.
+      // Code collision is astronomically unlikely (~50 bits) — retry once, then propagate.
       if (isUniqueViolation(error)) {
         return await this.allowlist.create({ email, inviteCode: generateInviteCode(), invited });
       }

--- a/packages/yucca-admin-api/src/services/auth.service.spec.ts
+++ b/packages/yucca-admin-api/src/services/auth.service.spec.ts
@@ -4,8 +4,7 @@ import { env } from 'src/env';
 import { Mocks, newMocks } from '../../test/mocks';
 import { AuthService } from './auth.service';
 
-// Real JwtService over the local-dev keypair: the CLI-flow tests exercise
-// actual ES256 mint/verify rather than mocked crypto.
+// Real JwtService over the local-dev keypair: CLI-flow tests exercise actual ES256 mint/verify, not mocked crypto.
 const newJwtService = () =>
   new JwtService({
     privateKey: env.JWT_PRIVATE_KEY,

--- a/packages/yucca-admin-api/src/services/auth.service.ts
+++ b/packages/yucca-admin-api/src/services/auth.service.ts
@@ -10,16 +10,14 @@ import { CookieName, JwtAudience } from 'src/enum';
 import { env } from 'src/env';
 import { OidcRepository } from 'src/repositories/oidc.repository';
 
-// Loopback-flow parameters set by the CLI on /auth/cli/login, carried through
-// the OIDC dance in the CliLogin cookie.
+// Loopback-flow params set by the CLI on /auth/cli/login, carried through the OIDC dance in the CliLogin cookie.
 export interface CliLoginParams {
   port: number;
   state: string;
   codeChallenge: string;
 }
 
-// state / code_challenge are CLI-generated random strings; constrain them to
-// URL-safe base64 so they can be echoed into the loopback redirect untouched.
+// CLI-generated state/code_challenge: constrain to URL-safe base64 so they can be echoed into the redirect untouched.
 const URL_SAFE = /^[\w-]{16,128}$/;
 
 @Injectable()
@@ -122,7 +120,6 @@ export class AuthService {
     return { sub: payload.sub };
   }
 
-  // Validates the loopback-flow query params of GET /auth/cli/login.
   parseCliLoginParams(port?: string, state?: string, codeChallenge?: string): CliLoginParams {
     const portNum = Number(port);
     if (!Number.isInteger(portNum) || portNum < 1024 || portNum > 65_535) {
@@ -137,10 +134,9 @@ export class AuthService {
     return { port: portNum, state, codeChallenge };
   }
 
-  // Mints the one-time code delivered to the CLI's loopback listener: a
-  // short-lived JWT binding the authenticated sub to the CLI's code_challenge.
-  // One-time use is enforced by PKCE semantics rather than server state — the
-  // code alone is useless without the verifier, which never leaves the CLI.
+  // One-time code for the CLI's loopback listener: short-lived JWT binding sub to the CLI's code_challenge. Single
+  // use is enforced by PKCE semantics, not server state — the code is useless without the verifier, which never
+  // leaves the CLI.
   async mintCliCode(sub: string, codeChallenge: string): Promise<string> {
     return await this.jwt.signAsync({ sub, cnf: codeChallenge }, { audience: JwtAudience.CliCode, expiresIn: '60s' });
   }

--- a/packages/yucca-admin-api/src/services/repository.service.spec.ts
+++ b/packages/yucca-admin-api/src/services/repository.service.spec.ts
@@ -103,8 +103,7 @@ describe(RepositoryService.name, () => {
   });
 
   describe('url', () => {
-    // The parsed env may carry dev RESTIC_* values (mise env); pin both
-    // states explicitly so the tests are environment-independent.
+    // The parsed env may carry dev RESTIC_* values (mise env); pin both states so tests are environment-independent.
     type ResticEnv = { RESTIC_JWT_PRIVATE_KEY?: string };
     const restic = env as ResticEnv;
     let saved: ResticEnv;

--- a/packages/yucca-admin-api/src/utils/openapi.ts
+++ b/packages/yucca-admin-api/src/utils/openapi.ts
@@ -26,7 +26,6 @@ export const useSwagger = (app: INestApplication, { write }: { write: boolean })
   SwaggerModule.setup('doc', app, specification, customOptions);
 
   if (write) {
-    // Generate API Documentation only in development mode
     const outputPath = resolve(process.cwd(), 'openapi-specs.json');
     writeFileSync(outputPath, JSON.stringify(specification, null, 2), { encoding: 'utf8' });
   }

--- a/packages/yucca-admin-api/test/auth.integration-spec.ts
+++ b/packages/yucca-admin-api/test/auth.integration-spec.ts
@@ -182,7 +182,6 @@ describe('AuthController (e2e)', () => {
       );
       const code = loopback.searchParams.get('code')!;
 
-      // Wrong verifier is rejected; the right one yields a Bearer session.
       await request(app.getHttpServer())
         .post('/api/auth/cli/token')
         .send({ code, codeVerifier: 'wrong-verifier' })

--- a/packages/yucca-api/Dockerfile
+++ b/packages/yucca-api/Dockerfile
@@ -1,24 +1,10 @@
-# yucca-api Docker image
-# Built on/for Alpine Linux
-#
-# mise is used as a command runner only
-# node.js & pnpm pinned in image =(
-#   (node.js 26 will remove yarn v1 fixing corepack install)
-#
-# References:
-# ===========
-# https://docs.nestjs.com/deployment
-# https://mise.jdx.dev/mise-cookbook/docker.html
-# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md
-# https://pnpm.io/cli/deploy
+# mise is a command runner only; node.js & pnpm pinned in-image (node 26 removes yarn v1, fixing corepack install).
 
 ARG ALPINE_VERSION=3.23
-# Pinned alpine runtime base. NOTE: this digest is alpine:3.23's, so it must NOT
-# be appended to the node/golang base tags (which reuse ${ALPINE_VERSION}).
+# NOTE: this digest is alpine:3.23's — do NOT append it to the node/golang base tags (they reuse ${ALPINE_VERSION}).
 ARG ALPINE_IMAGE=alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Manifest stage: strips everything except package.jsons + workspace files so
-# the pnpm-install layer below is cached on lockfile/manifest changes only.
+# Manifest stage: only package.jsons + workspace files survive, so the pnpm-install layer caches on manifest changes.
 FROM ${ALPINE_IMAGE} AS manifests
 WORKDIR /src
 COPY . ./
@@ -36,11 +22,9 @@ WORKDIR /app
 RUN apk add --no-cache bash && npm install -g pnpm@10.28.1
 ENV NODE_ENV="development"
 
-# 1. Install deps — cached unless lockfile or any package.json changes
 COPY --from=manifests /src ./
 RUN pnpm install --frozen-lockfile
 
-# 2. Copy sources, build workspace libs yucca-api imports at runtime
 COPY . ./
 RUN pnpm --filter @common/server build
 

--- a/packages/yucca-api/src/schema/migrations/20260729120000-AddSettingsAndSiteColumns.ts
+++ b/packages/yucca-api/src/schema/migrations/20260729120000-AddSettingsAndSiteColumns.ts
@@ -36,9 +36,8 @@ export async function up(db: Kysely<any>): Promise<void> {
     FROM "repositories" AS repository
     WHERE meter."repositoryId" = repository.id AND meter."storageClusterCode" IS NULL;`.execute(db);
 
-  // Defaults keep old application replicas safe during a rolling deployment:
-  // pre-topology inserts omit these columns, but can no longer create NULL
-  // placement after the backfill.
+  // Defaults keep old replicas safe during rolling deploy: pre-topology inserts omit these columns yet can no
+  // longer create NULL placement after the backfill.
   await sql`ALTER TABLE "repositories"
     ALTER COLUMN "siteCode" SET DEFAULT ${sql.lit(siteCode)},
     ALTER COLUMN "siteCode" SET NOT NULL,

--- a/packages/yucca-api/src/utils/connectionsMath.ts
+++ b/packages/yucca-api/src/utils/connectionsMath.ts
@@ -2,8 +2,7 @@
 //   expr   := term (('+' | '-') term)*
 //   term   := factor (('*' | '/') factor)*
 //   factor := integer | 'cores' | ('min' | 'max') '(' expr ',' expr ')' | '(' expr ')'
-// Clients substitute their local CPU count for `cores` and fall back to a
-// default when an expression fails to parse.
+// Clients substitute their local CPU count for `cores`; on parse failure they fall back to a default.
 
 type Token = { kind: 'number'; value: number } | { kind: 'ident'; value: string } | { kind: 'symbol'; value: string };
 

--- a/packages/yucca-api/src/utils/openapi.ts
+++ b/packages/yucca-api/src/utils/openapi.ts
@@ -26,7 +26,6 @@ export const useSwagger = (app: INestApplication, { write }: { write: boolean })
   SwaggerModule.setup('doc', app, specification, customOptions);
 
   if (write) {
-    // Generate API Documentation only in development mode
     const outputPath = resolve(process.cwd(), '../yucca-api-client/openapi-specs.json');
     writeFileSync(outputPath, JSON.stringify(specification, null, 2), { encoding: 'utf8' });
   }

--- a/packages/yucca-metrics-worker/Dockerfile
+++ b/packages/yucca-metrics-worker/Dockerfile
@@ -1,24 +1,10 @@
-# yucca-metrics-worker Docker image
-# Built on/for Alpine Linux
-#
-# mise is used as a command runner only
-# node.js & pnpm pinned in image =(
-#   (node.js 26 will remove yarn v1 fixing corepack install)
-#
-# References:
-# ===========
-# https://docs.nestjs.com/deployment
-# https://mise.jdx.dev/mise-cookbook/docker.html
-# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md
-# https://pnpm.io/cli/deploy
+# mise is a command runner only; node.js & pnpm pinned in-image (node 26 removes yarn v1, fixing corepack install).
 
 ARG ALPINE_VERSION=3.23
-# Pinned alpine runtime base. NOTE: this digest is alpine:3.23's, so it must NOT
-# be appended to the node/golang base tags (which reuse ${ALPINE_VERSION}).
+# NOTE: this digest is alpine:3.23's — do NOT append it to the node/golang base tags (they reuse ${ALPINE_VERSION}).
 ARG ALPINE_IMAGE=alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Manifest stage: strips everything except package.jsons + workspace files so
-# the pnpm-install layer below is cached on lockfile/manifest changes only.
+# Manifest stage: only package.jsons + workspace files survive, so the pnpm-install layer caches on manifest changes.
 FROM ${ALPINE_IMAGE} AS manifests
 WORKDIR /src
 COPY . ./
@@ -36,11 +22,9 @@ WORKDIR /app
 RUN apk add --no-cache bash && npm install -g pnpm@10.28.1
 ENV NODE_ENV="development"
 
-# 1. Install deps — cached unless lockfile or any package.json changes
 COPY --from=manifests /src ./
 RUN pnpm install --frozen-lockfile
 
-# 2. Copy sources, build workspace libs yucca-metrics-worker imports at runtime
 COPY . ./
 RUN pnpm --filter @common/server build
 

--- a/packages/yucca-metrics-worker/src/repositories/rgw.repository.ts
+++ b/packages/yucca-metrics-worker/src/repositories/rgw.repository.ts
@@ -36,10 +36,8 @@ export class RgwRepository {
   }
 
   async *getBucketStatsStream(pageSize = 1000): AsyncGenerator<BucketStats> {
-    // Some RGW versions ignore max-entries/marker on /admin/bucket (observed on
-    // v19.2.2, which returns the full listing on every page), so terminating on
-    // entries.length < pageSize alone would loop forever. Dedupe by bucket and
-    // stop as soon as a page yields nothing new.
+    // Some RGW versions ignore max-entries/marker on /admin/bucket (v19.2.2 returns the full listing every page),
+    // so entries.length < pageSize alone would loop forever. Dedupe by bucket; stop when a page yields nothing new.
     const seen = new Set<string>();
     let marker = '';
 

--- a/packages/yucca-sdk/orchestration-api/src/schema/tables/backend.table.ts
+++ b/packages/yucca-sdk/orchestration-api/src/schema/tables/backend.table.ts
@@ -3,33 +3,18 @@ import { BackendType } from '../../enum';
 
 export type BackendConfiguration =
   | {
-      /**
-       * Yucca backup backend
-       *
-       * * Discovers repositories by API
-       * * Repository ID used in API
-       */
+      /** Yucca backup backend — discovers repositories by API; repository ID is the API id. */
       type: BackendType.Yucca;
       url?: string;
       accessToken: string;
     }
   | {
-      /**
-       * Local backup backend
-       *
-       * * Discovers repositories by folder listing
-       * * Repository ID corresponds to `${path}/${id}`
-       */
+      /** Local backup backend — discovers repositories by folder listing; repository ID is `${path}/${id}`. */
       type: BackendType.Local;
       path: string;
     }
   | {
-      /**
-       * S3 backup backend
-       *
-       * * Discovers repositories by ListBuckets
-       * * Repository ID corresponds to bucket ID
-       */
+      /** S3 backup backend — discovers repositories by ListBuckets; repository ID is the bucket ID. */
       type: BackendType.S3;
       endpoint: string;
       region: string;

--- a/packages/yucca-sdk/orchestration-api/src/utils/connectionsMath.ts
+++ b/packages/yucca-sdk/orchestration-api/src/utils/connectionsMath.ts
@@ -2,8 +2,7 @@
 //   expr   := term (('+' | '-') term)*
 //   term   := factor (('*' | '/') factor)*
 //   factor := integer | 'cores' | ('min' | 'max') '(' expr ',' expr ')' | '(' expr ')'
-// Clients substitute their local CPU count for `cores` and fall back to a
-// default when an expression fails to parse.
+// Clients substitute their local CPU count for `cores`; on parse failure they fall back to a default.
 
 type Token = { kind: 'number'; value: number } | { kind: 'ident'; value: string } | { kind: 'symbol'; value: string };
 

--- a/packages/yucca-sdk/orchestration-api/src/wellKnown.ts
+++ b/packages/yucca-sdk/orchestration-api/src/wellKnown.ts
@@ -114,8 +114,7 @@ export class YuccaWellKnown {
     }
   }
 
-  // The api-client's operation paths already carry the /api prefix, so the
-  // request base is api_root without it.
+  // The api-client's operation paths already carry the /api prefix, so the request base is api_root without it.
   async getBaseUrl(): Promise<string> {
     const meta = await this.get();
     return meta.api_root.replace(/\/api\/?$/, '');

--- a/packages/yucca-sdk/orchestration-api/test/telemetry.integration-spec.ts
+++ b/packages/yucca-sdk/orchestration-api/test/telemetry.integration-spec.ts
@@ -23,8 +23,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   jest.clearAllMocks();
-  // Without this the backend resolves its base URL by fetching the real
-  // production .well-known over the network.
+  // Without this the backend resolves its base URL by fetching the real production .well-known over the network.
   jest.spyOn(yuccaWellKnown, 'getBaseUrl').mockResolvedValue('http://yucca.test');
   ctx.database.prepare("DELETE FROM config WHERE key = 'telemetry'").run();
   await ctx.module.get(BackendRepository).updateBackend(REPOSITORY_DEFAULT_CLOUD_UUID, {

--- a/packages/yucca-sdk/orchestration-api/test/wellKnown.integration-spec.ts
+++ b/packages/yucca-sdk/orchestration-api/test/wellKnown.integration-spec.ts
@@ -100,7 +100,7 @@ describe(YuccaWellKnown.name, () => {
   it('serves stale data when a refresh fails', async () => {
     await sut.getBaseUrl();
 
-    sut['fetchedAt'] = 0; // expire the cache
+    sut['fetchedAt'] = 0;
     fetchMock.mockRejectedValue(new Error('offline'));
 
     await expect(sut.getBaseUrl()).resolves.toBe('https://backups.futo.cloud');

--- a/packages/yucca-sdk/orchestration-ui/src/app.d.ts
+++ b/packages/yucca-sdk/orchestration-ui/src/app.d.ts
@@ -1,13 +1,5 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
 declare global {
-  namespace App {
-    // interface Error {}
-    // interface Locals {}
-    // interface PageData {}
-    // interface PageState {}
-    // interface Platform {}
-  }
+  namespace App {}
 }
 
 // eslint-disable-next-line unicorn/require-module-specifiers

--- a/packages/yucca-sdk/orchestration-ui/src/lib/services/log.service.svelte.ts
+++ b/packages/yucca-sdk/orchestration-ui/src/lib/services/log.service.svelte.ts
@@ -4,7 +4,6 @@ import debounce from 'lodash.debounce';
 
 type SummaryEvent = {
   message_type: 'summary';
-  // backup
   files_new?: number;
   files_changed?: number;
   files_unmodified?: number;
@@ -13,7 +12,6 @@ type SummaryEvent = {
   total_bytes_processed?: number;
   total_duration?: number;
   snapshot_id?: string;
-  // restore
   files_restored?: number;
   files_skipped?: number;
   files_deleted?: number;

--- a/packages/yucca-sdk/orchestration-ui/svelte.config.js
+++ b/packages/yucca-sdk/orchestration-ui/svelte.config.js
@@ -3,9 +3,6 @@ import adapter from '@sveltejs/adapter-auto';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-    // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-    // See https://svelte.dev/docs/kit/adapters for more information about adapters.
     adapter: adapter(),
   },
 };


### PR DESCRIPTION
Comment-only pass over the TypeScript/Node packages (`common`, `restic-api`, `web`, `yucca-api`, `yucca-admin-api`, `yucca-metrics-worker`, `yucca-sdk`). Generated files (`fetch-client.ts`, `web/src/locales`, `openapi-specs.json`) untouched.

**Deleted:** stock scaffolding (`tsc --init` option blocks, SvelteKit `app.d.ts` placeholder stubs, adapter-auto advice, the `$lib` placeholder note), Dockerfile headers restating the filename plus their numbered step comments, and doc comments restating a method signature.

**Kept:** PKCE one-time-use and cookie re-validation rationale, the non-PKCE `state` fallback, Crockford base32 and allowlist collision-retry math, the RGW v19.2.2 pagination gotcha, the TSDB `service.instance.id` merge and metric-cardinality notes, the k3d `host-resolver-rules` gotcha, corepack/node-26-yarn-v1 and alpine-digest Dockerfile notes, the rolling-deployment migration rationale, the `connections_math` grammar spec, and the backend-enum discovery JSDoc.

**Two side effects worth a look:**

1. Prettier collapses the now-empty `namespace App {}` in both `app.d.ts` files (whitespace only).
2. Two bare `// eslint-disable-next-line` directives were passing `unicorn/no-abusive-eslint-disable` only by accident -- the rule returns on the first non-disable comment, so the deleted scaffold comments were shielding them. They are now explicit (`unicorn/require-module-specifiers`, `unicorn/no-empty-file`), matching the sibling file byte-for-byte and preserving exactly the suppressions they performed.

**Verification:** eslint and prettier pass on all edited files; both tsconfigs parse as JSON; rewritten lines stay under the 120-column Prettier width.

- `main` <!-- branch-stack -->
  - \#456 :point\_left:
