### PR TITLE
feat(ceph): rebuild a replaced OSD onto its intended db slot

### DIFF
--- a/ansible/ceph/docs/runbooks/host-maintenance.md
+++ b/ansible/ceph/docs/runbooks/host-maintenance.md
@@ -1,0 +1,254 @@
+# Runbook: Take a Host Offline for Physical Maintenance
+
+**When:** A node must be powered off or rebooted for longer than a few minutes.
+Hetzner disk replacement, DIMM or NIC swap, chassis work, anything where remote
+hands need the machine down.
+
+**Time estimate:** 2 minutes to enter, 2 minutes to exit. The offline window is
+whatever the physical work takes.
+
+**Prerequisites:**
+- Cluster is not already degraded from something else
+- No backfill in flight that you care about finishing first
+- The host carries no MON you cannot afford to lose (see step 1)
+
+> This runbook is cluster-agnostic, but the worked numbers are spice. Resolve
+> `<host>` and the admin CLI for your cluster from
+> [cluster-profiles.md](../cluster-profiles.md).
+
+---
+
+## Use maintenance mode, not the cluster-wide flags
+
+`ceph orch host maintenance enter` is the supported path and it does three
+things that hand-set flags do not:
+
+1. Runs `ok-to-stop` against **every** daemon type on the host, not just OSDs
+2. Stops **and disables** the `ceph-<fsid>.target` systemd unit, so a power-on
+   does not bring daemons back before you are ready
+3. Applies `noout` to the host's **CRUSH subtree** via `osd set-group noout
+   <host>`, rather than the cluster-wide `noout` flag
+
+Do **not** also set `norebalance`, `nobackfill` or `norecover`. They are
+cluster-wide, and they are aimed at the wrong problem: `noout` already prevents
+the OSDs from being marked `out`, so their PGs are never remapped and there is no
+rebalance to suppress. Setting `norebalance` would instead pause legitimate
+recovery elsewhere in the cluster for the entire maintenance window.
+
+### Why noout is the part that matters
+
+`mon_osd_down_out_interval` defaults to **600** seconds. Ten minutes after the
+daemons stop, every OSD on the host is marked `out` and its PGs are remapped
+onto the rest of the cluster. For a 30-minute window that is a large, pointless
+data movement that must then be undone when the host returns. With `noout` the
+OSDs stay `in`: PGs go `undersized+degraded` and stay put.
+
+Confirm the interval on your cluster rather than trusting the default, and read
+it from the mon, since the config store can hold a value the mon is not running:
+
+```bash
+ceph tell mon.<bootstrap-host> config get mon_osd_down_out_interval
+```
+
+---
+
+## 1. Confirm the host is safe to lose
+
+```bash
+ceph -s
+ceph orch host ok-to-stop <host>
+```
+
+`ok-to-stop` must pass. It reports per daemon, so read the whole output: an OSD
+line saying "safe to restart" does not tell you anything about a MON or an
+ingress daemon on the same box.
+
+Check by hand what `ok-to-stop` does not weigh:
+
+```bash
+ceph -s | grep -E '^\s+(mon|mgr):'            # is this host in the quorum, or the active mgr?
+ceph orch ps <host> --format json | \
+  python3 -c 'import sys,json,collections; print(collections.Counter(d["daemon_type"] for d in json.load(sys.stdin)))'
+```
+
+Losing one MON of five is fine; losing one of three leaves no margin. If the
+host runs the active MGR, a standby takes over and `ceph orch` commands stall for
+a few seconds.
+
+**Failure domain.** The pools must tolerate the loss. On spice the EC profile is
+`ec-k16m4-host` with `crush-failure-domain=host`, and all replicated rules use
+host as well, so a PG has at most one shard on any single node: losing a host
+spends one of four tolerated failures. Verify for your cluster:
+
+```bash
+ceph osd erasure-code-profile get <profile>   # want crush-failure-domain=host
+ceph osd crush rule dump | \
+  python3 -c 'import sys,json; [print(r["rule_name"], [s.get("type") for s in r["steps"] if s.get("type")]) for r in json.load(sys.stdin)]'
+```
+
+**S3 availability.** An RGW on the host goes away with it. On spice the RGWs sit
+behind `ingress.rgw.spice.prod-z1`, whose haproxy health-checks its backends and
+routes around a dead one. Confirm the host is not itself running the ingress:
+
+```bash
+ceph orch ps --service-name ingress.rgw.<realm> --format json | \
+  python3 -c 'import sys,json; [print(d["hostname"]) for d in json.load(sys.stdin)]'
+```
+
+## 2. Let in-flight backfill finish
+
+```bash
+ceph -s | grep -E 'backfill|recovery|misplaced'
+```
+
+Entering maintenance while a backfill is running is not unsafe, but it stalls
+any PG whose remaining shards need the host you are about to stop, and it makes
+the degraded percentage in step 4 impossible to read against a baseline. If a
+rebuild is running, wait for `misplaced` to reach zero.
+
+## 3. Enter maintenance
+
+```bash
+ceph orch host maintenance enter <host>
+```
+
+Expected:
+
+```
+Daemons for Ceph cluster <fsid> stopped on host <host>. Host <host> moved to maintenance mode
+```
+
+## 4. Verify before releasing the host
+
+This is the step people skip, and it is the one that matters. The daemons are
+stopped **before** `noout` is applied, not after, so a failure in the flag step
+leaves the host down and unprotected.
+
+```bash
+ceph health detail | grep -A1 OSD_FLAGS
+```
+
+```
+[WRN] OSD_FLAGS: 1 OSDs or CRUSH {nodes, device-classes} have {NOUP,NODOWN,NOIN,NOOUT} flags set
+    host <host> has flags noout
+```
+
+**Plain `ceph osd dump` will not show this.** The flag lives on the CRUSH node,
+and the text output omits `crush_node_flags` entirely, so `ceph osd dump | grep
+noout` returns nothing and reads as a failure when everything is fine. Use
+`health detail` above, or ask for JSON:
+
+```bash
+ceph osd dump -f json | \
+  python3 -c 'import sys,json; print(json.load(sys.stdin)["crush_node_flags"])'
+# {'<host>': ['noout']}
+```
+
+Then confirm the host status and the shape of the damage:
+
+```bash
+ceph orch host ls --host-pattern <host>     # STATUS: Maintenance
+ceph -s
+```
+
+A healthy maintenance window looks like this. From spice, one 15-OSD host of 48
+with EC k16+m4:
+
+```
+health: HEALTH_WARN
+        1 host is in maintenance mode
+        14 osds down
+        1 OSDs or CRUSH {nodes, device-classes} have {NOUP,NODOWN,NOIN,NOOUT} flags set
+        1 host (15 osds) down
+        Degraded data redundancy: ... (2.020%), 1664 pgs degraded, 1670 pgs undersized
+osd: 720 osds: 705 up, 719 in
+rgw: 47 daemons active (47 hosts, 1 zones)
+```
+
+Read it as: `in` count unchanged (that is `noout` working), `up` count down by
+the live OSDs on the host, degraded roughly one host's share of the data, and no
+PGs `inactive`, `down`, `stale` or `incomplete`. **Inactive PGs mean I/O is
+blocked and the host must come back immediately.**
+
+The `up` count drops by the number of *live* OSDs, which is not the same as the
+host's OSD count if one was already down. Above, 14 went down but the host owns
+15.
+
+Now the machine can be powered off.
+
+## 5. While the host is offline
+
+Nothing to do. Do not "help" by setting more flags. Degraded PGs are expected
+and recovery elsewhere in the cluster continues normally.
+
+If the window stretches far beyond plan, the decision to abandon `noout` and let
+the cluster re-replicate is a capacity question, not a safety one: at that point
+you are choosing to spend free space to restore redundancy. Nothing here expires
+on its own.
+
+## 6. Exit maintenance
+
+Once the host is powered on and reachable:
+
+```bash
+ceph orch host maintenance exit <host>
+ceph orch host ls --host-pattern <host>     # STATUS empty again
+ceph -s
+```
+
+Exit re-enables the systemd target, starts the daemons, and issues `osd
+unset-group noout <host>`. **Nothing starts on its own after a power-on**, because
+entering maintenance disabled the target. A host that boots and stays silent is
+not broken; it is waiting for this command.
+
+Watch the OSDs return and the degraded count fall:
+
+```bash
+watch -n5 'ceph -s | grep -E "osds:|degraded|inactive"'
+```
+
+Confirm `noout` is gone:
+
+```bash
+ceph osd dump -f json | \
+  python3 -c 'import sys,json; print(json.load(sys.stdin)["crush_node_flags"])'
+# {}
+```
+
+Leaving `noout` set is the quiet failure mode here: the cluster looks healthy but
+will not react to a later disk failure on that host.
+
+## 7. If the host does not come back
+
+```bash
+ceph orch host maintenance exit <host> --force --offline
+```
+
+This clears the maintenance state for a host cephadm cannot reach, so the
+cluster stops waiting on it. It does not remove `noout`, which is what you want:
+the host is still expected back. If it is not coming back, drop `noout`
+deliberately so redundancy is restored:
+
+```bash
+ceph osd unset-group noout <host>
+```
+
+and then follow [replace-host.md](replace-host.md).
+
+---
+
+## Related
+
+- [replace-disk.md](replace-disk.md) - the disk swap this usually wraps, including
+  the `replace-osd.yml` rebuild once the new disk is in
+- [replace-host.md](replace-host.md) - when the node is not coming back
+- [remote-hands-access.md](remote-hands-access.md) - getting a human to the machine
+
+## Note on the reprovision path
+
+`roles/reprovision_hetzner/tasks/ceph_safety.yml` gates a node the other way: its
+own `ok-to-stop` check followed by per-OSD `ceph osd add-noout`. That is correct
+for reprovisioning, where the host is about to be wiped and the systemd target
+does not survive anyway. It is the wrong tool for a power-off-and-return, because
+it leaves the target enabled and the host status unset. Use this runbook for
+anything the node is expected to come back from.

--- a/ansible/ceph/docs/runbooks/host-maintenance.md
+++ b/ansible/ceph/docs/runbooks/host-maintenance.md
@@ -1,8 +1,13 @@
 # Runbook: Take a Host Offline for Physical Maintenance
 
 **When:** A node must be powered off or rebooted for longer than a few minutes.
-Hetzner disk replacement, DIMM or NIC swap, chassis work, anything where remote
-hands need the machine down.
+DIMM or NIC swap, cable reseating, chassis work, anything where remote hands need
+the machine down.
+
+**Not for a plain disk swap.** Hetzner will hot-swap a drive on a live SX295 if
+the ticket asks for `hot_swap`, so a failed disk whose OSD is already `down` and
+`out` needs no maintenance window. See
+[replace-disk.md](replace-disk.md).
 
 **Time estimate:** 2 minutes to enter, 2 minutes to exit. The offline window is
 whatever the physical work takes.

--- a/ansible/ceph/docs/runbooks/replace-disk.md
+++ b/ansible/ceph/docs/runbooks/replace-disk.md
@@ -344,13 +344,26 @@ it back to the same drive; draining relocates it to a healthy one.
 ```bash
 ceph orch daemon stop osd.<id>
 ceph orch osd rm <id> --replace     # keeps the id reserved for the new disk
+ceph orch osd rm status             # repeat until <id> is gone from the queue
 ceph osd tree destroyed             # must list <id> before step 6 can reuse it
 ```
 
-`--replace` marks the id `destroyed` instead of purging it, and `destroyed` is
-the only osdmap state ceph-volume will reuse an id from. An OSD that is merely
-`down` and `out` still owns its number, so skipping this step and rebuilding
-anyway hands the new disk the next free id above every existing OSD.
+`orch osd rm` only queues the removal; the mgr works through it in the
+background, gated on `ok-to-stop` and `safe-to-destroy`, and waits rather than
+forces if either says no. `--replace` then marks the id `destroyed` instead of
+purging it, and `destroyed` is the only osdmap state ceph-volume will reuse an
+id from. An OSD that is merely `down` and `out` still owns its number, so
+skipping this step and rebuilding anyway hands the new disk the next free id
+above every existing OSD.
+
+Do not add `--zap`. It runs `ceph-volume lvm zap --osd-id <id> --destroy`, and
+`--destroy` removes the db-slot LV rather than wiping it. Step 6 zaps the slot
+itself, without `--destroy`.
+
+Nothing here needs the old disk to still be present. When Hetzner swaps the
+drive before you reach this step, which is the usual order now that they
+hot-swap, run it unchanged. Do not put the new disk in service under a fresh
+id to save the step.
 
 If `orch osd rm` stalls on a daemon that is already dead, do the same thing by
 hand: `ceph osd destroy <id> --yes-i-really-mean-it`, then
@@ -473,7 +486,10 @@ spinning disk in front of every metadata operation. The bug is open against
 The same applies to `deploy-ceph.yml --tags osds`. It re-renders and re-applies
 the spec, which stays unmanaged, so it will not create the OSD for you; the
 `ceph_osd_allow_spec_provisioning` window that would let it is for initial
-cluster provisioning only. Use `replace-osd.yml` above.
+cluster provisioning only. And to `ceph orch device replace <host> <dev>`, the
+newer upstream flow: it stamps the old device so the managed drivegroup redeploys
+onto its replacement, which is the same spec-driven path with the same hazard,
+and it needs the old device to still be visible. Use `replace-osd.yml` above.
 
 [t68436]: https://tracker.ceph.com/issues/68436
 

--- a/ansible/ceph/docs/runbooks/replace-disk.md
+++ b/ansible/ceph/docs/runbooks/replace-disk.md
@@ -341,8 +341,21 @@ it back to the same drive; draining relocates it to a healthy one.
 
 ### 4. Remove the OSD and free the db slot
 
+If the daemon is still running, stop it on the host, not through the
+orchestrator:
+
 ```bash
-ceph orch daemon stop osd.<id>
+ssh <host> cephadm unit --fsid <fsid> --name osd.<id> stop
+```
+
+`ceph orch daemon stop|start|restart osd.<id>` only queues an action, and the
+serve loop skips every daemon of an unmanaged spec before it reads that queue.
+Against a spec-deployed OSD on spice it never runs and never clears, and the
+queued action then fires on the first pass after a rebuilt daemon of the same
+name boots. `orch daemon rm` does not drop it either. `replace-osd.yml` reads the
+queue and undoes a queued stop, but do not add to it.
+
+```bash
 ceph orch osd rm <id> --replace     # keeps the id reserved for the new disk
 ceph orch osd rm status             # repeat until <id> is gone from the queue
 ceph osd tree destroyed             # must list <id> before step 6 can reuse it
@@ -365,9 +378,31 @@ drive before you reach this step, which is the usual order now that they
 hot-swap, run it unchanged. Do not put the new disk in service under a fresh
 id to save the step.
 
-If `orch osd rm` stalls on a daemon that is already dead, do the same thing by
-hand: `ceph osd destroy <id> --yes-i-really-mean-it`, then
-`ceph orch daemon rm osd.<id> --force`.
+**When the cluster is not `active+clean`, `--replace` cannot finish.** The mgr's
+`safe-to-destroy` files every down OSD under "no reported stats" while any PG is
+unclean and answers EAGAIN, before and after destroy alike, and cephadm never
+bypasses that verdict (`--force` only skips the emptiness check). The entry sits
+at `done, waiting for purge` until the last backfill lands, and it is not inert
+while it waits: the moment a rebuilt osd.<id> boots and holds PGs, the entry
+marks it `out` and drains it. On spice a backfill is nearly always in flight, so
+expect this path:
+
+```bash
+ceph orch osd rm stop <id>                       # drops the entry; side effect: `osd in`
+ceph osd out <id>                                # undo that within the second
+ceph orch osd rm status                          # empty
+ceph config-key get mgr/cephadm/osd_remove_queue # []  (rm stop persists on the next serve pass)
+ceph osd destroy <id> --yes-i-really-mean-it     # the flag doubles as --force at the mgr
+ceph osd tree destroyed                          # lists <id>
+ceph orch daemon rm osd.<id> --force             # cephadm forgets the dead daemon
+```
+
+The `in`/`out` pair is two osdmap epochs a second apart. PGs whose placement
+includes the OSD re-peer and settle back onto the same map; nothing moves and
+nothing goes degraded. If the `out` could not run, the mon re-outs the OSD on
+its own after `mon_osd_down_out_interval` (600 s here). The end state is the one
+`--replace` would have produced: `destroyed`, cephx and lockbox keys scrubbed,
+CRUSH entry and weight kept.
 
 Leave the db LV alone. `replace-osd.yml` zaps it in step 6, and it zaps
 unconditionally so it does not matter whether the slot survived, was already
@@ -414,10 +449,11 @@ scripts/ansible-play.sh replace-osd.yml --limit <hostname> \
 ```
 
 It ensures the db slot LV exists, zaps it, drives `ceph-volume lvm create` with
-the slot and the id pinned explicitly, activates the daemon, and then asserts
-the result landed on the NVMe under the id you asked for. Re-running it against
-a bay that already holds an OSD is a no-op, so it is safe to repeat after a
-failure.
+the slot and the id pinned explicitly, activates the daemon, waits for it to be
+`up`, undoes a queued `orch daemon stop` if step 4 left one, and then asserts
+the metadata the new daemon reported names this disk and puts block.db on the
+NVMe. Re-running it against a bay that already holds an OSD is a no-op, so it
+is safe to repeat after a failure.
 
 `osd_id` is optional. Leave it off only when you want a fresh number, which on
 a full osdmap is one above every OSD in the cluster. With it set, the play
@@ -503,9 +539,22 @@ OSD by hand, check it yourself:
 ```bash
 ceph osd metadata <id> -f json | \
   python3 -c 'import sys,json; d=json.load(sys.stdin); \
-    print(d["bluefs_dedicated_db"], d["bluefs_db_devices"], d["bluefs_db_rotational"])'
-# expect: 1 md1 0
+    print(d["devices"], d["bluefs_dedicated_db"], d["bluefs_db_devices"], d["bluefs_db_rotational"])'
+# expect: md1,<new sdX> 1 md1 0
 ```
+
+Check `devices` first, and only after the OSD is `up`. `osd metadata` is the
+last report the mon holds for that id, so on a reused id it is the dead daemon's
+report until the new one boots, and the dead one had its block.db on `md1` too.
+A `1 md1 0` next to the old kernel device proves nothing.
+
+The rebuilt daemon is a different kind of cephadm citizen from its siblings.
+`ceph cephadm osd activate` deploys it under service `osd` (its `unit.meta`
+says so; `ceph orch ps` lists it under `osd`, not `osd.<host>-hdd`), so it has
+no spec and the serve loop does not skip it: queued `orch daemon` actions and
+config reconfigs run for it, where the spec-deployed 718 ignore them. osd.35
+and osd.17 are in that class. Harmless, and worth knowing when one of them
+behaves differently from the rest of the host.
 
 Then watch it fill:
 

--- a/ansible/ceph/docs/runbooks/replace-disk.md
+++ b/ansible/ceph/docs/runbooks/replace-disk.md
@@ -344,7 +344,17 @@ it back to the same drive; draining relocates it to a healthy one.
 ```bash
 ceph orch daemon stop osd.<id>
 ceph orch osd rm <id> --replace     # keeps the id reserved for the new disk
+ceph osd tree destroyed             # must list <id> before step 6 can reuse it
 ```
+
+`--replace` marks the id `destroyed` instead of purging it, and `destroyed` is
+the only osdmap state ceph-volume will reuse an id from. An OSD that is merely
+`down` and `out` still owns its number, so skipping this step and rebuilding
+anyway hands the new disk the next free id above every existing OSD.
+
+If `orch osd rm` stalls on a daemon that is already dead, do the same thing by
+hand: `ceph osd destroy <id> --yes-i-really-mean-it`, then
+`ceph orch daemon rm osd.<id> --force`.
 
 Leave the db LV alone. `replace-osd.yml` zaps it in step 6, and it zaps
 unconditionally so it does not matter whether the slot survived, was already
@@ -387,13 +397,25 @@ Run `replace-osd.yml`. It takes the bay and derives the rest:
 
 ```bash
 scripts/ansible-play.sh replace-osd.yml --limit <hostname> \
-  -e osd_bay=<bay-path>
+  -e osd_bay=<bay-path> -e osd_id=<id>
 ```
 
 It ensures the db slot LV exists, zaps it, drives `ceph-volume lvm create` with
-the slot pinned explicitly, activates the daemon, and then asserts the result
-landed on the NVMe. Re-running it against a bay that already holds an OSD is a
-no-op, so it is safe to repeat after a failure.
+the slot and the id pinned explicitly, activates the daemon, and then asserts
+the result landed on the NVMe under the id you asked for. Re-running it against
+a bay that already holds an OSD is a no-op, so it is safe to repeat after a
+failure.
+
+`osd_id` is optional. Leave it off only when you want a fresh number, which on
+a full osdmap is one above every OSD in the cluster. With it set, the play
+refuses to run until step 4 has marked that id `destroyed`.
+
+A hot swap on a host that has not rebooted leaves the dead OSD's dm-crypt
+mapping open on the db slot (`lvs` shows the LV as `-wi-ao----`, `lsblk` shows a
+`crypt` child under it). That is normal and needs no hand cleanup: `ceph-volume
+lvm zap` closes the mapping itself, by the LV uuid it is named after. The play
+only checks first that nothing still holds it open, since a zap under a live
+holder would wipe a block.db in use.
 
 The slot is derived, not passed: a slot counts as claimed only when it is the
 `db` entry of an OSD that also has a `block` entry. That distinction matters
@@ -419,7 +441,7 @@ cephadm ceph-volume \
   --config /run/replace-osd/ceph.conf \
   --keyring /run/replace-osd/bootstrap-osd.keyring \
   lvm create --dmcrypt --no-systemd --crush-device-class hdd \
-  --data "$DISK" --block.db "$DB_LV"
+  --osd-id <id> --data "$DISK" --block.db "$DB_LV"
 
 rm -rf /run/replace-osd
 ceph cephadm osd activate <hostname>

--- a/ansible/ceph/docs/runbooks/replace-disk.md
+++ b/ansible/ceph/docs/runbooks/replace-disk.md
@@ -291,6 +291,22 @@ smartctl -i /dev/<sdX> | grep -i "serial number"
 Record all four. The by-path identifies the bay; the serial identifies the disk
 to Hetzner; the db slot is what you zap and reuse.
 
+**When the disk has already dropped off the bus**, which is the common shape of a
+hard failure, both commands above fail: there is no `/dev/sdX` and the by-path
+symlink disappeared with the disk. Recover them from the cluster instead.
+
+```bash
+# serial: the mgr keeps its device inventory after the disk is gone
+ceph device ls-by-daemon osd.<id>
+
+# bay: every spice node has the same 14, so the missing one is the empty bay
+ls /dev/disk/by-path/ | grep -E 'ata-[0-9]+$' | sort -V
+```
+
+The full complement is `pci-0000:45:00.0-ata-{1..8}`, `pci-0000:46:00.0-ata-{1,2}`
+and `pci-0000:87:00.0-ata-{1..4}`. Diff against a healthy peer if it is easier to
+read that way.
+
 ### 2. Drain
 
 ```bash
@@ -330,22 +346,25 @@ ceph orch daemon stop osd.<id>
 ceph orch osd rm <id> --replace     # keeps the id reserved for the new disk
 ```
 
-Then, on the node, zap the db LV. The LV itself stays; only its contents go:
+Leave the db LV alone. `replace-osd.yml` zaps it in step 6, and it zaps
+unconditionally so it does not matter whether the slot survived, was already
+zapped, or was deleted outright by an earlier ad-hoc removal.
 
-```bash
-cephadm ceph-volume lvm zap vg0/db-slot<N>
-lvs vg0 | grep db-slot<N>           # confirm the LV still exists
-```
-
-Skipping this is the most common failure: ceph-volume refuses a db device that
-still carries an old OSD's metadata, and the recreate fails with no obvious
-pointer back to this step.
+Do **not** `lvremove` the slot. Deleting it rather than zapping it is what
+happened to osd.35 on alyssa, and while the play now recreates a missing slot,
+the deletion buys nothing and loses the record of which slot belonged to the OSD.
 
 ### 5. Physical swap
 
 Hetzner support ticket quoting the **serial** from step 1, since there is no
 IPMI and no bay LED. Reference the by-path only as supporting detail; Hetzner
 identifies drives by serial.
+
+These chassis have no hot-swap path that Hetzner will use, so expect them to ask
+to power the machine down. Put the host into maintenance before handing it over,
+or the remaining OSDs are marked `out` ten minutes in and the cluster starts a
+rebalance that has to be undone when it returns:
+[host-maintenance.md](host-maintenance.md).
 
 After the swap, confirm the new disk is present at the same by-path:
 
@@ -359,19 +378,59 @@ not actually swapped.
 
 ### 6. Recreate the OSD
 
-Create explicitly rather than re-applying the spec. This is the only way to
-pin the disk to the intended slot:
+Run `replace-osd.yml`. It takes the bay and derives the rest:
+
+```bash
+scripts/ansible-play.sh replace-osd.yml --limit <hostname> \
+  -e osd_bay=<bay-path>
+```
+
+It ensures the db slot LV exists, zaps it, drives `ceph-volume lvm create` with
+the slot pinned explicitly, activates the daemon, and then asserts the result
+landed on the NVMe. Re-running it against a bay that already holds an OSD is a
+no-op, so it is safe to repeat after a failure.
+
+The slot is derived, not passed: a slot counts as claimed only when it is the
+`db` entry of an OSD that also has a `block` entry. That distinction matters
+because a db-slot whose data disk died keeps its `ceph.osd_id` tag and reads as
+claimed forever if you go by LV tags alone. Pass `-e osd_db_slot=<n>` if the play
+reports more than one candidate.
+
+The equivalent by hand, for when you need to see what it is doing:
 
 ```bash
 DISK=/dev/disk/by-path/<bay-path>
 DB_LV=vg0/db-slot<N>
 
-cephadm ceph-volume \
-  --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring \
-  lvm create --dmcrypt --no-systemd --data "$DISK" --block.db "$DB_LV"
+# These nodes carry no /etc/ceph and no bootstrap-osd keyring: cephadm hands the
+# mgr-supplied credentials to the container at deploy time and leaves nothing
+# behind. Stage both, from the bootstrap node, for the one command.
+install -d -m 0700 /run/replace-osd
+ssh <bootstrap> ceph config generate-minimal-conf > /run/replace-osd/ceph.conf
+ssh <bootstrap> ceph auth get client.bootstrap-osd > /run/replace-osd/bootstrap-osd.keyring
+chmod 600 /run/replace-osd/*
 
+cephadm ceph-volume \
+  --config /run/replace-osd/ceph.conf \
+  --keyring /run/replace-osd/bootstrap-osd.keyring \
+  lvm create --dmcrypt --no-systemd --crush-device-class hdd \
+  --data "$DISK" --block.db "$DB_LV"
+
+rm -rf /run/replace-osd
 ceph cephadm osd activate <hostname>
 ```
+
+Two traps in that block, both of which cost a failed run:
+
+- **The ceph.conf must end in a newline.** Without it `conf_read_file` throws
+  `InvalidArgumentError('RADOS invalid argument')` and ceph-volume then reports
+  `RuntimeError: Unable to create a new OSD id`, which reads like a credentials
+  problem and is not. Shell redirection preserves the newline; anything that
+  captures the output as a string is liable to strip it.
+- **Pass `--crush-device-class` explicitly.** Ceph infers `hdd` from rotational
+  if you omit it, so the OSD comes up in the right class either way, but its LV
+  tag is then left empty while every OSD built from the drivegroup spec carries
+  the class. Inference is not declarative; set it.
 
 **Do not rebuild a replaced disk by re-managing the OSD spec.** spice's specs
 carry `unmanaged: true` (`ceph_osd_spec_unmanaged` in its group_vars) precisely
@@ -387,11 +446,25 @@ spinning disk in front of every metadata operation. The bug is open against
 The same applies to `deploy-ceph.yml --tags osds`. It re-renders and re-applies
 the spec, which stays unmanaged, so it will not create the OSD for you; the
 `ceph_osd_allow_spec_provisioning` window that would let it is for initial
-cluster provisioning only. Use `ceph-volume` above.
+cluster provisioning only. Use `replace-osd.yml` above.
 
 [t68436]: https://tracker.ceph.com/issues/68436
 
 ### 7. Verify
+
+`replace-osd.yml` already asserts the part that is invisible from the outside:
+that `bluefs_dedicated_db` is 1 and the db is non-rotational. A colocated
+block.db does not show up in `ceph -s` or `ceph osd tree`, so if you built the
+OSD by hand, check it yourself:
+
+```bash
+ceph osd metadata <id> -f json | \
+  python3 -c 'import sys,json; d=json.load(sys.stdin); \
+    print(d["bluefs_dedicated_db"], d["bluefs_db_devices"], d["bluefs_db_rotational"])'
+# expect: 1 md1 0
+```
+
+Then watch it fill:
 
 ```bash
 ceph osd tree | grep "osd.<id>"        # up, weight > 0
@@ -399,8 +472,9 @@ ceph osd df | awk 'NR==1 || $1==<id>'  # PGs climbing as backfill lands
 ceph -s                                # back to active+clean
 ```
 
-Confirm the new OSD picked up the intended slot, since nothing enforced it:
+Confirm it took the intended slot and matches its siblings:
 
 ```bash
 cephadm ceph-volume lvm list | grep -A 8 "====== osd.<id>"
+lvs -a -o lv_tags | grep "ceph.osd_id=<id>," | grep -o 'ceph.crush_device_class=[a-z]*'
 ```

--- a/ansible/ceph/docs/runbooks/replace-disk.md
+++ b/ansible/ceph/docs/runbooks/replace-disk.md
@@ -360,11 +360,16 @@ Hetzner support ticket quoting the **serial** from step 1, since there is no
 IPMI and no bay LED. Reference the by-path only as supporting detail; Hetzner
 identifies drives by serial.
 
-These chassis have no hot-swap path that Hetzner will use, so expect them to ask
-to power the machine down. Put the host into maintenance before handing it over,
-or the remaining OSDs are marked `out` ten minutes in and the cluster starts a
-rebalance that has to be undone when it returns:
-[host-maintenance.md](host-maintenance.md).
+Ask for a hot swap. The Robot form carries a `Replacement method` field, and
+these bays do support `hot_swap`: Hetzner replaced a drive on a live SX295 with
+no downtime. A single-disk swap then needs no maintenance window at all, as long
+as the OSD is already `down` and `out` so nothing is reading the device.
+
+Take the host into maintenance only when the work genuinely needs the machine
+down, which so far means anything inside the chassis, such as reseating a SATA
+cable. Skipping it in that case leaves the remaining OSDs to be marked `out` ten
+minutes in, and the cluster starts a rebalance that has to be undone when the
+host returns: [host-maintenance.md](host-maintenance.md).
 
 After the swap, confirm the new disk is present at the same by-path:
 

--- a/ansible/ceph/replace-osd.yml
+++ b/ansible/ceph/replace-osd.yml
@@ -59,7 +59,7 @@
     # The by-path symlink is the bay; it disappears with the disk. A missing one
     # means the swap has not happened yet, not that the play is misconfigured.
     - name: Resolve the bay to a kernel device
-      ansible.builtin.command: readlink -f /dev/disk/by-path/{{ osd_bay }}
+      ansible.builtin.command: readlink -e /dev/disk/by-path/{{ osd_bay }}
       register: replace_osd_dev
       changed_when: false
       check_mode: false
@@ -261,6 +261,7 @@
     # nothing behind. Driving ceph-volume by hand means supplying both, so stage
     # them on tmpfs for the one command and remove them either way.
     - name: Build the OSD
+      when: not ansible_check_mode
       block:
         - name: Stage a private directory for the bootstrap credentials
           ansible.builtin.file:
@@ -347,6 +348,21 @@
           ansible.builtin.set_fact:
             replace_osd_new_id: "{{ (replace_osd_created.stdout | from_json).keys() | first }}"
 
+        # The queued action runs on the first serve pass after the daemon lands in
+        # cephadm's cache, up to a minute later, and a start queued before then is
+        # dropped because stop outranks it. So let it fire, then judge the OSD.
+        - name: Wait for cephadm to consume the queued action
+          ansible.builtin.command: ceph config-key get mgr/cephadm/host.{{ inventory_hostname }}
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          register: replace_osd_host_cache_after
+          changed_when: false
+          until: >-
+            ('osd.' ~ replace_osd_new_id) not in
+            ((replace_osd_host_cache_after.stdout | from_json).scheduled_daemon_actions | default({}))
+          retries: 18
+          delay: 10
+          when: (replace_osd_queued_action | default('')) | length > 0
+
         - name: Wait for the OSD to be up
           ansible.builtin.command: ceph osd tree -f json
           register: replace_osd_tree_after
@@ -361,8 +377,6 @@
           delay: 10
           ignore_errors: true
 
-        # The queued action recorded before the build ran on the first serve pass
-        # after boot. A stop is the only one that leaves the daemon down.
         - name: Start the daemon that cephadm's queued stop took down
           ansible.builtin.command: ceph orch daemon start osd.{{ replace_osd_new_id }}
           delegate_to: "{{ groups['ceph_bootstrap'][0] }}"

--- a/ansible/ceph/replace-osd.yml
+++ b/ansible/ceph/replace-osd.yml
@@ -175,6 +175,34 @@
           destroyed. Run `ceph orch osd rm {{ osd_id }} --replace` first.
       when: osd_id is defined
 
+    # `orch daemon stop|start|restart` only queues an action per daemon name;
+    # the serve loop skips daemons of an unmanaged spec before it reads the
+    # queue, so against a spec-deployed OSD it never runs and never clears. The
+    # rebuilt daemon has no spec, so the first pass after it boots runs it.
+    # Nothing drops a queued action, so record it and undo it after the boot.
+    - name: Read cephadm's queued daemon actions for this host
+      ansible.builtin.command: ceph config-key get mgr/cephadm/host.{{ inventory_hostname }}
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      register: replace_osd_host_cache
+      changed_when: false
+      check_mode: false
+      when: osd_id is defined
+
+    - name: Note the action cephadm will run against the rebuilt daemon
+      ansible.builtin.set_fact:
+        replace_osd_queued_action: >-
+          {{ ((replace_osd_host_cache.stdout | from_json).scheduled_daemon_actions
+              | default({}))['osd.' ~ osd_id] | default('') }}
+      when: osd_id is defined
+
+    - name: Report the queued action
+      ansible.builtin.debug:
+        msg: >-
+          cephadm holds a queued `{{ replace_osd_queued_action }}` for
+          osd.{{ osd_id }} on {{ inventory_hostname }}. It runs on the first
+          serve pass after the rebuilt daemon boots; a stop is undone below.
+      when: (replace_osd_queued_action | default('')) | length > 0
+
     - name: Report the plan
       ansible.builtin.debug:
         msg: >-
@@ -315,15 +343,62 @@
               osd.{{ (replace_osd_created.stdout | from_json).keys() | first }}.
           when: osd_id is defined
 
-        - name: Read the new OSD's BlueStore metadata
+        - name: Set the new OSD id
+          ansible.builtin.set_fact:
+            replace_osd_new_id: "{{ (replace_osd_created.stdout | from_json).keys() | first }}"
+
+        - name: Wait for the OSD to be up
+          ansible.builtin.command: ceph osd tree -f json
+          register: replace_osd_tree_after
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          changed_when: false
+          until: >-
+            (replace_osd_tree_after.stdout | from_json).nodes
+            | selectattr('type', 'eq', 'osd')
+            | selectattr('id', 'eq', replace_osd_new_id | int)
+            | map(attribute='status') | first | default('') == 'up'
+          retries: 12
+          delay: 10
+          ignore_errors: true
+
+        # The queued action recorded before the build ran on the first serve pass
+        # after boot. A stop is the only one that leaves the daemon down.
+        - name: Start the daemon that cephadm's queued stop took down
+          ansible.builtin.command: ceph orch daemon start osd.{{ replace_osd_new_id }}
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          changed_when: true
+          when:
+            - replace_osd_tree_after is failed
+            - (replace_osd_queued_action | default('')) == 'stop'
+
+        - name: Wait for the OSD to be up after the restart
+          ansible.builtin.command: ceph osd tree -f json
+          register: replace_osd_tree_after
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          changed_when: false
+          until: >-
+            (replace_osd_tree_after.stdout | from_json).nodes
+            | selectattr('type', 'eq', 'osd')
+            | selectattr('id', 'eq', replace_osd_new_id | int)
+            | map(attribute='status') | first | default('') == 'up'
+          retries: 12
+          delay: 10
+          when: replace_osd_tree_after is failed
+
+        # `osd metadata` is the last report the mon holds for that id. On a reused
+        # id that is the dead daemon's report until the new one boots, and it
+        # would pass every assert below. Insist the report names this disk.
+        - name: Read the BlueStore metadata the new daemon reported
           ansible.builtin.command: >-
-            ceph osd metadata
-            {{ (replace_osd_created.stdout | from_json).keys() | first }} --format json
+            ceph osd metadata {{ replace_osd_new_id }} --format json
           register: replace_osd_meta
           delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
           changed_when: false
-          until: replace_osd_meta.rc == 0
-          retries: 12
+          until: >-
+            replace_osd_meta.rc == 0 and
+            (replace_osd_dev.stdout | basename) in
+            ((replace_osd_meta.stdout | from_json).devices | default('') | split(','))
+          retries: 6
           delay: 10
 
         # The whole reason this play drives ceph-volume instead of the spec. A
@@ -334,12 +409,12 @@
               - (replace_osd_meta.stdout | from_json).bluefs_dedicated_db == "1"
               - (replace_osd_meta.stdout | from_json).bluefs_db_rotational == "0"
             fail_msg: >-
-              osd.{{ (replace_osd_created.stdout | from_json).keys() | first }} came up
+              osd.{{ replace_osd_new_id }} came up
               with block.db on
               {{ (replace_osd_meta.stdout | from_json).bluefs_db_devices | default('?') }}
               (dedicated={{ (replace_osd_meta.stdout | from_json).bluefs_dedicated_db | default('?') }}).
               It is a spinning-disk metadata path; destroy and rebuild it.
             success_msg: >-
-              osd.{{ (replace_osd_created.stdout | from_json).keys() | first }} up on
+              osd.{{ replace_osd_new_id }} up on
               {{ osd_bay }} with block.db on
               {{ (replace_osd_meta.stdout | from_json).bluefs_db_devices }}.

--- a/ansible/ceph/replace-osd.yml
+++ b/ansible/ceph/replace-osd.yml
@@ -141,6 +141,21 @@
           with -e osd_db_slot=<n>.
       when: osd_db_slot is undefined
 
+    # An explicit slot only picks among the free ones. A slot whose OSD is
+    # merely stopped still reads as live here, its LUKS mapping is closed so
+    # the open-count guard below would pass, and the zap would take that OSD's
+    # block.db with it.
+    - name: Assert the requested slot is one the scan found free
+      ansible.builtin.assert:
+        that:
+          - (osd_db_slot | int) in (replace_osd_scan.stdout | from_json).free
+        fail_msg: >-
+          db-slot{{ osd_db_slot }} is not free: it is the block.db of an OSD that
+          still has its data disk (running or not). Free slots:
+          {{ (replace_osd_scan.stdout | from_json).free }}. This play never zaps a
+          slot it can account for.
+      when: osd_db_slot is defined
+
     - name: Select the db slot
       ansible.builtin.set_fact:
         replace_osd_slot: >-

--- a/ansible/ceph/replace-osd.yml
+++ b/ansible/ceph/replace-osd.yml
@@ -1,0 +1,278 @@
+---
+# Rebuild one OSD onto a replaced HDD, on the NVMe-RAID (spice) shape.
+#
+# Picks up AFTER the disk is physically in the bay: drain, `ceph orch osd rm
+# <id> --replace`, and the Hetzner serial ticket stay manual in
+# docs/runbooks/replace-disk.md. Those steps are one-way and need an operator
+# watching a drain, so wrapping them would only cost the idempotency below.
+#
+# WHY this exists rather than re-applying the OSD spec: with one blank disk and
+# one free db slot, cephadm may recreate the OSD without its block.db (Ceph
+# tracker #68436, open against 18.2.4, cluster runs 20.2.2). On this shape that
+# silently colocates block.db on the 22TB HDD instead of the vg0 db-slot LV, and
+# the OSD comes up looking healthy. Driving ceph-volume directly is the only way
+# to pin the disk to its slot; the final assert is what proves it landed.
+#
+#   scripts/ansible-play.sh replace-osd.yml --limit spice-ceph-alyssa \
+#     -e osd_bay=pci-0000:45:00.0-ata-6
+#
+# Re-running against an OSD that already exists on that bay is a no-op.
+
+- name: Rebuild an OSD on a replaced disk
+  hosts: ceph_nodes
+  become: true
+  gather_facts: false
+
+  vars:
+    replace_osd_staging: /run/replace-osd
+    # Ceph auto-detects this from rotational, so leaving it unset still lands on
+    # hdd. Set it anyway: the drivegroup spec pins it, so an OSD built here would
+    # otherwise be the one on the node whose LV tag disagrees with its siblings.
+    osd_crush_device_class: hdd
+
+  pre_tasks:
+    # Standing directive for spice: one node at a time, never a blanket re-run.
+    - name: Assert exactly one target host
+      ansible.builtin.assert:
+        that:
+          - ansible_play_hosts | length == 1
+        fail_msg: >-
+          replace-osd.yml targets exactly one host per run, got
+          {{ ansible_play_hosts | length }}: {{ ansible_play_hosts | join(', ') }}.
+          Re-run with --limit <host>.
+        success_msg: "Target: {{ ansible_play_hosts | first }}."
+
+    - name: Assert the required inputs are present
+      ansible.builtin.assert:
+        that:
+          - osd_bay is defined
+          - ceph_db_lvs_per_node is defined
+          - sas_path_prefix is undefined
+        fail_msg: >-
+          Needs -e osd_bay=<by-path under /dev/disk/by-path>, and a host on the
+          NVMe-RAID shape (ceph_db_lvs_per_node set, no sas_path_prefix).
+
+  tasks:
+    # The by-path symlink is the bay; it disappears with the disk. A missing one
+    # means the swap has not happened yet, not that the play is misconfigured.
+    - name: Resolve the bay to a kernel device
+      ansible.builtin.command: readlink -f /dev/disk/by-path/{{ osd_bay }}
+      register: replace_osd_dev
+      changed_when: false
+      check_mode: false
+      failed_when: replace_osd_dev.rc != 0 or replace_osd_dev.stdout | length == 0
+
+    - name: Look for an OSD already on this disk
+      ansible.builtin.command: >-
+        cephadm ceph-volume lvm list {{ replace_osd_dev.stdout }} --format json
+      register: replace_osd_existing
+      changed_when: false
+      check_mode: false
+
+    - name: Report the OSD already present on this bay
+      ansible.builtin.debug:
+        msg: >-
+          osd.{{ (replace_osd_existing.stdout | from_json).keys() | first }} already
+          occupies {{ osd_bay }} ({{ replace_osd_dev.stdout }}). Nothing to do.
+      when: (replace_osd_existing.stdout | from_json) | length > 0
+
+    - name: End the run when the OSD already exists
+      ansible.builtin.meta: end_host
+      when: (replace_osd_existing.stdout | from_json) | length > 0
+
+    - name: Gate on cluster health
+      ansible.builtin.import_tasks: tasks/health_gate.yml
+
+    - name: Check whether the disk carries an LVM PV
+      ansible.builtin.command: pvs {{ replace_osd_dev.stdout }}
+      register: replace_osd_pv
+      changed_when: false
+      check_mode: false
+      failed_when: false
+
+    - name: Assert the replacement disk is bare
+      ansible.builtin.assert:
+        that:
+          - replace_osd_pv.rc != 0
+        fail_msg: >-
+          {{ replace_osd_dev.stdout }} already carries an LVM PV but no OSD. Zap it
+          by hand before rebuilding: this play will not destroy data it cannot
+          account for.
+
+    # A slot is claimed only when it is the `db` entry of an OSD that ALSO has a
+    # `block` entry. LV tags alone are not enough: a db-slot whose data disk died
+    # keeps its ceph.osd_id tag and reads as claimed forever. The shapes are
+    # ('block','db') for a live HDD OSD, ('db',) for that orphan, and ('block',)
+    # for the colocated ssd-osd, which never consumes a slot.
+    - name: Scan db slots for one that is free to reuse
+      ansible.builtin.shell: |
+        set -o pipefail
+        cephadm ceph-volume lvm list --format json 2>/dev/null | python3 -c '
+        import sys, json, re
+        entries = json.load(sys.stdin)
+        live, orphan = set(), set()
+        for devs in entries.values():
+            types = {d.get("type") for d in devs}
+            for d in devs:
+                if d.get("type") != "db":
+                    continue
+                m = re.search(r"db-slot(\d+)", d.get("lv_path", ""))
+                if m:
+                    (live if "block" in types else orphan).add(int(m.group(1)))
+        free = sorted(set(range({{ ceph_db_lvs_per_node }})) - live)
+        print(json.dumps({"free": free, "orphan": sorted(orphan)}))
+        '
+      args:
+        executable: /bin/bash
+      register: replace_osd_scan
+      changed_when: false
+      check_mode: false
+
+    - name: Assert the free slot is unambiguous
+      ansible.builtin.assert:
+        that:
+          - (replace_osd_scan.stdout | from_json).free | length == 1
+        fail_msg: >-
+          Expected exactly one reusable db slot, found
+          {{ (replace_osd_scan.stdout | from_json).free }}. Name one explicitly
+          with -e osd_db_slot=<n>.
+      when: osd_db_slot is undefined
+
+    - name: Select the db slot
+      ansible.builtin.set_fact:
+        replace_osd_slot: >-
+          {{ osd_db_slot | default((replace_osd_scan.stdout | from_json).free | first) }}
+
+    - name: Report the plan
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}: build an OSD on {{ osd_bay }}
+          ({{ replace_osd_dev.stdout }}) against
+          {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }}
+          (orphaned slots seen: {{ (replace_osd_scan.stdout | from_json).orphan }})
+
+    # Covers the slot having been deleted rather than zapped by an earlier ad-hoc
+    # removal. shrink:false so this can never truncate a live block.db; -Wy wipes
+    # stale signatures on a slot it does create.
+    - name: Ensure the db slot LV exists
+      community.general.lvol:
+        vg: "{{ ceph_db_vg }}"
+        lv: "db-slot{{ replace_osd_slot }}"
+        size: "{{ ceph_db_lv_size }}"
+        shrink: false
+        opts: "-Wy"
+        state: present
+
+    # Unconditional so the deleted-slot and the zapped-slot cases converge on one
+    # path. ceph-volume refuses a db device still carrying an old OSD's metadata,
+    # and the resulting create failure does not point back here.
+    - name: Zap the db slot
+      ansible.builtin.command: >-
+        cephadm ceph-volume lvm zap {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }}
+      changed_when: true
+
+    # These hosts carry no /etc/ceph and no bootstrap-osd keyring: cephadm hands
+    # the mgr-supplied credentials to the container at deploy time and leaves
+    # nothing behind. Driving ceph-volume by hand means supplying both, so stage
+    # them on tmpfs for the one command and remove them either way.
+    - name: Build the OSD
+      block:
+        - name: Stage a private directory for the bootstrap credentials
+          ansible.builtin.file:
+            path: "{{ replace_osd_staging }}"
+            state: directory
+            mode: "0700"
+
+        - name: Fetch the minimal cluster config
+          ansible.builtin.command: ceph config generate-minimal-conf
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          register: replace_osd_conf
+          changed_when: false
+
+        - name: Fetch the client.bootstrap-osd keyring
+          ansible.builtin.command: ceph auth get client.bootstrap-osd
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          register: replace_osd_key
+          changed_when: false
+          no_log: true
+
+        # The trailing newline is load-bearing. `command` strips it from stdout,
+        # and a ceph.conf whose last line has no newline fails to parse with
+        # InvalidArgumentError('RADOS invalid argument (error calling
+        # conf_read_file)'), which reads as a credentials problem and is not.
+        - name: Write the staged credentials
+          ansible.builtin.copy:
+            content: "{{ item.body }}\n"
+            dest: "{{ replace_osd_staging }}/{{ item.name }}"
+            mode: "0600"
+          loop:
+            - name: ceph.conf
+              body: "{{ replace_osd_conf.stdout }}"
+            - name: bootstrap-osd.keyring
+              body: "{{ replace_osd_key.stdout }}"
+          loop_control:
+            label: "{{ item.name }}"
+          no_log: true
+
+        - name: Create the OSD
+          ansible.builtin.command: >-
+            cephadm ceph-volume
+            --config {{ replace_osd_staging }}/ceph.conf
+            --keyring {{ replace_osd_staging }}/bootstrap-osd.keyring
+            lvm create --dmcrypt --no-systemd
+            --crush-device-class {{ osd_crush_device_class }}
+            --data /dev/disk/by-path/{{ osd_bay }}
+            --block.db {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }}
+          changed_when: true
+
+      always:
+        - name: Remove the staged credentials
+          ansible.builtin.file:
+            path: "{{ replace_osd_staging }}"
+            state: absent
+
+    - name: Activate the new daemon
+      ansible.builtin.command: ceph cephadm osd activate {{ inventory_hostname }}
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      changed_when: true
+
+    - name: Post-create verification
+      when: not ansible_check_mode
+      block:
+        - name: Resolve the new OSD id
+          ansible.builtin.command: >-
+            cephadm ceph-volume lvm list {{ replace_osd_dev.stdout }} --format json
+          register: replace_osd_created
+          changed_when: false
+          until: (replace_osd_created.stdout | from_json) | length > 0
+          retries: 12
+          delay: 10
+
+        - name: Read the new OSD's BlueStore metadata
+          ansible.builtin.command: >-
+            ceph osd metadata
+            {{ (replace_osd_created.stdout | from_json).keys() | first }} --format json
+          register: replace_osd_meta
+          delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+          changed_when: false
+          until: replace_osd_meta.rc == 0
+          retries: 12
+          delay: 10
+
+        # The whole reason this play drives ceph-volume instead of the spec. A
+        # colocated block.db is invisible in `ceph -s` and in `ceph osd tree`.
+        - name: Assert block.db landed on the NVMe slot and not the HDD
+          ansible.builtin.assert:
+            that:
+              - (replace_osd_meta.stdout | from_json).bluefs_dedicated_db == "1"
+              - (replace_osd_meta.stdout | from_json).bluefs_db_rotational == "0"
+            fail_msg: >-
+              osd.{{ (replace_osd_created.stdout | from_json).keys() | first }} came up
+              with block.db on
+              {{ (replace_osd_meta.stdout | from_json).bluefs_db_devices | default('?') }}
+              (dedicated={{ (replace_osd_meta.stdout | from_json).bluefs_dedicated_db | default('?') }}).
+              It is a spinning-disk metadata path; destroy and rebuild it.
+            success_msg: >-
+              osd.{{ (replace_osd_created.stdout | from_json).keys() | first }} up on
+              {{ osd_bay }} with block.db on
+              {{ (replace_osd_meta.stdout | from_json).bluefs_db_devices }}.

--- a/ansible/ceph/replace-osd.yml
+++ b/ansible/ceph/replace-osd.yml
@@ -14,7 +14,10 @@
 # to pin the disk to its slot; the final assert is what proves it landed.
 #
 #   scripts/ansible-play.sh replace-osd.yml --limit spice-ceph-alyssa \
-#     -e osd_bay=pci-0000:45:00.0-ata-6
+#     -e osd_bay=pci-0000:45:00.0-ata-6 [-e osd_id=35]
+#
+# osd_id keeps the old id. Without it ceph-volume allocates the next free id,
+# and on a full osdmap that is a new number above every existing OSD.
 #
 # Re-running against an OSD that already exists on that bay is a no-op.
 
@@ -143,11 +146,41 @@
         replace_osd_slot: >-
           {{ osd_db_slot | default((replace_osd_scan.stdout | from_json).free | first) }}
 
+    # ceph-volume reuses a requested id only when the osdmap already marks it
+    # destroyed. down and out do not qualify, and the `osd new` error for that
+    # case ("already in use or does not exist") does not say so.
+    - name: Read the osdmap status of the requested id
+      ansible.builtin.command: ceph osd tree -f json
+      delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
+      register: replace_osd_tree
+      changed_when: false
+      check_mode: false
+      when: osd_id is defined
+
+    - name: Resolve the osdmap status of the requested id
+      ansible.builtin.set_fact:
+        replace_osd_id_status: >-
+          {{ ((replace_osd_tree.stdout | from_json).nodes
+              | selectattr('type', 'eq', 'osd')
+              | selectattr('id', 'eq', osd_id | int)
+              | map(attribute='status') | list + ['absent']) | first }}
+      when: osd_id is defined
+
+    - name: Assert the requested id is destroyed or absent
+      ansible.builtin.assert:
+        that:
+          - replace_osd_id_status in ['destroyed', 'absent']
+        fail_msg: >-
+          osd.{{ osd_id }} is {{ replace_osd_id_status }} in the osdmap, not
+          destroyed. Run `ceph orch osd rm {{ osd_id }} --replace` first.
+      when: osd_id is defined
+
     - name: Report the plan
       ansible.builtin.debug:
         msg: >-
-          {{ inventory_hostname }}: build an OSD on {{ osd_bay }}
-          ({{ replace_osd_dev.stdout }}) against
+          {{ inventory_hostname }}: build
+          {{ ('osd.' ~ osd_id) if osd_id is defined else 'a new OSD' }}
+          on {{ osd_bay }} ({{ replace_osd_dev.stdout }}) against
           {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }}
           (orphaned slots seen: {{ (replace_osd_scan.stdout | from_json).orphan }})
 
@@ -162,6 +195,30 @@
         shrink: false
         opts: "-Wy"
         state: present
+
+    # zap closes the slot's dm-crypt mapping itself, by the LV uuid it is named
+    # after, but it warns rather than stops when that close fails and then wipes
+    # the LV regardless. The one holder that survives an orphaned slot is an OSD
+    # process that lost its data disk and has not exited yet.
+    - name: Read the open count on the slot's dm-crypt mapping
+      ansible.builtin.shell: |
+        set -o pipefail
+        uuid=$(lvs --noheadings -o lv_uuid {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }} | tr -d ' ')
+        dmsetup info -c --noheadings -o open "$uuid" 2>/dev/null || echo 0
+      args:
+        executable: /bin/bash
+      register: replace_osd_slot_open
+      changed_when: false
+      check_mode: false
+
+    - name: Assert nothing holds the slot's dm-crypt mapping open
+      ansible.builtin.assert:
+        that:
+          - replace_osd_slot_open.stdout | trim | int == 0
+        fail_msg: >-
+          {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }} has a dm-crypt mapping with
+          open count {{ replace_osd_slot_open.stdout | trim }}. Find and stop the
+          holder before rebuilding; zapping under it would wipe a live block.db.
 
     # Unconditional so the deleted-slot and the zapped-slot cases converge on one
     # path. ceph-volume refuses a db device still carrying an old OSD's metadata,
@@ -221,6 +278,7 @@
             --keyring {{ replace_osd_staging }}/bootstrap-osd.keyring
             lvm create --dmcrypt --no-systemd
             --crush-device-class {{ osd_crush_device_class }}
+            {{ ('--osd-id ' ~ osd_id) if osd_id is defined else '' }}
             --data /dev/disk/by-path/{{ osd_bay }}
             --block.db {{ ceph_db_vg }}/db-slot{{ replace_osd_slot }}
           changed_when: true
@@ -247,6 +305,15 @@
           until: (replace_osd_created.stdout | from_json) | length > 0
           retries: 12
           delay: 10
+
+        - name: Assert the OSD kept the requested id
+          ansible.builtin.assert:
+            that:
+              - (replace_osd_created.stdout | from_json).keys() | first | int == osd_id | int
+            fail_msg: >-
+              Asked for osd.{{ osd_id }} and got
+              osd.{{ (replace_osd_created.stdout | from_json).keys() | first }}.
+          when: osd_id is defined
 
         - name: Read the new OSD's BlueStore metadata
           ansible.builtin.command: >-

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -61,6 +61,10 @@
   delay: 10
   when: inventory_hostname in groups['ceph_bootstrap']
   changed_when: false
+  # Read-only, so run it under --check too. Left to default it skips, `until`
+  # can never be satisfied, and every --check of this tag fails here after
+  # burning the full 30 retries.
+  check_mode: false
 
 # --- Step 2.5: Re-spec the monitoring stack (fabric bind + alert delivery) ---
 # cephadm auto-deployed the stack binding all interfaces and with NO alertmanager

--- a/ansible/ceph/tasks/health_gate.yml
+++ b/ansible/ceph/tasks/health_gate.yml
@@ -20,6 +20,9 @@
   register: _ceph_health_gate
   changed_when: false
   failed_when: false
+  # Read-only, so run it under --check too. Left to default the probe skips,
+  # the assert below sees no stdout, and a --check run loses the gate entirely.
+  check_mode: false
   run_once: true
   delegate_to: "{{ groups['ceph_bootstrap'][0] }}"
   when: (groups['ceph_bootstrap'] | default([]) | length) > 0


### PR DESCRIPTION
A replaced HDD on a spice node becomes an OSD again through `ansible/ceph/replace-osd.yml`: it takes the bay's by-path and an optional `osd_id`, derives the free `vg0` db slot, zaps it, drives `ceph-volume lvm create` with slot, id and crush class pinned, activates the daemon, and asserts from the new daemon's own report that block.db landed on the NVMe rather than colocated on the 22TB HDD. Re-runs against a populated bay are no-ops. The runbook keeps the one-way half (drain, `orch osd rm --replace`, the Hetzner ticket) and adds the path for when cephadm's `--replace` cannot finish because the cluster is not `active+clean`, which on spice is the normal case; the two `check_mode: false` edits let the read-only probes run under `--check`. Used for osd.35 on alyssa and osd.17 on alexus. See ansible/ceph/docs/runbooks/replace-disk.md and ansible/ceph/docs/runbooks/host-maintenance.md.

- `main` <!-- branch-stack -->
  - \#462 :point\_left:
