### PR TITLE
fix(ceph): deliver recovery progress and repeat chronic alerts every 12h

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/files/custom_alerts.yml
+++ b/ansible/ceph/roles/ceph_deploy/files/custom_alerts.yml
@@ -11,9 +11,10 @@ groups:
       # a rebuilt 22 TB OSD backfills for more than a day. Ceph itself reports
       # those PGs as misplaced, not as a warning. This alert is true, per pool,
       # exactly while that pool's shards are moving, so a pool whose unclean
-      # PGs have nothing moving them still warns; the info severity keeps it
-      # off the operator route, it exists to inhibit. The metadata join gives
-      # it the same labels as the stock rule. keep_firing_for covers the
+      # PGs have nothing moving them still warns. The operator route for the
+      # chronic alerts (alertmanager override in tasks/monitoring.yml) carries
+      # it at a 12h repeat. The metadata join gives it the same labels as the
+      # stock rule. keep_firing_for covers the
       # hand-off gaps between one PG finishing and the next reservation being
       # granted, so the inhibition does not flap.
       - alert: CephRecoveryInProgress

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -233,8 +233,15 @@
         # that pool's CephPGsUnclean, which otherwise fires for the whole of a
         # backfill: more than a day per rebuilt 22 TB OSD, on PGs Ceph itself
         # reports as misplaced. A pool with unclean PGs and nothing moving them
-        # still warns. The operator route takes only warning and critical, so
-        # the source alert ends at the dashboard; no stock rule carries info.
+        # still warns.
+        #
+        # Two operator routes. The first takes the chronic, slow-moving alerts
+        # (recovery in progress, unclean, not scrubbed) at a 12h repeat: each
+        # still notifies on start and on resolve, but a day-long backfill or a
+        # week-long scrub catch-up is a handful of messages, not one an hour.
+        # The second takes every other warning and critical at the stock 1h.
+        # Info alerts outside the first route stop at the dashboard; no stock
+        # rule carries info.
         OVERRIDES.append({
             "service": "alertmanager",
             "template": "alertmanager/alertmanager.yml.j2",
@@ -250,6 +257,13 @@
                     "find": "      receiver: 'ceph-dashboard'\n",
                     "replace": "      receiver: 'ceph-dashboard'\n"
                                "      continue: true\n"
+                               "    - group_by: ['alertname', 'pool_id']\n"
+                               "      group_wait: 10s\n"
+                               "      group_interval: 10s\n"
+                               "      repeat_interval: 12h\n"
+                               "      receiver: 'default'\n"
+                               "      matchers:\n"
+                               "        - alertname =~ \"CephRecoveryInProgress|CephPGsUnclean|CephPGNotScrubbed|CephPGNotDeepScrubbed\"\n"
                                "    - group_by: ['alertname', 'pool_id']\n"
                                "      group_wait: 10s\n"
                                "      group_interval: 10s\n"


### PR DESCRIPTION
`CephRecoveryInProgress` now reaches the operator route, and the chronic, slow-moving alerts (`CephRecoveryInProgress`, `CephPGsUnclean`, `CephPGNotScrubbed`, `CephPGNotDeepScrubbed`) repeat every 12h instead of every hour: each still notifies on start and on resolve, so a day-long backfill or a week-long scrub catch-up is a handful of messages rather than one an hour. The derived alertmanager override gains a second operator route matching those four names at `repeat_interval: 12h`, placed ahead of the stock-cadence `severity =~ "warning|critical"` route; everything else keeps the 1h repeat and no stock rule carries info. Derived against the shipped 20.2.2 template the config passes `amtool check-config` (0.28.1) and `amtool config routes test` delivers all four to `ceph-dashboard,default`.

- `main` <!-- branch-stack -->
  - \#487 :point\_left:
