### PR TITLE
fix(api): tolerate concurrent first-time oidc sign-ins

### DIFF
--- a/packages/e2e/test/it-works.spec.ts
+++ b/packages/e2e/test/it-works.spec.ts
@@ -16,7 +16,7 @@ it('can connect to the orchestrator API', async () => {
 it('can load restic', async () => {
   await expect(version).resolves.toEqual(
     expect.objectContaining({
-      version: '0.19.0',
+      version: '0.19.1',
     }),
   );
 });

--- a/packages/yucca-api/src/repositories/connection.repository.ts
+++ b/packages/yucca-api/src/repositories/connection.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Insertable, Kysely } from 'kysely';
+import { Insertable, Kysely, sql } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { DB } from 'src/schema';
 import { ConnectionTable } from 'src/schema/tables/connection.table';
@@ -56,16 +56,29 @@ export class ConnectionRepository {
   }
 
   async getOrCreateDefault(userId: string) {
-    const existing = await this.db
-      .selectFrom('connections')
-      .selectAll()
-      .where('userId', '=', userId)
-      .where('type', '=', 'immich')
-      .orderBy('createdAt', 'asc')
-      .orderBy('id', 'asc')
-      .executeTakeFirst();
+    return this.db.transaction().execute(async (trx) => {
+      // Serialise per user: without this, two concurrent sign-ins can both
+      // miss the lookup below and each insert a default connection.
+      await sql`select pg_advisory_xact_lock(hashtextextended(${userId}, 0))`.execute(trx);
 
-    return existing ?? (await this.create({ userId, type: 'immich', name: 'Immich' }));
+      const existing = await trx
+        .selectFrom('connections')
+        .selectAll()
+        .where('userId', '=', userId)
+        .where('type', '=', 'immich')
+        .orderBy('createdAt', 'asc')
+        .orderBy('id', 'asc')
+        .executeTakeFirst();
+
+      return (
+        existing ??
+        (await trx
+          .insertInto('connections')
+          .values({ userId, type: 'immich', name: 'Immich' })
+          .returningAll()
+          .executeTakeFirstOrThrow())
+      );
+    });
   }
 
   async touchLastSeen(id: string) {

--- a/packages/yucca-api/src/repositories/user.repository.ts
+++ b/packages/yucca-api/src/repositories/user.repository.ts
@@ -9,8 +9,13 @@ import { UserTable } from 'src/schema/tables/user.table';
 export class UserRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
 
-  create(user: Insertable<UserTable>) {
-    return this.db.insertInto('users').values(user).returningAll().executeTakeFirstOrThrow();
+  upsertBySub(user: Insertable<UserTable>) {
+    return this.db
+      .insertInto('users')
+      .values(user)
+      .onConflict((oc) => oc.column('sub').doUpdateSet({ name: user.name, email: user.email }))
+      .returningAll()
+      .executeTakeFirstOrThrow();
   }
 
   getBySub(sub: string) {

--- a/packages/yucca-api/src/services/auth.service.spec.ts
+++ b/packages/yucca-api/src/services/auth.service.spec.ts
@@ -216,7 +216,7 @@ describe(AuthService.name, () => {
 
       env.ALLOWED_EMAIL_DOMAINS = ['example.test'];
       mocks.user.getBySub.mockResolvedValue(void 0);
-      mocks.user.create.mockResolvedValue(mockUser);
+      mocks.user.upsertBySub.mockResolvedValue(mockUser);
       mocks.oidc.callback.mockResolvedValue(claims as never);
       mocks.crypto.randomHex.mockReturnValue(accessToken as never);
 
@@ -378,7 +378,7 @@ describe(AuthService.name, () => {
 
     beforeEach(() => {
       mocks.user.getBySub.mockResolvedValue(void 0);
-      mocks.user.create.mockResolvedValue(mockUser);
+      mocks.user.upsertBySub.mockResolvedValue(mockUser);
     });
 
     it('should allow a new user whose email domain is allowed', async () => {
@@ -387,7 +387,16 @@ describe(AuthService.name, () => {
       await expect(sut.getOrCreateUser(claims)).resolves.toBe(mockUser);
 
       expect(mocks.userAllowlist.getByEmail).not.toHaveBeenCalled();
-      expect(mocks.user.create).toHaveBeenCalledWith({ sub: claims.sub, name: claims.name, email: claims.email });
+      expect(mocks.user.upsertBySub).toHaveBeenCalledWith({ sub: claims.sub, name: claims.name, email: claims.email });
+    });
+
+    it('should reject when a concurrent sign-in resolves to a disabled account', async () => {
+      env.ALLOWED_EMAIL_DOMAINS = ['example.com'];
+      mocks.user.upsertBySub.mockResolvedValue({ ...mockUser, disabled: true });
+
+      await expect(sut.getOrCreateUser(claims)).rejects.toThrowErrorMatchingInlineSnapshot(`"Account is disabled"`);
+
+      expect(mocks.connection.getOrCreateDefault).not.toHaveBeenCalled();
     });
 
     it('should allow a new user with an invited allowlist entry and mark it used', async () => {
@@ -413,7 +422,7 @@ describe(AuthService.name, () => {
       await expect(sut.getOrCreateUser(claims)).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Email is not allowed during the beta"`,
       );
-      expect(mocks.user.create).not.toHaveBeenCalled();
+      expect(mocks.user.upsertBySub).not.toHaveBeenCalled();
     });
 
     it('should allow a new user with a valid invite code and mark it used', async () => {
@@ -432,14 +441,14 @@ describe(AuthService.name, () => {
         `"Email is not allowed during the beta"`,
       );
       expect(mocks.userAllowlist.markUsed).not.toHaveBeenCalled();
-      expect(mocks.user.create).not.toHaveBeenCalled();
+      expect(mocks.user.upsertBySub).not.toHaveBeenCalled();
     });
 
     it('should reject a new user with no allowlist match', async () => {
       await expect(sut.getOrCreateUser(claims)).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Email is not allowed during the beta"`,
       );
-      expect(mocks.user.create).not.toHaveBeenCalled();
+      expect(mocks.user.upsertBySub).not.toHaveBeenCalled();
     });
 
     it('should let an existing user log in regardless of the allowlist', async () => {

--- a/packages/yucca-api/src/services/auth.service.ts
+++ b/packages/yucca-api/src/services/auth.service.ts
@@ -143,11 +143,15 @@ export class AuthService {
     } else {
       await this.assertEmailAllowed(claims.email.toLowerCase(), inviteCode);
 
-      user = await this.user.create({
+      user = await this.user.upsertBySub({
         sub: claims.sub,
         name: claims.name,
         email: claims.email,
       });
+
+      if (user.disabled) {
+        throw new UnauthorizedException('Account is disabled');
+      }
 
       await this.connection.getOrCreateDefault(user.id);
     }

--- a/packages/yucca-api/test/mocks.ts
+++ b/packages/yucca-api/test/mocks.ts
@@ -44,7 +44,7 @@ export const newSessionRepositoryMock = (): jest.Mocked<RepositoryInterface<Sess
 
 export const newUserRepositoryMock = (): jest.Mocked<RepositoryInterface<UserRepository>> => {
   return {
-    create: jest.fn(),
+    upsertBySub: jest.fn(),
     getByAccessToken: jest.fn(),
     getBySub: jest.fn(),
     getFeatureOverrides: jest.fn().mockResolvedValue([]),

--- a/packages/yucca-api/test/testUtils.ts
+++ b/packages/yucca-api/test/testUtils.ts
@@ -56,7 +56,7 @@ export const testUtils = {
     const connectionRepository = new ConnectionRepository(db);
     const cryptoRepository = new CryptoRepository();
 
-    const user = await userRepository.create({
+    const user = await userRepository.upsertBySub({
       name,
       email,
       sub,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,7 +695,7 @@ importers:
         version: 5.55.7(@typescript-eslint/types@8.52.0)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.3.5(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.52.0))(typescript@5.9.3)
+        version: 4.3.5(picomatch@4.0.5)(svelte@5.55.7(@typescript-eslint/types@8.52.0))(typescript@5.9.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18


### PR DESCRIPTION
getOrCreateUser looked an account up by sub and then inserted when the lookup missed, which is not atomic. Two sign-ins for the same subject can both miss and race to insert, and the users\_sub\_uq constraint turns the loser into a 500 with no session cookie, leaving the browser on an unauthenticated dashboard.

Upsert on sub so the loser folds into an update of the row the winner just wrote, and re-check disabled on that path.

This is what makes the two web e2e specs flake: both log in as `foo` through the same mock OIDC provider under parallel Playwright workers, so whichever loses the insert never renders `Backup Health`.

- `main` <!-- branch-stack -->
  - \#464 :point\_left:
