### PR TITLE
feat(infra): plumb postmark config into staging and prod

### DIFF
--- a/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
+++ b/kubernetes/apps/base/yucca-admin-api/helmrelease.yaml
@@ -60,3 +60,9 @@ spec:
         value: ${LEGACY_STORAGE_CLUSTER_CODE}
       - name: OTEL_METRICS
         value: http://${VMAGENT_OTLP}/opentelemetry/v1/metrics
+      # Invite emails: real Postmark (the API URL default), token from the
+      # TF-provisioned Secret above; links point at the public web app.
+      - name: WEB_BASE_URL
+        value: https://${APP_DOMAIN}
+      - name: EMAIL_FROM_ADDRESS
+        value: ${EMAIL_FROM_ADDRESS}

--- a/kubernetes/clusters/prod/htz-fsn1/cluster-settings.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/cluster-settings.yaml
@@ -74,6 +74,10 @@ data:
   # ACME registration contact for Let's Encrypt. TODO: real ops address.
   ACME_EMAIL: fubar-prod@futo.org
 
+  # From header for invite/transactional email (must match a Postmark-verified
+  # sender signature).
+  EMAIL_FROM_ADDRESS: "FUTO Backups <noreply@backups.futo.cloud>"
+
   # ─── OpenEBS (shared apps/base/openebs, see the father openebs wrapper) ──
   # Mayastor ON: openebs-replicated (repl=2) on the r-mayastor partitions.
   # LocalPV on the u-localpv xfs partition (node-local; CNPG replicates itself).

--- a/kubernetes/clusters/staging/austin/cluster-settings.yaml
+++ b/kubernetes/clusters/staging/austin/cluster-settings.yaml
@@ -56,6 +56,10 @@ data:
   # ACME registration contact for Let's Encrypt. TODO: real ops address.
   ACME_EMAIL: fubar-prod@futo.org
 
+  # From header for invite/transactional email (must match a Postmark-verified
+  # sender signature).
+  EMAIL_FROM_ADDRESS: "FUTO Backups Staging <noreply@staging.backups.futo.cloud>"
+
   # ─── Storage ─────────────────────────────────────────────────────────
   # CNPG database PVs: node-local NVMe via the overlay's spare-disk SC.
   DB_STORAGE_CLASS: openebs-spare-disk

--- a/tf/.env
+++ b/tf/.env
@@ -42,6 +42,11 @@ export TF_VAR_yucca_oidc_device_client_id="op://yucca_tf_staging/CUSTOMER_ZITADE
 export TF_VAR_yucca_oidc_admin_client_id="op://shared_tf/FUTO_ZITADEL_OAUTH_CLIENT_ID_YUCCA_INTERNAL_TOOLING/password"
 export TF_VAR_yucca_oidc_admin_client_secret="op://shared_tf/FUTO_ZITADEL_OAUTH_CLIENT_SECRET_YUCCA_INTERNAL_TOOLING/password"
 
+# Postmark server token for invite/transactional email. Mint the 1P item, then
+# uncomment; while commented the TF var defaults to "" and admin-api logs and
+# skips sends (docs/email.md).
+# export TF_VAR_yucca_postmark_server_token="op://yucca_tf_staging/POSTMARK_SERVER_TOKEN/password"
+
 # michael RGW (S3) creds — the `svc-yucca-restic` user created by the ceph
 # Ansible (sietch / dev Ceph); duplicated into yucca_tf_staging for the SA.
 export TF_VAR_yucca_rgw_access_key_id="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_RESTIC_ACCESS_KEY/password"

--- a/tf/.env.prod
+++ b/tf/.env.prod
@@ -63,6 +63,11 @@ export TF_VAR_yucca_oidc_device_client_id="op://yucca_tf_prod/CUSTOMER_ZITADEL_O
 export TF_VAR_yucca_oidc_admin_client_id="op://shared_tf/FUTO_ZITADEL_OAUTH_CLIENT_ID_YUCCA_INTERNAL_TOOLING/password"
 export TF_VAR_yucca_oidc_admin_client_secret="op://shared_tf/FUTO_ZITADEL_OAUTH_CLIENT_SECRET_YUCCA_INTERNAL_TOOLING/password"
 
+# Postmark server token for invite/transactional email. Mint the 1P item, then
+# uncomment; while commented the TF var defaults to "" and admin-api logs and
+# skips sends (docs/email.md).
+# export TF_VAR_yucca_postmark_server_token="op://yucca_tf_prod/POSTMARK_SERVER_TOKEN/password"
+
 # michael → spice RGW (svc-yucca-restic, out-of-band contract items).
 export TF_VAR_yucca_rgw_access_key_id="op://yucca_tf_prod/SPICE_CEPH_S3_SVC_YUCCA_RESTIC_ACCESS_KEY/password"
 export TF_VAR_yucca_rgw_secret_access_key="op://yucca_tf_prod/SPICE_CEPH_S3_SVC_YUCCA_RESTIC_SECRET_KEY/password"

--- a/tf/deployment/prod/htz-fsn1/talos/secrets.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/secrets.tf
@@ -165,6 +165,9 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
     # bench): deliberately the yucca_jwt SIGNING key — michael only accepts
     # tokens from that keypair. Admin session JWTs stay on yucca_admin_jwt.
     RESTIC_JWT_PRIVATE_KEY = tls_private_key.yucca_jwt.private_key_pem_pkcs8
+    # Empty until the 1P ref is minted — admin-api then logs and skips sends
+    # instead of crashing (see docs/email.md).
+    POSTMARK_SERVER_TOKEN = var.yucca_postmark_server_token
   }
 
   lifecycle {

--- a/tf/deployment/prod/htz-fsn1/talos/variables.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/variables.tf
@@ -188,6 +188,13 @@ variable "yucca_oidc_admin_client_secret" {
   default     = ""
 }
 
+variable "yucca_postmark_server_token" {
+  description = "Postmark server API token for invite/transactional email (ref stays commented in tf/.env.prod until minted; empty token = admin-api logs and skips sends)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "yucca_rgw_access_key_id" {
   description = "Spice RGW (S3) access key for michael (svc-yucca-restic, out-of-band contract item)."
   type        = string

--- a/tf/deployment/staging/austin/talos/secrets.tf
+++ b/tf/deployment/staging/austin/talos/secrets.tf
@@ -179,6 +179,9 @@ resource "kubernetes_secret_v1" "yucca_admin_api" {
     # bench): deliberately the yucca_jwt SIGNING key — michael only accepts
     # tokens from that keypair. Admin session JWTs stay on yucca_admin_jwt.
     RESTIC_JWT_PRIVATE_KEY = tls_private_key.yucca_jwt[0].private_key_pem_pkcs8
+    # Empty until the 1P ref is minted — admin-api then logs and skips sends
+    # instead of crashing (see docs/email.md).
+    POSTMARK_SERVER_TOKEN = var.yucca_postmark_server_token
   }
 
   lifecycle {

--- a/tf/deployment/staging/austin/talos/variables.tf
+++ b/tf/deployment/staging/austin/talos/variables.tf
@@ -84,6 +84,13 @@ variable "yucca_oidc_admin_client_secret" {
   default     = ""
 }
 
+variable "yucca_postmark_server_token" {
+  description = "Postmark server API token for invite/transactional email (ref stays commented in tf/.env until minted; empty token = admin-api logs and skips sends). Injected via TF_VAR from 1P."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # michael S3 credentials — the `svc-yucca-restic` RGW user on the bare-metal
 # Ceph (sietch / dev Ceph), created by the ceph Ansible with predetermined keys;
 # duplicated into yucca_tf_staging (op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_


### PR DESCRIPTION
POSTMARK\_SERVER\_TOKEN in the TF-provisioned admin-api Secrets (op\:// refs commented until minted) plus EMAIL\_FROM\_ADDRESS/WEB\_BASE\_URL via cluster-settings and the base HelmRelease.

- `main` <!-- branch-stack -->
  - \#489
    - \#490
      - \#491
        - \#492
          - \#493 :point\_left:
