### PR TITLE
fix(o11y): point alert rules and imported dashboards at the fleet datasource

### DIFF
--- a/o11y/README.md
+++ b/o11y/README.md
@@ -126,13 +126,17 @@ Conventions:
   while firing (e.g. cert expiry alerts on seconds *inside* the warning
   window, which keeps growing past expiry, not seconds-to-expiry, which would
   go negative and stop firing).
-- **`intervalMs: 300000` on every query node, non-negotiable**: VictoriaMetrics
-  uses an instant query's `step` as its staleness lookback, and Grafana derives
-  that step from `intervalMs`. At Grafana's ~15s default, any metric scraped
-  less often than the step resolves to *no data* → `noDataState: OK` → the rule
-  sits Normal while the condition is true (this silently killed the junos
-  alerts, whose exporter scrapes at 60s). 5m restores Prometheus-standard
-  staleness for every cadence in the fleet.
+- **Wrap slow-cadence instant selectors in `last_over_time(...[5m])`**:
+  Grafana sends the rule group's evaluation interval as the instant query's
+  `step`, and VictoriaMetrics uses `step` as the staleness lookback (setting
+  `intervalMs` on the query model does NOT change it — measured). A metric
+  whose cadence is at or above the step loses that race often enough that a
+  multi-minute `for` can never sustain: the rule sits Normal via
+  `noDataState: OK` while the condition is true. This silently killed the
+  junos rules (60s NETCONF scrape) through a real transit outage. Range
+  vectors are immune, so `rate()`/`increase()` expressions need nothing;
+  every raw selector on a source slower than ~20s gets the wrap, and
+  absence guards use `absent(last_over_time(x[10m]))`.
 - **Guarded absence**: absence-style rules use
   `absent(x) and on() count(count_over_time(x[24h])) > 0` so an o11y instance
   that never receives that data (staging sees no fabric) never alarms, while

--- a/o11y/README.md
+++ b/o11y/README.md
@@ -126,6 +126,13 @@ Conventions:
   while firing (e.g. cert expiry alerts on seconds *inside* the warning
   window, which keeps growing past expiry, not seconds-to-expiry, which would
   go negative and stop firing).
+- **`intervalMs: 300000` on every query node, non-negotiable**: VictoriaMetrics
+  uses an instant query's `step` as its staleness lookback, and Grafana derives
+  that step from `intervalMs`. At Grafana's ~15s default, any metric scraped
+  less often than the step resolves to *no data* → `noDataState: OK` → the rule
+  sits Normal while the condition is true (this silently killed the junos
+  alerts, whose exporter scrapes at 60s). 5m restores Prometheus-standard
+  staleness for every cadence in the fleet.
 - **Guarded absence**: absence-style rules use
   `absent(x) and on() count(count_over_time(x[24h])) > 0` so an o11y instance
   that never receives that data (staging sees no fabric) never alarms, while

--- a/o11y/README.md
+++ b/o11y/README.md
@@ -110,9 +110,15 @@ the "Top source addresses" table aggregates out of VictoriaLogs.
 contact points, notification policy, Discord — is configured on the o11y side
 and out of scope for this repo. Two bindings the CRs must get right:
 `folderRef: yucca` (the bundle's own `GrafanaFolder`), and `datasourceUid:
-VictoriaMetrics` on every query node — alert rules cannot use a `$datasource`
-variable the way dashboards do, so they pin o11y's default VictoriaMetrics
-datasource UID.
+VictoriaMetricsFleet` on every query node — alert rules cannot use a
+`$datasource` variable the way dashboards do. NEVER pin the default
+`VictoriaMetrics` datasource: it fronts `vmauth-self-select`, which serves
+ONLY the o11y cluster's own series, so every rule over yucca/fabric/ceph data
+evaluates to NoData and sits Normal through real outages (this shipped, and
+the Colt transit outage went unalerted until it was caught). Only
+`VictoriaMetricsFleet` (vmselect direct) sees the whole fleet — the same
+reason every dashboard's `$datasource` variable carries the
+`/^VictoriaMetrics Fleet$/` regex.
 
 Conventions:
 

--- a/o11y/alerts/backup-health.yaml
+++ b/o11y/alerts/backup-health.yaml
@@ -34,7 +34,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -83,7 +83,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/backup-health.yaml
+++ b/o11y/alerts/backup-health.yaml
@@ -42,7 +42,7 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              absent(rgw_repository_size_bytes) and on()
+              absent(last_over_time(rgw_repository_size_bytes[10m])) and on()
               count(count_over_time(rgw_repository_size_bytes[24h])) > 0
         - refId: B
           relativeTimeRange:
@@ -91,10 +91,12 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              count(count by (user_id) ((time() - user_last_successful_backup)
-              > 172800)) / count(count by (user_id)
-              (user_last_successful_backup)) > 0.25 and on() count(count by
-              (user_id) (user_last_successful_backup)) >= 10
+              count(count by (user_id) ((time() -
+              last_over_time(user_last_successful_backup[10m])) > 172800)) /
+              count(count by (user_id)
+              (last_over_time(user_last_successful_backup[10m]))) > 0.25 and
+              on() count(count by (user_id)
+              (last_over_time(user_last_successful_backup[10m]))) >= 10
         - refId: B
           relativeTimeRange:
             from: 600

--- a/o11y/alerts/backup-health.yaml
+++ b/o11y/alerts/backup-health.yaml
@@ -39,7 +39,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(rgw_repository_size_bytes) and on()
@@ -88,7 +88,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               count(count by (user_id) ((time() - user_last_successful_backup)

--- a/o11y/alerts/cilium.yaml
+++ b/o11y/alerts/cilium.yaml
@@ -30,7 +30,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -77,7 +77,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/cilium.yaml
+++ b/o11y/alerts/cilium.yaml
@@ -35,7 +35,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_daemonset_status_number_unavailable{namespace="kube-system",
@@ -82,7 +82,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               max by (cluster, pod, neighbor)

--- a/o11y/alerts/fabric.yaml
+++ b/o11y/alerts/fabric.yaml
@@ -44,7 +44,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -87,7 +87,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -130,7 +130,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -173,7 +173,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -216,7 +216,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -260,7 +260,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -306,7 +306,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -350,7 +350,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/fabric.yaml
+++ b/o11y/alerts/fabric.yaml
@@ -44,7 +44,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               junos_bgp_session_up{cluster="netops", group!="cilium-nodes"} ==
@@ -87,7 +87,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum(junos_bgp_session_up{cluster="netops",
@@ -130,7 +130,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               junos_bgp_session_up{cluster="netops", group="cilium-nodes"} ==
@@ -173,7 +173,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (target) (junos_alarms_red_count{cluster="netops"}) > 0
@@ -214,7 +214,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (target) (junos_alarms_yellow_count{cluster="netops"}) >
@@ -257,7 +257,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (target, name) (
@@ -303,7 +303,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               up{cluster="netops", job="junos"} == bool 0
@@ -347,7 +347,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(sflow_ifinoctets{cluster="netops"}) and on()

--- a/o11y/alerts/fabric.yaml
+++ b/o11y/alerts/fabric.yaml
@@ -1,6 +1,11 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanaalertrulegroup_v1beta1.json
 # Fabric series only ever come from the netops vmagent (cluster="netops");
-# spice's own health is alerted by cephadm's alertmanager, not here.
+# spice's own health is alerted by cephadm's alertmanager, not here. Every
+# instant selector is wrapped in last_over_time[5m]: Grafana evaluates with the
+# group interval as the query step, VictoriaMetrics treats step as the staleness
+# lookback, and the junos exporter's 60s cadence loses the race often enough
+# that a 5m `for` can never sustain — the rules sat Normal through a real
+# transit outage until wrapped.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaAlertRuleGroup
 metadata:
@@ -47,8 +52,8 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              junos_bgp_session_up{cluster="netops", group!="cilium-nodes"} ==
-              bool 0
+              last_over_time(junos_bgp_session_up{cluster="netops",
+              group!="cilium-nodes"}[5m]) == bool 0
         - refId: B
           relativeTimeRange:
             from: 600
@@ -90,8 +95,8 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              sum(junos_bgp_session_up{cluster="netops",
-              group!="cilium-nodes"}) == bool 0
+              sum(last_over_time(junos_bgp_session_up{cluster="netops",
+              group!="cilium-nodes"}[5m])) == bool 0
         - refId: B
           relativeTimeRange:
             from: 600
@@ -133,8 +138,8 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              junos_bgp_session_up{cluster="netops", group="cilium-nodes"} ==
-              bool 0
+              last_over_time(junos_bgp_session_up{cluster="netops",
+              group="cilium-nodes"}[5m]) == bool 0
         - refId: B
           relativeTimeRange:
             from: 600
@@ -176,7 +181,9 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              sum by (target) (junos_alarms_red_count{cluster="netops"}) > 0
+              sum by (target)
+              (last_over_time(junos_alarms_red_count{cluster="netops"}[5m])) >
+              0
         - refId: B
           relativeTimeRange:
             from: 600
@@ -217,8 +224,9 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              sum by (target) (junos_alarms_yellow_count{cluster="netops"}) >
-              0
+              sum by (target)
+              (last_over_time(junos_alarms_yellow_count{cluster="netops"}[5m]))
+              > 0
         - refId: B
           relativeTimeRange:
             from: 600
@@ -306,7 +314,7 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              up{cluster="netops", job="junos"} == bool 0
+              last_over_time(up{cluster="netops", job="junos"}[5m]) == bool 0
         - refId: B
           relativeTimeRange:
             from: 600

--- a/o11y/alerts/kubernetes.yaml
+++ b/o11y/alerts/kubernetes.yaml
@@ -38,7 +38,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -81,7 +81,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -128,7 +128,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -172,7 +172,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -214,7 +214,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -257,7 +257,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -300,7 +300,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -346,7 +346,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/kubernetes.yaml
+++ b/o11y/alerts/kubernetes.yaml
@@ -43,7 +43,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               count by (cluster, customresource_kind, exported_namespace,
@@ -86,7 +86,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster, pod) (rate(
@@ -133,7 +133,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               ((time() + 14 * 86400) - min by (cluster, exported_namespace,
@@ -177,7 +177,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               max by (cluster, exported_namespace, name)
@@ -219,7 +219,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_node_status_condition{cluster=~"father|luke",
@@ -262,7 +262,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               increase(kube_pod_container_status_restarts_total{cluster=~"father|luke"}[30m])
@@ -305,7 +305,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               (1 -
@@ -351,7 +351,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               (1 -

--- a/o11y/alerts/michael.yaml
+++ b/o11y/alerts/michael.yaml
@@ -36,7 +36,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (rate({__name__="http.server.request.errors",
@@ -80,7 +80,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (rate({__name__="http.server.request.errors",
@@ -124,7 +124,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               min by (cluster, backend) ({__name__="s3.backend.healthy"}) ==
@@ -166,7 +166,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (max by (cluster, backend)
@@ -209,7 +209,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster, operation)
@@ -253,7 +253,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster)
@@ -296,7 +296,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               histogram_quantile(0.99, sum by (cluster, le)
@@ -338,7 +338,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_deployment_status_replicas_available{namespace="yucca",

--- a/o11y/alerts/michael.yaml
+++ b/o11y/alerts/michael.yaml
@@ -31,7 +31,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -75,7 +75,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -119,7 +119,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -161,7 +161,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -204,7 +204,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -248,7 +248,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -291,7 +291,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -333,7 +333,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/telemetry.yaml
+++ b/o11y/alerts/telemetry.yaml
@@ -34,7 +34,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -76,7 +76,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -118,7 +118,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -161,7 +161,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/telemetry.yaml
+++ b/o11y/alerts/telemetry.yaml
@@ -39,7 +39,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="father"}) and on()
@@ -81,7 +81,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="luke"}) and on()
@@ -123,7 +123,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="netops"}) and on()
@@ -166,7 +166,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               absent(up{cluster="spice"}) and on()

--- a/o11y/alerts/telemetry.yaml
+++ b/o11y/alerts/telemetry.yaml
@@ -42,7 +42,7 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              absent(up{cluster="father"}) and on()
+              absent(last_over_time(up{cluster="father"}[5m])) and on()
               count(count_over_time(up{cluster="father"}[24h])) > 0
         - refId: B
           relativeTimeRange:
@@ -84,7 +84,7 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              absent(up{cluster="luke"}) and on()
+              absent(last_over_time(up{cluster="luke"}[5m])) and on()
               count(count_over_time(up{cluster="luke"}[24h])) > 0
         - refId: B
           relativeTimeRange:
@@ -126,7 +126,7 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              absent(up{cluster="netops"}) and on()
+              absent(last_over_time(up{cluster="netops"}[5m])) and on()
               count(count_over_time(up{cluster="netops"}[24h])) > 0
         - refId: B
           relativeTimeRange:
@@ -169,7 +169,7 @@ spec:
             intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
-              absent(up{cluster="spice"}) and on()
+              absent(last_over_time(up{cluster="spice"}[5m])) and on()
               count(count_over_time(up{cluster="spice"}[24h])) > 0
         - refId: B
           relativeTimeRange:

--- a/o11y/alerts/yucca-services.yaml
+++ b/o11y/alerts/yucca-services.yaml
@@ -29,7 +29,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true
@@ -76,7 +76,7 @@ spec:
           relativeTimeRange:
             from: 600
             to: 0
-          datasourceUid: VictoriaMetrics
+          datasourceUid: VictoriaMetricsFleet
           model:
             refId: A
             instant: true

--- a/o11y/alerts/yucca-services.yaml
+++ b/o11y/alerts/yucca-services.yaml
@@ -34,7 +34,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               sum by (cluster) (rate(api_request_count{status=~"5.."}[5m])) /
@@ -81,7 +81,7 @@ spec:
             refId: A
             instant: true
             range: false
-            intervalMs: 1000
+            intervalMs: 300000
             maxDataPoints: 43200
             expr: >-
               kube_deployment_status_replicas_available{namespace="yucca",

--- a/o11y/dashboards/yucca-cilium-operator.json
+++ b/o11y/dashboards/yucca-cilium-operator.json
@@ -991,10 +991,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-cilium.json
+++ b/o11y/dashboards/yucca-cilium.json
@@ -10980,10 +10980,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-flux-controllers.json
+++ b/o11y/dashboards/yucca-flux-controllers.json
@@ -1663,10 +1663,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-flux.json
+++ b/o11y/dashboards/yucca-flux.json
@@ -1280,10 +1280,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-hubble.json
+++ b/o11y/dashboards/yucca-hubble.json
@@ -2826,10 +2826,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-k8s-apiserver.json
+++ b/o11y/dashboards/yucca-k8s-apiserver.json
@@ -1235,10 +1235,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-k8s-coredns.json
+++ b/o11y/dashboards/yucca-k8s-coredns.json
@@ -1338,10 +1338,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-k8s-global.json
+++ b/o11y/dashboards/yucca-k8s-global.json
@@ -2894,10 +2894,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-k8s-namespaces.json
+++ b/o11y/dashboards/yucca-k8s-namespaces.json
@@ -2767,10 +2767,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-k8s-nodes.json
+++ b/o11y/dashboards/yucca-k8s-nodes.json
@@ -3740,10 +3740,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-k8s-pods.json
+++ b/o11y/dashboards/yucca-k8s-pods.json
@@ -2723,10 +2723,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-node-exporter.json
+++ b/o11y/dashboards/yucca-node-exporter.json
@@ -15286,10 +15286,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/dashboards/yucca-vmagent.json
+++ b/o11y/dashboards/yucca-vmagent.json
@@ -8902,10 +8902,14 @@
         "type": "datasource",
         "query": "prometheus",
         "label": "Datasource",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "/^VictoriaMetrics Fleet$/",
         "hide": 0
       },
       {

--- a/o11y/scripts/import-upstream.py
+++ b/o11y/scripts/import-upstream.py
@@ -162,10 +162,10 @@ def process(uid, url, title, inject, anchor, tags, drop):
             "type": "datasource",
             "query": "prometheus",
             "label": "Datasource",
-            "current": {},
+            "current": {"selected": True, "text": "VictoriaMetrics Fleet", "value": "VictoriaMetricsFleet"},
             "options": [],
             "refresh": 1,
-            "regex": "",
+            "regex": "/^VictoriaMetrics Fleet$/",
             "hide": 0,
         },
     )


### PR DESCRIPTION
Root cause of the silent JunosTransitSessionDown, found via the Grafana API: every yucca rule evaluated to **Normal (NoData)** except CertManagerCertExpiringSoon, whose only firing instances were `cluster=o11y` — because the rules pinned the default `VictoriaMetrics` datasource, which fronts `vmauth-self-select` and serves only the o11y cluster's own series. Remote-cluster data (yucca, fabric, ceph) is invisible through it. `VictoriaMetricsFleet` (vmselect direct) is the fleet-wide view — the same datasource the house dashboards pin by name regex.

- `datasourceUid: VictoriaMetricsFleet` on all 34 rule queries
- imported dashboards' `$datasource` var gets the `/^VictoriaMetrics Fleet$/` regex + default, matching the house convention (they were defaulting to the self-scoped datasource)
- README documents the trap

(#499/#501's staleness hardening stays — correct, but this was the actual blocker.)

- `main` <!-- branch-stack -->
  - \#502 :point\_left:
