### PR TITLE
perf(net): pin gw alpn to http/1.1

### DIFF
--- a/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
+++ b/kubernetes/apps/prod/htz-fsn1/gw-proxy/policies.yaml
@@ -1,7 +1,19 @@
 ---
 # HTTP/2 + buffer tuning for the gw (michael) listener, validated 2026-07-24:
 # EG defaults (64KiB stream / 1MiB conn windows, 32KiB buffers) needlessly
-# constrain per-connection throughput. ALPN deliberately untouched (h2 stays).
+# constrain per-connection throughput.
+#
+# ALPN pinned to http/1.1 2026-08-12, reversing the earlier "h2 stays" call.
+# restic runs its own connection pool (-o rest.connections=N) and assumes each
+# concurrent operation gets its own TCP connection. h2 multiplexes all N onto
+# ONE connection, so N stopped meaning anything: prod ran rest.connections=16
+# against exactly 1 established TCP connection, and throughput collapsed to one
+# connection's window/RTT. ALPN is negotiated, so pinning it here makes clients
+# fall back to HTTP/1.1 with no client-side change. Measured at 90ms RTT with a
+# stock restic: 10.9 -> 374.7 MB/s at 20 connections.
+#
+# The http2 block below is inert while h2 is not negotiated. It is kept as a
+# safety net for anyone who restores h2 without re-deriving these numbers.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
@@ -12,6 +24,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: gw
+  tls:
+    alpnProtocols:
+      - http/1.1
   connection:
     bufferLimit: 4Mi
   http2:


### PR DESCRIPTION
One field. Reverses the `# ALPN deliberately untouched (h2 stays)` call, which turns out to be the whole bottleneck on the restic upload path.

```yaml
  tls:
    alpnProtocols:
      - http/1.1
```

## The problem

restic runs its own connection pool and assumes each concurrent operation gets its own TCP connection. HTTP/2 multiplexes all of them onto **one**, so `-o rest.connections=N` silently stopped meaning anything — and upload throughput became one connection's flow-control window ÷ RTT.

Confirmed on the live prod backup: started with `rest.connections=16`, holding exactly **1** established TCP connection to `69.48.224.6:443` (`GW_VIP`).

ALPN is negotiated, so pinning it server-side makes clients fall back to HTTP/1.1 **with no client-side change and no restic patch**.

## Measured

netem testbed, real kernel TCP, 90ms RTT, 3 GiB incompressible source, stock unpatched restic + rest-server:

|                                  | 5 conns   | 20 conns  | 40 conns  | TCP conns |
| -------------------------------- | --------- | --------- | --------- | --------- |
| h2 (today)                       | 10.9      | 10.9      | —         | **1**     |
| h2 + windows raised to 64/16 MiB | 37.0      | 37.4      | —         | **1**     |
| **h2 out of ALPN (this PR)**     | **133.3** | **374.7** | **402.0** | **20**    |

Note rows 1 and 2: adding connections changes nothing while h2 is negotiated, tuned windows or not. Raising windows only moves the cap from the h2 window to the single TCP connection.

Also verified the h2 ceiling tracks `1 MiB ÷ RTT` across an 8× latency range (45.5 / 23.4 / 10.6 / 6.1 MB/s at 20 / 40 / 90 / 160 ms), so this is a confirmed mechanism, not a correlation.

## Risk

Low, and easy to reverse.

- The `gw` Gateway is dedicated to michael/restic — it fronts exactly one backend (`yucca-michael:3010`) via the `gw` and `gw-internal` HTTPRoutes. No other workload is affected.
- restic gets nothing from h2; it is not a browser and issues no concurrent small requests that benefit from multiplexing.
- The policy has no `sectionName`, so this hits the public and internal listeners together — there is no way to canary one against the other with the current shape.
- Revert = delete four lines.

The `http2` block is left in place. It is inert while h2 is not negotiated, and it is a safety net if anyone restores h2 later without re-deriving the numbers.

## Relationship to #474

Independent — both are off `main`, take either first. They edit adjacent lines of the same file, so **whichever merges second will need a trivial conflict resolution.**

If this merges, #474 becomes largely redundant for throughput: it is worth \~25 → \~37 MB/s, this is worth \~25 → \~375. #474's fix to the untuned `gw-internal` upstream route still stands on its own merit.

## Validation

`mise k8s:validate` → `k8s surface: ALL VALID`. `spec.tls.alpnProtocols` confirmed present in the Envoy Gateway 1.7.0 CRD schema.

Worth confirming after rollout:

```
curl -sI --http2 https://<GW_HOST>/ -o /dev/null -w '%{http_version}\n'   # expect 1.1
```

- `main` <!-- branch-stack -->
  - \#475 :point\_left:
