### PR TITLE
feat(o11y): add env/provider/region filters to the yucca dashboards

### DIFF
--- a/o11y/dashboards/yucca-father-kubernetes.json
+++ b/o11y/dashboards/yucca-father-kubernetes.json
@@ -888,6 +888,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {},
         "datasource": {
           "uid": "$datasource"
@@ -896,7 +950,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values(apiserver_request_total, cluster)",
+        "query": "label_values(apiserver_request_total{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/o11y/dashboards/yucca-father-kubernetes.json
+++ b/o11y/dashboards/yucca-father-kubernetes.json
@@ -894,6 +894,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -912,6 +915,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -929,6 +935,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-michael.json
+++ b/o11y/dashboards/yucca-michael.json
@@ -2738,6 +2738,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {},
         "datasource": {
           "uid": "$datasource"
@@ -2746,7 +2800,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values({__name__=\"s3.backend.healthy\"}, cluster)",
+        "query": "label_values({__name__=\"s3.backend.healthy\", env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/o11y/dashboards/yucca-michael.json
+++ b/o11y/dashboards/yucca-michael.json
@@ -2744,6 +2744,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -2762,6 +2765,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -2779,6 +2785,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-per-user.json
+++ b/o11y/dashboards/yucca-per-user.json
@@ -1858,6 +1858,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {},
         "datasource": {
           "uid": "$datasource"
@@ -1866,7 +1920,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values({__name__=~\"rgw_repository_size_bytes|blobs.uploaded_bytes\"}, cluster)",
+        "query": "label_values({__name__=~\"rgw_repository_size_bytes|blobs.uploaded_bytes\", env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/o11y/dashboards/yucca-per-user.json
+++ b/o11y/dashboards/yucca-per-user.json
@@ -1864,6 +1864,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -1882,6 +1885,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -1899,6 +1905,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-spice-blockdb-bluefs.json
+++ b/o11y/dashboards/yucca-spice-blockdb-bluefs.json
@@ -36,13 +36,67 @@
         "skipUrlSync": false
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "name": "cluster",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "query": "label_values(ceph_health_status, cluster)",
+        "query": "label_values(ceph_health_status{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "label": "Cluster",
         "refresh": 1,
         "hide": 0,

--- a/o11y/dashboards/yucca-spice-blockdb-bluefs.json
+++ b/o11y/dashboards/yucca-spice-blockdb-bluefs.json
@@ -42,6 +42,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -60,6 +63,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -77,6 +83,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-spice-ceph-health.json
+++ b/o11y/dashboards/yucca-spice-ceph-health.json
@@ -1138,6 +1138,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {},
         "datasource": {
           "uid": "$datasource"
@@ -1146,7 +1200,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values(ceph_health_status, cluster)",
+        "query": "label_values(ceph_health_status{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/o11y/dashboards/yucca-spice-ceph-health.json
+++ b/o11y/dashboards/yucca-spice-ceph-health.json
@@ -1144,6 +1144,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -1162,6 +1165,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -1179,6 +1185,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-spice-nodes.json
+++ b/o11y/dashboards/yucca-spice-nodes.json
@@ -1080,6 +1080,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {},
         "datasource": {
           "uid": "$datasource"
@@ -1088,7 +1142,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values(node_uname_info, cluster)",
+        "query": "label_values(node_uname_info{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/o11y/dashboards/yucca-spice-nodes.json
+++ b/o11y/dashboards/yucca-spice-nodes.json
@@ -1086,6 +1086,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -1104,6 +1107,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -1121,6 +1127,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-spice-recovery-backfill.json
+++ b/o11y/dashboards/yucca-spice-recovery-backfill.json
@@ -885,6 +885,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -903,6 +906,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -920,6 +926,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-spice-recovery-backfill.json
+++ b/o11y/dashboards/yucca-spice-recovery-backfill.json
@@ -879,6 +879,60 @@
         "skipUrlSync": false
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "name": "cluster",
         "label": "cluster",
         "type": "query",
@@ -886,7 +940,7 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "query": "label_values(ceph_health_status, cluster)",
+        "query": "label_values(ceph_health_status{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "current": {},
         "hide": 0,
         "refresh": 1,
@@ -895,7 +949,7 @@
         "regex": "",
         "sort": 1,
         "skipUrlSync": false,
-        "definition": "label_values(ceph_health_status, cluster)"
+        "definition": "label_values(ceph_health_status{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)"
       }
     ]
   },

--- a/o11y/dashboards/yucca-spice-rgw-capacity.json
+++ b/o11y/dashboards/yucca-spice-rgw-capacity.json
@@ -2770,6 +2770,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -2788,6 +2791,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -2805,6 +2811,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",

--- a/o11y/dashboards/yucca-spice-rgw-capacity.json
+++ b/o11y/dashboards/yucca-spice-rgw-capacity.json
@@ -2764,6 +2764,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "text": "spice",
           "value": "spice"
@@ -2773,7 +2827,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values(ceph_health_status, cluster)",
+        "query": "label_values(ceph_health_status{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "(.*)",
         "sort": 1,

--- a/o11y/dashboards/yucca-top-users.json
+++ b/o11y/dashboards/yucca-top-users.json
@@ -1257,6 +1257,60 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {},
         "datasource": {
           "uid": "$datasource"
@@ -1265,7 +1319,7 @@
         "label": "cluster",
         "name": "cluster",
         "options": [],
-        "query": "label_values({__name__=~\"rgw_repository_size_bytes|blobs.uploaded_bytes\"}, cluster)",
+        "query": "label_values({__name__=~\"rgw_repository_size_bytes|blobs.uploaded_bytes\", env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/o11y/dashboards/yucca-top-users.json
+++ b/o11y/dashboards/yucca-top-users.json
@@ -1263,6 +1263,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Env",
         "multi": true,
@@ -1281,6 +1284,9 @@
           "text": ["All"],
           "value": ["$__all"]
         },
+        "datasource": {
+          "uid": "$datasource"
+        },
         "includeAll": true,
         "label": "Provider",
         "multi": true,
@@ -1298,6 +1304,9 @@
           "selected": true,
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "uid": "$datasource"
         },
         "includeAll": true,
         "label": "Region",


### PR DESCRIPTION
Adds chained Env, Provider and Region template variables to the nine dashboards that have a cluster picker, built on the identity labels the shippers now stamp. The new variables narrow the cluster dropdown; panel expressions are untouched since cluster already uniquely scopes them. All three default to All, so dashboards render exactly as before until someone filters.

Variable queries are scoped to project=yucca so the dropdowns only offer yucca values on the Fleet datasource. The Env filter becomes useful once luke ships, since these dashboards deploy to both Grafanas. The fixed-purpose dashboards (overview, telemetry-pipeline, fabric-htz-fsn1) hardcode their clusters and are deliberately unchanged.

- `main` <!-- branch-stack -->
  - \#466 :point\_left:
