### PR TITLE
feat(o11y): pin dashboards to Fleet datasource and conform telemetry labels

### DIFF
--- a/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
@@ -49,9 +49,9 @@ spec:
         - kubernetes.pod_namespace
         - kubernetes.container_name
         - kubernetes.pod_labels.app.kubernetes.io/name
-      # Stamp the remote-cluster identity on every log line (cluster/site/env/
-      # project, same tags as the metrics pipeline).
-      extraFields: '{"cluster":"${METRICS_CLUSTER_LABEL}","site":"${METRICS_SITE_LABEL}","env":"${METRICS_ENV_LABEL}","project":"yucca"}'
+      # Stamp the remote-cluster identity on every log line (same five tags
+      # as the metrics pipeline: project/env/cluster/provider/region).
+      extraFields: '{"project":"yucca","env":"${METRICS_ENV_LABEL}","cluster":"${METRICS_CLUSTER_LABEL}","provider":"${METRICS_PROVIDER_LABEL}","region":"${METRICS_REGION_LABEL}"}'
 
     # All staging nodes are control-plane; tolerate the taint so the DaemonSet
     # lands everywhere.

--- a/kubernetes/apps/base/vmagent/helmrelease.yaml
+++ b/kubernetes/apps/base/vmagent/helmrelease.yaml
@@ -129,15 +129,18 @@ spec:
       enabled: true
       spec:
         # Stamp the remote-cluster identity on EVERY series: cluster (short
-        # cluster name), site, env, project. Relabel (not externalLabels):
+        # cluster name), env, project, provider, region — the identity set from
+        # o11y's shipping guide. Relabel (not externalLabels):
         # externalLabels only tags scraped data, leaving OTLP-pushed app
         # metrics untagged. This applies to all data (scraped + ingested)
         # before remote-write.
         inlineRelabelConfig:
           - target_label: cluster
             replacement: ${METRICS_CLUSTER_LABEL}
-          - target_label: site
-            replacement: ${METRICS_SITE_LABEL}
+          - target_label: provider
+            replacement: ${METRICS_PROVIDER_LABEL}
+          - target_label: region
+            replacement: ${METRICS_REGION_LABEL}
           - target_label: env
             replacement: ${METRICS_ENV_LABEL}
           - target_label: project

--- a/kubernetes/apps/prod/htz-fsn1/netops/vmagent.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/vmagent.yaml
@@ -39,7 +39,7 @@ data:
   scrape.yml: |
     global:
       scrape_interval: 10s
-      # Site/env/project identity tags. `cluster` is deliberately NOT here:
+      # Env/project/provider/region identity tags. `cluster` is deliberately NOT here:
       # vmagent applies external_labels OVER target labels (unlike
       # Prometheus's fill-gaps semantics — it relabeled all 48 spice targets
       # to cluster=netops), so each job stamps its own cluster label instead.

--- a/kubernetes/apps/prod/htz-fsn1/netops/vmagent.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/netops/vmagent.yaml
@@ -44,9 +44,10 @@ data:
       # Prometheus's fill-gaps semantics — it relabeled all 48 spice targets
       # to cluster=netops), so each job stamps its own cluster label instead.
       external_labels:
-        site: htz-fsn1
         env: prod
         project: yucca
+        provider: hetzner
+        region: fsn
     scrape_configs:
       # The fabric switches (spine + cls1 leaf) via junos_exporter. The exporter
       # polls the switches synchronously per scrape and burns ~20s/device in its

--- a/kubernetes/clusters/prod/htz-fsn1/cluster-settings.generated.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/cluster-settings.generated.yaml
@@ -11,10 +11,12 @@ data:
   # Cluster identity (derived: yucca_<partition>_<region>).
   CLUSTER_NAME: yucca_prod_htz_fsn1
   CLUSTER_ROLE: primary
-  # Telemetry identity tags (cluster = short cluster name; site; env). The
+  # Telemetry identity tags (cluster = short cluster name; env; provider and
+  # region = 3-letter codes from region.hcl, except provider spelled out). The
   # netops vmagent stamps its own set (cluster=netops, spice jobs cluster=spice).
   METRICS_CLUSTER_LABEL: father
-  METRICS_SITE_LABEL: htz-fsn1
+  METRICS_PROVIDER_LABEL: hetzner
+  METRICS_REGION_LABEL: fsn
   METRICS_ENV_LABEL: prod
   # CP node IPs (kube-cp VLAN 11; clusters.auto.tfvars) — the vmagent's
   # kubeEtcd static targets, hitting the plain-HTTP etcd metrics listener the

--- a/kubernetes/clusters/staging/austin/cluster-settings.generated.yaml
+++ b/kubernetes/clusters/staging/austin/cluster-settings.generated.yaml
@@ -18,10 +18,11 @@ data:
   # mirrored compile-time by the components/roles/<role> the overlay composes).
   CLUSTER_ROLE: primary
   # Telemetry identity tags stamped on everything the agents ship (cluster =
-  # short cluster name; site; env). NB: values changed from the old single
-  # yucca_staging_austin label — o11y queries keyed on it need updating.
+  # short cluster name; env; provider and region = 3-letter codes from
+  # region.hcl).
   METRICS_CLUSTER_LABEL: luke
-  METRICS_SITE_LABEL: austin
+  METRICS_PROVIDER_LABEL: int
+  METRICS_REGION_LABEL: aus
   METRICS_ENV_LABEL: staging
   # CP node IPs (clusters.auto.tfvars) — the vmagent's kubeEtcd static targets,
   # hitting the plain-HTTP etcd metrics listener the machine config opens

--- a/o11y/dashboards/yucca-fabric-htz-fsn1.json
+++ b/o11y/dashboards/yucca-fabric-htz-fsn1.json
@@ -683,15 +683,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       }
     ]

--- a/o11y/dashboards/yucca-father-kubernetes.json
+++ b/o11y/dashboards/yucca-father-kubernetes.json
@@ -876,15 +876,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {

--- a/o11y/dashboards/yucca-michael.json
+++ b/o11y/dashboards/yucca-michael.json
@@ -2716,15 +2716,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {

--- a/o11y/dashboards/yucca-overview.json
+++ b/o11y/dashboards/yucca-overview.json
@@ -943,15 +943,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       }
     ]

--- a/o11y/dashboards/yucca-per-user.json
+++ b/o11y/dashboards/yucca-per-user.json
@@ -1836,15 +1836,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {

--- a/o11y/dashboards/yucca-spice-blockdb-bluefs.json
+++ b/o11y/dashboards/yucca-spice-blockdb-bluefs.json
@@ -27,9 +27,12 @@
         "label": "Data Source",
         "refresh": 1,
         "hide": 0,
-        "current": {},
+        "current": {
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "skipUrlSync": false
       },
       {

--- a/o11y/dashboards/yucca-spice-ceph-health.json
+++ b/o11y/dashboards/yucca-spice-ceph-health.json
@@ -1126,15 +1126,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {

--- a/o11y/dashboards/yucca-spice-nodes.json
+++ b/o11y/dashboards/yucca-spice-nodes.json
@@ -1068,15 +1068,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {

--- a/o11y/dashboards/yucca-spice-recovery-backfill.json
+++ b/o11y/dashboards/yucca-spice-recovery-backfill.json
@@ -869,10 +869,13 @@
         "label": "datasource",
         "type": "datasource",
         "query": "prometheus",
-        "current": {},
+        "current": {
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "hide": 0,
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "skipUrlSync": false
       },
       {

--- a/o11y/dashboards/yucca-spice-rgw-capacity.json
+++ b/o11y/dashboards/yucca-spice-rgw-capacity.json
@@ -2752,15 +2752,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {

--- a/o11y/dashboards/yucca-telemetry-pipeline.json
+++ b/o11y/dashboards/yucca-telemetry-pipeline.json
@@ -702,15 +702,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       }
     ]

--- a/o11y/dashboards/yucca-top-users.json
+++ b/o11y/dashboards/yucca-top-users.json
@@ -1245,15 +1245,15 @@
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
         },
         "label": "Data source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "type": "datasource"
       },
       {


### PR DESCRIPTION
Pins all 12 dashboards to the new VictoriaMetrics Fleet datasource (immich-app/yucca-o11y#195), ahead of o11y scoping its default datasource to its own cluster. No visible change until that flip lands.

Also replaces the site label with provider and region, completing the five-label identity set from o11y's shipping guide: father ships provider=hetzner region=fsn, luke ships provider=int region=aus. Nothing queries site. The label change re-keys shipped series, which costs one retention window of duplicate index on the o11y stores and affects no alerts.

- `main` <!-- branch-stack -->
  - \#461 :point\_left:
