### PR TITLE
feat(ceph): install hdparm on every ceph node

### DIFF
--- a/ansible/ceph/roles/baseline/defaults/main.yml
+++ b/ansible/ceph/roles/baseline/defaults/main.yml
@@ -47,6 +47,7 @@ baseline_podman_packages:
 # Diagnostic and ops toolset
 baseline_diag_packages:
   - smartmontools
+  - hdparm
   - ipmitool
   - lsscsi
   - pciutils


### PR DESCRIPTION
Every ceph node carries `hdparm`, declared in `baseline_diag_packages` next to `smartmontools`. Applied to all 48 spice nodes with `baseline.yml --tags packages`. It is there to read and set the drives' volatile write cache: the fleet's HDDs run write-back today, and BlueStore's per-commit flush was measured on spice-ceph-alexus at \~109 flushes/s x 7 ms per drive, which is the ceiling on backfill and client write throughput per OSD; the Ceph hardware guidance is to disable that cache. This PR only installs the tool. Any cache change is a separate, benchmarked decision.

- `main` <!-- branch-stack -->
  - \#479 :point\_left:
