### PR TITLE
perf(net): raise gw envoy buffers

### DIFF
--- a/kubernetes/apps/prod/htz-fsn1/gw-internal.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-internal.yaml
@@ -38,9 +38,16 @@ spec:
         - name: yucca-michael
           port: 3010
 ---
-# Upstream buffer tuning for envoy→michael (the restore direction rides these);
-# lives here rather than gw-proxy/ because that tree is targetNamespace-forced
-# to envoy-system and this policy must sit beside its HTTPRoute in yucca.
+# Upstream buffer tuning for envoy→michael (both directions ride these: a backup
+# streams the request body through to michael, a restore streams the response
+# back); lives here rather than gw-proxy/ because that tree is
+# targetNamespace-forced to envoy-system and this policy must sit beside its
+# HTTPRoute in yucca.
+#
+# Raised to 16Mi 2026-08-12 to match the downstream bufferLimit in
+# gw-proxy/policies.yaml — leaving this at 4Mi would just move the gate from the
+# client side of the proxy to the michael side. Both routes are listed so the
+# internal listener is not left on Envoy's 32KiB default.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -51,5 +58,8 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: gw
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: gw-internal
   connection:
-    bufferLimit: 4Mi
+    bufferLimit: 16Mi

--- a/kubernetes/apps/prod/htz-fsn1/gw-internal.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-internal.yaml
@@ -44,10 +44,14 @@ spec:
 # targetNamespace-forced to envoy-system and this policy must sit beside its
 # HTTPRoute in yucca.
 #
-# Raised to 16Mi 2026-08-12 to match the downstream bufferLimit in
-# gw-proxy/policies.yaml — leaving this at 4Mi would just move the gate from the
-# client side of the proxy to the michael side. Both routes are listed so the
-# internal listener is not left on Envoy's 32KiB default.
+# Deliberately NOT raised alongside the downstream buffers in
+# gw-proxy/policies.yaml: this hop is HTTP/1.1 over the sub-millisecond fabric,
+# so 4Mi is already orders of magnitude past its BDP, and this is the term that
+# multiplies by concurrent stream count.
+#
+# gw-internal added to targetRefs 2026-08-12. EG builds one cluster per HTTPRoute
+# destination, so that route was running on the 32KiB default — 128x smaller than
+# the public path, and it is the path yuctl bench measures over the internal VIP.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -62,4 +66,4 @@ spec:
       kind: HTTPRoute
       name: gw-internal
   connection:
-    bufferLimit: 16Mi
+    bufferLimit: 4Mi

--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
@@ -3,14 +3,20 @@
 # EG defaults (64KiB stream / 1MiB conn windows, 32KiB buffers) needlessly
 # constrain per-connection throughput. ALPN deliberately untouched (h2 stays).
 #
-# Raised 2026-08-12. h2 puts every restic connection on ONE TCP connection, so
-# upload throughput is (smallest window on the path) / RTT. At the previous 4Mi
-# that is ~46 MB/s at the 90ms US->fsn1 RTT, and the client's own 4MiB
-# net.ipv4.tcp_wmem sits at the same figure, so both gate together. 16Mi lifts
-# the Envoy side to ~178 MB/s and leaves the client socket buffer as the only
-# remaining gate (raise net.ipv4.tcp_wmem on backup clients to collect it).
-# Kept at 16Mi rather than matching the 32Mi connection window because
-# bufferLimit is charged PER CONNECTION and the proxy pods have no memory limit.
+# Raised 2026-08-12, as HEADROOM rather than as a fix. h2 puts every restic
+# connection on ONE TCP connection, so the real ceiling is that connection's
+# min(socket buffer, cwnd) / RTT — measured at ~37 MB/s at the 90ms US->fsn1 RTT
+# with a client on Linux's default 4MiB net.ipv4.tcp_wmem, and h2 windows an
+# order of magnitude larger than these made no difference to it. So these values
+# buy nothing on their own; they stop Envoy becoming the next gate once client
+# tcp_wmem is raised. The throughput fix is ALPN (see the companion change).
+#
+# 64Mi connection window matches the kernel rcvbuf ceiling set for the workers in
+# tf/.../talos/talos.tf — past that the kernel binds first. 16Mi stream window
+# keeps 5 streams (restic's default rest.connections) able to fill it, and
+# bufferLimit >= streamWindow keeps the L4 watermark off the critical path.
+# bufferLimit is charged PER CONNECTION and these pods have no memory limit, so
+# it is deliberately not raised beyond the stream window.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
@@ -25,4 +31,4 @@ spec:
     bufferLimit: 16Mi
   http2:
     initialStreamWindowSize: 16Mi
-    initialConnectionWindowSize: 32Mi
+    initialConnectionWindowSize: 64Mi

--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
@@ -11,12 +11,15 @@
 # buy nothing on their own; they stop Envoy becoming the next gate once client
 # tcp_wmem is raised. The throughput fix is ALPN (see the companion change).
 #
-# 64Mi connection window matches the kernel rcvbuf ceiling set for the workers in
-# tf/.../talos/talos.tf — past that the kernel binds first. 16Mi stream window
-# keeps 5 streams (restic's default rest.connections) able to fill it, and
-# bufferLimit >= streamWindow keeps the L4 watermark off the critical path.
-# bufferLimit is charged PER CONNECTION and these pods have no memory limit, so
-# it is deliberately not raised beyond the stream window.
+# 64Mi connection window is sized against the kernel rcvbuf ceiling the pod's
+# netns will actually have; past that the kernel binds first. Note that ceiling
+# is NOT settable from the node — net.ipv4.tcp_* is per-netns and a fresh netns
+# gets kernel-computed defaults rather than the host's values, so it needs pod
+# securityContext.sysctls plus kubelet allowed-unsafe-sysctls. Untried so far.
+# 16Mi stream window keeps 5 streams (restic's default rest.connections) able to
+# fill the connection window, and bufferLimit >= streamWindow keeps the L4
+# watermark off the critical path. bufferLimit is charged PER CONNECTION and
+# these pods have no memory limit, so it is not raised beyond the stream window.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:

--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
@@ -2,6 +2,15 @@
 # HTTP/2 + buffer tuning for the gw (michael) listener, validated 2026-07-24:
 # EG defaults (64KiB stream / 1MiB conn windows, 32KiB buffers) needlessly
 # constrain per-connection throughput. ALPN deliberately untouched (h2 stays).
+#
+# Raised 2026-08-12. h2 puts every restic connection on ONE TCP connection, so
+# upload throughput is (smallest window on the path) / RTT. At the previous 4Mi
+# that is ~46 MB/s at the 90ms US->fsn1 RTT, and the client's own 4MiB
+# net.ipv4.tcp_wmem sits at the same figure, so both gate together. 16Mi lifts
+# the Envoy side to ~178 MB/s and leaves the client socket buffer as the only
+# remaining gate (raise net.ipv4.tcp_wmem on backup clients to collect it).
+# Kept at 16Mi rather than matching the 32Mi connection window because
+# bufferLimit is charged PER CONNECTION and the proxy pods have no memory limit.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
@@ -13,7 +22,7 @@ spec:
       kind: Gateway
       name: gw
   connection:
-    bufferLimit: 4Mi
+    bufferLimit: 16Mi
   http2:
-    initialStreamWindowSize: 4Mi
+    initialStreamWindowSize: 16Mi
     initialConnectionWindowSize: 32Mi

--- a/tf/deployment/prod/htz-fsn1/talos/talos.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/talos.tf
@@ -184,33 +184,10 @@ locals {
     }
   })
 
-  # Workers terminate the gw (michael/restic) listener, whose clients are a
-  # transatlantic ~90ms away. A TCP flow can only carry (socket buffer / RTT), and
-  # the kernel's 6MiB tcp_rmem ceiling caps one flow at ~66 MB/s at that RTT —
-  # which HTTP/2 makes the WHOLE backup, because it multiplexes every restic
-  # connection onto a single TCP connection. 64MiB moves that ceiling out of the
-  # way. These are autotuning CEILINGS, not allocations: the kernel only grows a
-  # buffer for a flow that is actually filling it, so the low-RTT fabric and Ceph
-  # traffic on these same nodes keep their small buffers.
-  #
-  # net.ipv4.* is per-network-namespace and a new netns is seeded from init_net,
-  # so pods pick these up — but only pods created AFTER the sysctl lands. The gw
-  # Envoy pods must be restarted before the ceiling applies to them.
-  worker_socket_buffer_patch = yamlencode({
-    machine = {
-      sysctls = {
-        "net.ipv4.tcp_rmem" = "4096 131072 67108864"
-        "net.ipv4.tcp_wmem" = "4096 16384 67108864"
-        "net.core.rmem_max" = "67108864"
-        "net.core.wmem_max" = "67108864"
-      }
-    }
-  })
-
   cp_base_patches = compact([local.hostdns_patch, local.cp_netbird_patch, local.cp_nodeip_patch, local.spegel_containerd_patch])
   # (install patch is PER-NODE — by disk serial — appended in controlplane.tf /
   # workers.tf, along with the bond/VLAN network patches.)
-  worker_base_patches = compact([local.hostdns_patch, local.worker_mayastor_patch, local.worker_volumes_patch, local.worker_netbird_patch, local.worker_nodeip_patch, local.spegel_containerd_patch, local.worker_socket_buffer_patch])
+  worker_base_patches = compact([local.hostdns_patch, local.worker_mayastor_patch, local.worker_volumes_patch, local.worker_netbird_patch, local.worker_nodeip_patch, local.spegel_containerd_patch])
 
   # ── Control-plane cluster config (same on every CP) ──────────────────────
   cp_cluster_patch = yamlencode({

--- a/tf/deployment/prod/htz-fsn1/talos/talos.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/talos.tf
@@ -184,10 +184,33 @@ locals {
     }
   })
 
+  # Workers terminate the gw (michael/restic) listener, whose clients are a
+  # transatlantic ~90ms away. A TCP flow can only carry (socket buffer / RTT), and
+  # the kernel's 6MiB tcp_rmem ceiling caps one flow at ~66 MB/s at that RTT —
+  # which HTTP/2 makes the WHOLE backup, because it multiplexes every restic
+  # connection onto a single TCP connection. 64MiB moves that ceiling out of the
+  # way. These are autotuning CEILINGS, not allocations: the kernel only grows a
+  # buffer for a flow that is actually filling it, so the low-RTT fabric and Ceph
+  # traffic on these same nodes keep their small buffers.
+  #
+  # net.ipv4.* is per-network-namespace and a new netns is seeded from init_net,
+  # so pods pick these up — but only pods created AFTER the sysctl lands. The gw
+  # Envoy pods must be restarted before the ceiling applies to them.
+  worker_socket_buffer_patch = yamlencode({
+    machine = {
+      sysctls = {
+        "net.ipv4.tcp_rmem" = "4096 131072 67108864"
+        "net.ipv4.tcp_wmem" = "4096 16384 67108864"
+        "net.core.rmem_max" = "67108864"
+        "net.core.wmem_max" = "67108864"
+      }
+    }
+  })
+
   cp_base_patches = compact([local.hostdns_patch, local.cp_netbird_patch, local.cp_nodeip_patch, local.spegel_containerd_patch])
   # (install patch is PER-NODE — by disk serial — appended in controlplane.tf /
   # workers.tf, along with the bond/VLAN network patches.)
-  worker_base_patches = compact([local.hostdns_patch, local.worker_mayastor_patch, local.worker_volumes_patch, local.worker_netbird_patch, local.worker_nodeip_patch, local.spegel_containerd_patch])
+  worker_base_patches = compact([local.hostdns_patch, local.worker_mayastor_patch, local.worker_volumes_patch, local.worker_netbird_patch, local.worker_nodeip_patch, local.spegel_containerd_patch, local.worker_socket_buffer_patch])
 
   # ── Control-plane cluster config (same on every CP) ──────────────────────
   cp_cluster_patch = yamlencode({


### PR DESCRIPTION
Raises the Envoy-side buffers on the restic upload path, and fixes an untuned route. **This is headroom plus a bug fix — expect no throughput change from it.** If you want throughput, merge #475.

## What changes

- `gw-h2-windows` (downstream, client→envoy): `bufferLimit` and `initialStreamWindowSize` 4Mi → 16Mi, `initialConnectionWindowSize` 32Mi → 64Mi
- `gw-buffers` (upstream, envoy→michael): **adds the `gw-internal` HTTPRoute**. `bufferLimit` stays at 4Mi

## Why no throughput change

h2 collapses every `rest.connections` onto **one** TCP connection — confirmed on the live prod backup: `rest.connections=16`, exactly **1** established TCP connection to `69.48.224.6:443`. With 16 streams against the existing 32Mi connection window the h2 layer already permitted ~32 MiB in flight (~373 MB/s at 90ms); it was never the binding term. The single TCP connection is, against the client's default 4MiB `net.ipv4.tcp_wmem`.

Measured at 90ms RTT, 20 connections — h2 windows an order of magnitude above this PR's values changed nothing until the client socket buffer moved:

| | MB/s |
|---|---|
| h2, 64Mi/16Mi server windows, default 4MiB client `tcp_wmem` | 37.4 |
| h2, same server windows, 64MiB client `tcp_wmem` | 277.4 |
| **h2 dropped from ALPN**, no buffer tuning at all | **374.7** |

So this lands for two narrower reasons:

1. **The `gw-internal` targetRef fix is a standalone bug.** EG builds one cluster per HTTPRoute destination, so that route ran on Envoy's 32KiB default — 128× smaller than the public path, and it is the path `yuctl bench` measures over the internal VIP. Benchmarks taken there were describing a different configuration than production.
2. **It stops Envoy becoming the next gate** once client-side socket buffers are raised.

## Why the upstream buffer stays at 4Mi

The envoy→michael hop is HTTP/1.1 (michael is a plain `&http.Server` with no h2c wrapper, and nothing sets `appProtocol`) over the sub-millisecond intra-cluster fabric. 4Mi is already orders of magnitude past that BDP, and it is the term that multiplies by concurrent stream count in the memory ceiling.

## Dropped: the Talos worker sysctl commit

This PR originally raised `net.ipv4.tcp_rmem`/`tcp_wmem` on the workers. **I've reverted it — it would most likely have been a no-op**, and I do not want an unverified machineconfig roll in a production PR.

`net.ipv4.tcp_*` is per-network-namespace and the gw Envoy pods are not `hostNetwork`. I tested namespace behaviour directly: a nested netns did **not** inherit its parent's value (12345678 did not carry through), it got the kernel-computed default. Setting it on the node therefore does not reach the pod. Doing this properly needs pod-level `securityContext.sysctls` on the Envoy deployment plus `allowed-unsafe-sysctls` on the kubelet — a cluster-wide relaxation on those workers, worth its own PR and its own argument.

The client-side `net.ipv4.tcp_wmem`, which is the term that actually binds today, is on the backup hosts and not in this repo either way.

## Open, not addressed here

The gw Envoy pods have **no memory requests or limits**, and `http2.maxConcurrentStreams` sits on EG's default of 100 — one client connection can fan out to 100 upstream connections × the 4Mi cluster buffer. Capping it (~32) is the cheapest memory guard available and would make a buffer increase net memory-negative at the tail. Pre-existing exposure, left out to keep this scoped.

## Validation

`mise k8s:validate` → `k8s surface: ALL VALID`. Not applied anywhere; no staging equivalent exists (austin has no `gw` Gateway — michael rides the shared app gateway there).

## Relationship to #475

Independent, both off `main`. They edit adjacent lines of the same file, so whichever merges second needs a trivial conflict resolution.