### PR TITLE
fix(ci): point prettierignore at the moved yuctl warp manifests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -38,10 +38,10 @@ tf/
 charts/
 
 # yuctl warp manifests: Go-templated YAML embedded into the binary (//go:embed
-# in internal/warp/session.go). Worth ignoring rather than fixing up, because
+# in fleet/warp/session.go). Worth ignoring rather than fixing up, because
 # prettier --write rewrites `{{ .Name }}` to `{ { .Name } }` (legal YAML, read
 # as a nested flow mapping) and text/template then emits it literally.
-packages/yuctl/internal/warp/manifests/
+packages/yuctl/fleet/warp/manifests/
 
 # Grafana dashboard exports: machine-generated JSON, round-tripped through
 # the Grafana UI — not worth format churn.


### PR DESCRIPTION
`.prettierignore` names the yuctl warp manifests at their post-#485 path, `packages/yuctl/fleet/warp/manifests/`. #485 moved the package from `internal/warp` to `fleet/warp` and the ignore still pointed at the old directory, so `mise check` parses the Go-templated `deployment.yaml` (`{{ .Name }}`) as YAML and the `Checks & Unit Tests` job has been red on main since `b7bbe2e8` and on every PR rebased onto it. The comment's `//go:embed` pointer moves with it.

- `main` <!-- branch-stack -->
  - \#486 :point\_left:
