### PR TITLE
fix(o11y): pin 5m staleness lookback on alert rule queries

### DIFF
--- a/o11y/README.md
+++ b/o11y/README.md
@@ -126,6 +126,13 @@ Conventions:
   while firing (e.g. cert expiry alerts on seconds *inside* the warning
   window, which keeps growing past expiry, not seconds-to-expiry, which would
   go negative and stop firing).
+- **`intervalMs: 300000` on every query node, non-negotiable**: VictoriaMetrics
+  uses an instant query's `step` as its staleness lookback, and Grafana derives
+  that step from `intervalMs`. At Grafana's ~15s default, any metric scraped
+  less often than the step resolves to *no data* → `noDataState: OK` → the rule
+  sits Normal while the condition is true (this silently killed the junos
+  alerts, whose exporter scrapes at 60s). 5m restores Prometheus-standard
+  staleness for every cadence in the fleet.
 - **Guarded absence**: absence-style rules use
   `absent(x) and on() count(count_over_time(x[24h])) > 0` so an o11y instance
   that never receives that data (staging sees no fabric) never alarms, while

--- a/o11y/alerts/backup-health.yaml
+++ b/o11y/alerts/backup-health.yaml
@@ -39,7 +39,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(rgw_repository_size_bytes) and on()
@@ -88,7 +88,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               count(count by (user_id) ((time() - user_last_successful_backup)

--- a/o11y/alerts/cilium.yaml
+++ b/o11y/alerts/cilium.yaml
@@ -35,7 +35,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_daemonset_status_number_unavailable{namespace="kube-system",
@@ -82,7 +82,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               max by (cluster, pod, neighbor)

--- a/o11y/alerts/fabric.yaml
+++ b/o11y/alerts/fabric.yaml
@@ -44,7 +44,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               junos_bgp_session_up{cluster="netops", group!="cilium-nodes"} ==
@@ -87,7 +87,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum(junos_bgp_session_up{cluster="netops",
@@ -130,7 +130,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               junos_bgp_session_up{cluster="netops", group="cilium-nodes"} ==
@@ -173,7 +173,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (target) (junos_alarms_red_count{cluster="netops"}) > 0
@@ -214,7 +214,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (target) (junos_alarms_yellow_count{cluster="netops"}) >
@@ -257,7 +257,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (target, name) (
@@ -303,7 +303,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               up{cluster="netops", job="junos"} == bool 0
@@ -347,7 +347,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(sflow_ifinoctets{cluster="netops"}) and on()

--- a/o11y/alerts/kubernetes.yaml
+++ b/o11y/alerts/kubernetes.yaml
@@ -43,7 +43,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               count by (cluster, customresource_kind, exported_namespace,
@@ -86,7 +86,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster, pod) (rate(
@@ -133,7 +133,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               ((time() + 14 * 86400) - min by (cluster, exported_namespace,
@@ -177,7 +177,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               max by (cluster, exported_namespace, name)
@@ -219,7 +219,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_node_status_condition{cluster=~"father|luke",
@@ -262,7 +262,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               increase(kube_pod_container_status_restarts_total{cluster=~"father|luke"}[30m])
@@ -305,7 +305,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               (1 -
@@ -351,7 +351,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               (1 -

--- a/o11y/alerts/michael.yaml
+++ b/o11y/alerts/michael.yaml
@@ -36,7 +36,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (rate({__name__="http.server.request.errors",
@@ -80,7 +80,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (rate({__name__="http.server.request.errors",
@@ -124,7 +124,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               min by (cluster, backend) ({__name__="s3.backend.healthy"}) ==
@@ -166,7 +166,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (max by (cluster, backend)
@@ -209,7 +209,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster, operation)
@@ -253,7 +253,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster)
@@ -296,7 +296,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               histogram_quantile(0.99, sum by (cluster, le)
@@ -338,7 +338,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_deployment_status_replicas_available{namespace="yucca",

--- a/o11y/alerts/telemetry.yaml
+++ b/o11y/alerts/telemetry.yaml
@@ -39,7 +39,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="father"}) and on()
@@ -81,7 +81,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="luke"}) and on()
@@ -123,7 +123,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="netops"}) and on()
@@ -166,7 +166,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="spice"}) and on()

--- a/o11y/alerts/yucca-services.yaml
+++ b/o11y/alerts/yucca-services.yaml
@@ -34,7 +34,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (rate(api_request_count{status=~"5.."}[5m])) /
@@ -81,7 +81,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_deployment_status_replicas_available{namespace="yucca",


### PR DESCRIPTION
VictoriaMetrics uses an instant query's `step` as the staleness lookback and Grafana derives step from `intervalMs`, clamped to \~15s. Metrics scraped less often than the step resolve to no-data, and `noDataState: OK` parks the rule at Normal while its condition is true: the junos-based rules (60s NETCONF scrape) never fired, with the Colt transit session down right now. Verified empirically against prod vmselect: `junos_bgp_session_up` returns 0 series at `step=15s`, 1 series at `step>=30s`.

`intervalMs: 300000` on every rule query restores Prometheus-standard 5m staleness for every scrape cadence in the fleet; documented as a hard convention in the o11y README.

- `main` <!-- branch-stack -->
  - \#499 :point\_left:
