### PR TITLE
feat(emails): mailpit + mock-postmark local dev stack

### DIFF
--- a/.mise/tasks/k8s/validate
+++ b/.mise/tasks/k8s/validate
@@ -10,10 +10,10 @@
 set -euo pipefail
 
 # Charts are role-grouped: apps/* (services), platform/* (operators/CRs),
-# lib/yucca-common (shared library), dev/mock-oidc (dev-only). Paths below are
+# lib/yucca-common (shared library), dev/* (dev-only). Paths below are
 # relative to charts/.
-LIB_CONSUMERS=(apps/yucca-api apps/yucca-admin-api apps/yucca-metrics-worker apps/web apps/meta apps/michael dev/mock-oidc)
-ALL_CHARTS=(apps/yucca-api apps/yucca-admin-api apps/yucca-metrics-worker apps/web apps/meta apps/michael dev/mock-oidc platform/cnpg-cluster platform/ceph-objectuser platform/rook-ceph-cluster)
+LIB_CONSUMERS=(apps/yucca-api apps/yucca-admin-api apps/yucca-metrics-worker apps/web apps/meta apps/michael dev/mock-oidc dev/mock-postmark dev/mailpit)
+ALL_CHARTS=(apps/yucca-api apps/yucca-admin-api apps/yucca-metrics-worker apps/web apps/meta apps/michael dev/mock-oidc dev/mock-postmark dev/mailpit platform/cnpg-cluster platform/ceph-objectuser platform/rook-ceph-cluster)
 
 echo "==> helm dependency build (yucca-common consumers)"
 for c in "${LIB_CONSUMERS[@]}"; do

--- a/Tiltfile
+++ b/Tiltfile
@@ -269,13 +269,32 @@ docker_build(
     ],
 )
 
+# Same config-only posture as mock-oidc: a plain build, reconfigured through
+# Helm values.
+docker_build(
+    'mock-postmark-provider',
+    context='.',
+    dockerfile='packages/mock-postmark-provider/Dockerfile',
+    only=[
+        './pnpm-workspace.yaml',
+        './pnpm-lock.yaml',
+        './package.json',
+        './.npmrc',
+        './packages/mock-postmark-provider',
+    ],
+    ignore=[
+        '**/node_modules',
+        '**/dist',
+    ],
+)
+
 # ---------------------------------------------------------------------------
 # First-party Helm charts that depend on the yucca-common library need their
 # subchart snapshot built before `helm upgrade` can render them.
 # ---------------------------------------------------------------------------
 local_resource(
     'helm-deps',
-    cmd='rm -rf charts/apps/yucca-api/charts charts/apps/yucca-admin-api/charts charts/apps/yucca-metrics-worker/charts charts/apps/web/charts charts/apps/meta/charts charts/apps/michael/charts charts/dev/mock-oidc/charts && for d in charts/apps/yucca-api charts/apps/yucca-admin-api charts/apps/yucca-metrics-worker charts/apps/web charts/apps/meta charts/apps/michael charts/dev/mock-oidc; do (cd $d && helm dependency build); done',
+    cmd='rm -rf charts/apps/yucca-api/charts charts/apps/yucca-admin-api/charts charts/apps/yucca-metrics-worker/charts charts/apps/web/charts charts/apps/meta/charts charts/apps/michael/charts charts/dev/mock-oidc/charts charts/dev/mock-postmark/charts charts/dev/mailpit/charts && for d in charts/apps/yucca-api charts/apps/yucca-admin-api charts/apps/yucca-metrics-worker charts/apps/web charts/apps/meta charts/apps/michael charts/dev/mock-oidc charts/dev/mock-postmark charts/dev/mailpit; do (cd $d && helm dependency build); done',
     deps=[
         'charts/apps/yucca-api',
         'charts/apps/yucca-admin-api',
@@ -284,6 +303,8 @@ local_resource(
         'charts/apps/meta',
         'charts/apps/michael',
         'charts/dev/mock-oidc',
+        'charts/dev/mock-postmark',
+        'charts/dev/mailpit',
         'charts/lib/yucca-common',
     ],
     # `helm dependency build` rewrites these; if Tilt watches them we re-enter
@@ -322,6 +343,8 @@ APP_WIRING = {
     'yucca-meta':             {'build': None,                 'deps': []},
     'yucca-michael':          {'build': 'michael',            'deps': ['yucca-object-user'], 'dev_keypair': True},
     'yucca-mock-oidc':        {'build': 'mock-oidc-provider', 'deps': []},
+    'yucca-mailpit':          {'build': None,                 'deps': []},
+    'yucca-mock-postmark':    {'build': 'mock-postmark-provider', 'deps': ['yucca-mailpit']},
     'yucca-database':         {'build': None,                 'deps': ['cloudnative-pg']},
     # The CephObjectStoreUser creates no pods (just a Secret once Rook mints the
     # RGW user), so Tilt's pod tracking would hang at "pending". Mark ready on
@@ -515,6 +538,8 @@ kubectl port-forward -n yucca svc/yucca-web 5173:5173 &
 kubectl port-forward -n yucca svc/yucca-meta 8081:8080 &
 kubectl port-forward -n yucca svc/yucca-michael 3010:3010 &
 kubectl port-forward -n yucca svc/yucca-mock-oidc 8092:8092 &
+kubectl port-forward -n yucca svc/yucca-mailpit 8025:8025 &
+kubectl port-forward -n yucca svc/yucca-mock-postmark 8093:8093 &
 kubectl port-forward -n rook-ceph svc/rook-ceph-rgw-yucca 9000:80 &
 kubectl port-forward -n yucca svc/victoria-metrics 8428:8428 &
 kubectl port-forward -n yucca svc/victoria-logs 9428:9428 &
@@ -528,6 +553,8 @@ wait''',
         link('http://localhost:3010', 'michael'),
         link('http://localhost:8081/.well-known/yucca.json', 'meta (.well-known)'),
         link('http://localhost:8092', 'mock-oidc'),
+        link('http://localhost:8025', 'mailpit (inbox)'),
+        link('http://localhost:8093', 'mock-postmark'),
         link('http://localhost:9000', 'ceph rgw (s3)'),
         link('http://localhost:8428', 'victoria-metrics'),
         link('http://localhost:9428', 'victoria-logs'),

--- a/charts/dev/mailpit/Chart.yaml
+++ b/charts/dev/mailpit/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: mailpit
+description: Mailpit inbox for local dev — catches everything mock-postmark delivers
+type: application
+version: 0.1.0
+appVersion: "1.30.7"
+dependencies:
+  - name: yucca-common
+    version: 0.2.0
+    repository: "file://../../lib/yucca-common"

--- a/charts/dev/mailpit/templates/deployment.yaml
+++ b/charts/dev/mailpit/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- include "yucca-common.deployment" . }}

--- a/charts/dev/mailpit/templates/service.yaml
+++ b/charts/dev/mailpit/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "yucca-common.service" . }}

--- a/charts/dev/mailpit/values.yaml
+++ b/charts/dev/mailpit/values.yaml
@@ -1,0 +1,28 @@
+replicas: 1
+
+# Stable in-cluster name, independent of the Helm release name (dev == prod).
+# mock-postmark delivers here; e2e assertions read the message API.
+fullnameOverride: yucca-mailpit
+
+image:
+  repository: axllent/mailpit
+  tag: v1.30.7@sha256:d5ecbb067db3705fa953d79e1b7f81ef84038df67aba6c52825d8c02a1ea748a
+  pullPolicy: IfNotPresent
+
+# 8025 serves both the web inbox and the REST API (SMTP on 1025 stays
+# unexposed — delivery arrives over the HTTP send API).
+ports:
+  - name: http
+    containerPort: 8025
+    servicePort: 8025
+
+service:
+  type: ClusterIP
+
+startupProbe:
+  httpGet: { path: /readyz, port: http }
+  periodSeconds: 2
+  failureThreshold: 60
+readinessProbe:
+  httpGet: { path: /readyz, port: http }
+  periodSeconds: 10

--- a/charts/dev/mock-postmark/Chart.yaml
+++ b/charts/dev/mock-postmark/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: mock-postmark
+description: Mock Postmark API for local dev (homegrown packages/mock-postmark-provider)
+type: application
+version: 0.1.0
+appVersion: "0.0.1"
+dependencies:
+  - name: yucca-common
+    version: 0.2.0
+    repository: "file://../../lib/yucca-common"

--- a/charts/dev/mock-postmark/templates/deployment.yaml
+++ b/charts/dev/mock-postmark/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- include "yucca-common.deployment" . }}

--- a/charts/dev/mock-postmark/templates/service.yaml
+++ b/charts/dev/mock-postmark/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "yucca-common.service" . }}

--- a/charts/dev/mock-postmark/values.yaml
+++ b/charts/dev/mock-postmark/values.yaml
@@ -1,0 +1,34 @@
+replicas: 1
+
+# Stable in-cluster name, independent of the Helm release name (dev == prod).
+# yucca-admin-api points POSTMARK_API_URL here in dev.
+fullnameOverride: yucca-mock-postmark
+
+image:
+  repository: k3d-registry.localhost:5000/mock-postmark-provider
+  tag: dev
+  pullPolicy: IfNotPresent
+
+# Container listens on 80 (see packages/mock-postmark-provider); exposed
+# in-cluster and via port-forward as 8093.
+ports:
+  - name: http
+    containerPort: 80
+    servicePort: 8093
+
+service:
+  type: ClusterIP
+
+env:
+  - name: PORT
+    value: "80"
+  - name: MAILPIT_URL
+    value: http://yucca-mailpit:8025
+
+startupProbe:
+  httpGet: { path: /health, port: http }
+  periodSeconds: 2
+  failureThreshold: 60
+readinessProbe:
+  httpGet: { path: /health, port: http }
+  periodSeconds: 10

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,26 @@ services:
       retries: 30
       start_period: 5s
 
+  mailpit:
+    image: axllent/mailpit:v1.30.7@sha256:d5ecbb067db3705fa953d79e1b7f81ef84038df67aba6c52825d8c02a1ea748a
+    ports:
+      - 8025:8025
+
+  mock-postmark-provider:
+    build:
+      context: .
+      dockerfile: packages/mock-postmark-provider/Dockerfile
+    environment:
+      MAILPIT_URL: http://mailpit:8025
+    ports:
+      - 8093:80
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost/health > /dev/null']
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+
   victoria-metrics:
     image: victoriametrics/victoria-metrics:latest@sha256:dc030542eb0cd262287c9ec32e5867f8dcccc0efd5906c10f7fc8176c53d34d7
     ports:

--- a/kubernetes/apps/dev/local/yucca/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ./object-user/ks.yaml
   - ./metrics-object-user/ks.yaml
   - ./mock-oidc/ks.yaml
+  - ./mailpit/ks.yaml
+  - ./mock-postmark/ks.yaml
   - ./victoria-metrics/ks.yaml
   - ./victoria-logs/ks.yaml
   - ./michael/ks.yaml

--- a/kubernetes/apps/dev/local/yucca/mailpit/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/mailpit/app/helmrelease.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: yucca-mailpit
+  namespace: yucca
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: charts/dev/mailpit
+      sourceRef:
+        kind: GitRepository
+        name: yucca
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # DEV ONLY. Prod sends through the real Postmark — there is nothing to
+    # deploy there; this inbox exists so dev/e2e can read what was sent.
+    fullnameOverride: yucca-mailpit

--- a/kubernetes/apps/dev/local/yucca/mailpit/app/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/mailpit/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/dev/local/yucca/mailpit/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/mailpit/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: yucca-mailpit
+  namespace: flux-system
+spec:
+  targetNamespace: yucca
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: yucca-mailpit
+  path: ./kubernetes/apps/dev/local/yucca/mailpit/app
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: yucca

--- a/kubernetes/apps/dev/local/yucca/mock-postmark/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/local/yucca/mock-postmark/app/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: yucca-mock-postmark
+  namespace: yucca
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: charts/dev/mock-postmark
+      sourceRef:
+        kind: GitRepository
+        name: yucca
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # DEV ONLY. Prod points POSTMARK_API_URL at the real Postmark instead of
+    # deploying this mock.
+    fullnameOverride: yucca-mock-postmark
+    image:
+      repository: ghcr.io/immich-app/yucca/mock-postmark-provider # TODO: confirm prod registry
+      tag: 0.0.1

--- a/kubernetes/apps/dev/local/yucca/mock-postmark/app/kustomization.yaml
+++ b/kubernetes/apps/dev/local/yucca/mock-postmark/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/dev/local/yucca/mock-postmark/ks.yaml
+++ b/kubernetes/apps/dev/local/yucca/mock-postmark/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: yucca-mock-postmark
+  namespace: flux-system
+spec:
+  targetNamespace: yucca
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: yucca-mock-postmark
+  path: ./kubernetes/apps/dev/local/yucca/mock-postmark/app
+  prune: true
+  wait: true
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: yucca

--- a/packages/mock-postmark-provider/Dockerfile
+++ b/packages/mock-postmark-provider/Dockerfile
@@ -1,0 +1,21 @@
+ARG ALPINE_VERSION=3.23
+
+FROM node:25-alpine${ALPINE_VERSION} AS builder
+WORKDIR /build
+RUN npm install -g pnpm@10.28.1
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/mock-postmark-provider/package.json ./packages/mock-postmark-provider/
+RUN pnpm install --frozen-lockfile --filter mock-postmark-provider
+
+COPY packages/mock-postmark-provider ./packages/mock-postmark-provider
+RUN pnpm --filter mock-postmark-provider build
+RUN pnpm --filter mock-postmark-provider deploy /deploy --prod --legacy
+
+FROM node:25-alpine${ALPINE_VERSION}
+WORKDIR /usr/src/app
+COPY --from=builder /deploy ./
+USER node
+ENV NODE_ENV=production
+EXPOSE 80
+CMD ["node", "dist/index.js"]

--- a/packages/mock-postmark-provider/package.json
+++ b/packages/mock-postmark-provider/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mock-postmark-provider",
+  "version": "0.30.1",
+  "description": "In-repo Postmark API mock for dev and e2e tests, delivering into Mailpit",
+  "private": true,
+  "license": "UNLICENSED",
+  "type": "module",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "start:dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/mock-postmark-provider/src/env.ts
+++ b/packages/mock-postmark-provider/src/env.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+const schema = z.object({
+  PORT: z.coerce.number().default(80),
+  MAILPIT_URL: z.url().default('http://localhost:8025'),
+});
+
+export const env = schema.parse(process.env);

--- a/packages/mock-postmark-provider/src/index.ts
+++ b/packages/mock-postmark-provider/src/index.ts
@@ -1,0 +1,122 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { z } from 'zod';
+import { env } from './env.js';
+
+const messageSchema = z.object({
+  From: z.string(),
+  To: z.string(),
+  Subject: z.string(),
+  HtmlBody: z.string().optional(),
+  TextBody: z.string().optional(),
+  Tag: z.string().optional(),
+  MessageStream: z.string().optional(),
+});
+
+type PostmarkMessage = z.infer<typeof messageSchema>;
+
+const parseAddress = (address: string) => {
+  const match = address.match(/^\s*(.*?)\s*<([^>]+)>\s*$/);
+  return match ? { Name: match[1], Email: match[2] } : { Name: '', Email: address.trim() };
+};
+
+const deliverToMailpit = async (message: PostmarkMessage) => {
+  const response = await fetch(new URL('/api/v1/send', env.MAILPIT_URL), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      From: parseAddress(message.From),
+      To: message.To.split(',').map((address) => parseAddress(address)),
+      Subject: message.Subject,
+      HTML: message.HtmlBody ?? '',
+      Text: message.TextBody ?? '',
+      Tags: message.Tag ? [message.Tag] : [],
+      Headers: { 'X-Message-Stream': message.MessageStream ?? 'outbound' },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Mailpit send failed: ${response.status} ${response.statusText} — ${await response.text()}`);
+  }
+  const { ID } = (await response.json()) as { ID: string };
+  return ID;
+};
+
+const sendOne = async (message: unknown) => {
+  const parsed = messageSchema.safeParse(message);
+  if (!parsed.success) {
+    return { ErrorCode: 300, Message: `Invalid request: ${parsed.error.message}` };
+  }
+
+  try {
+    const id = await deliverToMailpit(parsed.data);
+    return {
+      To: parsed.data.To,
+      SubmittedAt: new Date().toISOString(),
+      MessageID: id,
+      ErrorCode: 0,
+      Message: 'OK',
+    };
+  } catch (error) {
+    return { To: parsed.data.To, ErrorCode: 300, Message: `${error}` };
+  }
+};
+
+const readBody = (request: IncomingMessage): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let data = '';
+    request.on('data', (chunk) => (data += chunk));
+    request.on('end', () => resolve(data));
+    request.on('error', reject);
+  });
+
+const respond = (response: ServerResponse, status: number, body: unknown) => {
+  response.writeHead(status, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(body));
+};
+
+const server = createServer((request, response) => {
+  handle(request, response).catch((error) => {
+    console.error(error);
+    respond(response, 500, { ErrorCode: 500, Message: `${error}` });
+  });
+});
+
+async function handle(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const path = new URL(request.url ?? '/', 'http://localhost').pathname;
+
+  if (request.method === 'GET' && path === '/health') {
+    respond(response, 200, { status: 'ok' });
+    return;
+  }
+
+  if (request.method !== 'POST' || (path !== '/email' && path !== '/email/batch')) {
+    respond(response, 404, { ErrorCode: 404, Message: `No such endpoint: ${request.method} ${path}` });
+    return;
+  }
+
+  if (!request.headers['x-postmark-server-token']) {
+    respond(response, 401, { ErrorCode: 10, Message: 'No Account or Server API tokens were supplied.' });
+    return;
+  }
+
+  const body: unknown = JSON.parse(await readBody(request));
+
+  if (path === '/email') {
+    const result = await sendOne(body);
+    respond(response, result.ErrorCode === 0 ? 200 : 422, result);
+    return;
+  }
+
+  if (!Array.isArray(body)) {
+    respond(response, 422, { ErrorCode: 300, Message: 'Batch payload must be an array' });
+    return;
+  }
+  const results = [];
+  for (const message of body) {
+    results.push(await sendOne(message));
+  }
+  respond(response, 200, results);
+}
+
+server.listen(env.PORT, () => {
+  console.log(`mock-postmark-provider listening on :${env.PORT}, delivering to ${env.MAILPIT_URL}`);
+});

--- a/packages/mock-postmark-provider/tsconfig.json
+++ b/packages/mock-postmark-provider/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "declaration": false,
+    "removeComments": true,
+    "target": "ES2023",
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,22 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/mock-postmark-provider:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.5
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.2.1
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/restic-api:
     dependencies:
       '@aws-sdk/client-s3':


### PR DESCRIPTION
In-repo Postmark API mock delivering into a Mailpit inbox, wired into compose, charts/dev, the k3d overlay and Tilt (UI on :8025, mock on :8093).

- `main` <!-- branch-stack -->
  - \#489
    - \#490
      - \#491 :point\_left:
        - \#492
          - \#493
