### PR TITLE
fix(k8s): staging gw via SNI passthrough — mergeGateways is unsupported under GatewayNamespace mode

### DIFF
--- a/kubernetes/apps/base/gw-proxy/envoyproxy.yaml
+++ b/kubernetes/apps/base/gw-proxy/envoyproxy.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
 # Data-plane config for the DEDICATED michael (restic) gateway, separate from
-# the app gateway so the backup data plane scales independently. Deleted in
-# staging (mergeGateways rides the app fleet); father patches in its dual
-# public/internal VIPs.
+# the app gateway so the backup data plane scales independently. father patches
+# in its dual public/internal VIPs; staging replaces the Service with a
+# ClusterIP reached via the app gateway's SNI passthrough.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:

--- a/kubernetes/apps/base/gw-proxy/gateway.yaml
+++ b/kubernetes/apps/base/gw-proxy/gateway.yaml
@@ -2,8 +2,7 @@
 # The michael (restic) Gateway: HTTPS-only, scoped to ${GW_HOST}. Shares the
 # `envoy` GatewayClass but attaches its own EnvoyProxy via
 # infrastructure.parametersRef (Envoy Gateway creates one proxy fleet per
-# Gateway); staging drops the ref and merges into the app fleet instead. No
-# :80 listener — restic clients speak HTTPS only.
+# Gateway). No :80 listener — restic clients speak HTTPS only.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/kubernetes/apps/staging/austin/gw-proxy/kustomization.yaml
+++ b/kubernetes/apps/staging/austin/gw-proxy/kustomization.yaml
@@ -1,24 +1,22 @@
 ---
-# staging's specialization of apps/base/gw-proxy: no dedicated fleet — Austin
-# has one public entry (the NAT in front of the ingress VIP), so mergeGateways
-# (patched onto the app EnvoyProxy in ../infra) serves the gw Gateway from the
-# app fleet on the shared VIP. Merged gateways take the class-level EnvoyProxy,
-# so the per-gateway one is deleted and its parametersRef dropped.
+# staging's specialization of apps/base/gw-proxy: Austin has one public entry
+# (the NAT in front of the ingress VIP), so the gw fleet gets no VIP of its
+# own — the app gateway's SNI passthrough listener (see ../infra) forwards
+# ${GW_HOST}'s raw TLS here via the TLSRoute, and the fleet Service is plain
+# ClusterIP. TLS still terminates in THIS fleet (gw-public cert, ALPN pin,
+# buffer policies), same as father.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/gw-proxy
+  - ./tlsroute.yaml
 patches:
   - target:
-      group: gateway.networking.k8s.io
-      kind: Gateway
-      name: gw
-    patch: |-
-      - op: remove
-        path: /spec/infrastructure
-  - patch: |-
-      apiVersion: gateway.envoyproxy.io/v1alpha1
+      group: gateway.envoyproxy.io
       kind: EnvoyProxy
-      metadata:
-        name: envoy-gw
-      $patch: delete
+      name: envoy-gw
+    patch: |-
+      - op: replace
+        path: /spec/provider/kubernetes/envoyService
+        value:
+          type: ClusterIP

--- a/kubernetes/apps/staging/austin/gw-proxy/tlsroute.yaml
+++ b/kubernetes/apps/staging/austin/gw-proxy/tlsroute.yaml
@@ -1,0 +1,18 @@
+---
+# Hands ${GW_HOST}'s raw TLS from the app gateway's gw-passthrough listener to
+# the gw fleet. Backend `gw` is the Service Envoy Gateway provisions for the
+# gw Gateway — named exactly after it under the GatewayNamespace deploy mode.
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: gw-passthrough
+spec:
+  parentRefs:
+    - name: envoy
+      sectionName: gw-passthrough
+  hostnames:
+    - "${GW_HOST}"
+  rules:
+    - backendRefs:
+        - name: gw
+          port: 443

--- a/kubernetes/apps/staging/austin/infra/kustomization.yaml
+++ b/kubernetes/apps/staging/austin/infra/kustomization.yaml
@@ -16,10 +16,13 @@ components:
 patches:
   # STAGING TOPOLOGY: Austin has ONE public entry (the NAT in front of
   # ${INGRESS_VIP}), so the gw Gateway can't get its own VIP like father's.
-  # mergeGateways folds every Gateway of the class into the app fleet instead:
-  # gw's listener rides the same Service/VIP, SNI-demuxed against the app
-  # wildcard (exact hostname wins). The per-gateway EnvoyProxy side is dropped
-  # in ../gw-proxy.
+  # Instead the app gateway gets an SNI PASSTHROUGH listener for ${GW_HOST}
+  # (exact SNI beats the wildcard cert listener) whose TLSRoute hands the raw
+  # TLS stream to the gw fleet — clients still terminate against gw's own cert
+  # and policies. NOT mergeGateways: EG rejects it under the GatewayNamespace
+  # deploy mode the shared install runs ("Merged Gateways with Gateway
+  # Namespace Mode is not supported"), and a rejected class EnvoyProxy drops
+  # the whole app fleet to chart defaults (replicas 1, no VIP annotation).
   - target:
       group: kustomize.toolkit.fluxcd.io
       kind: Kustomization
@@ -32,10 +35,19 @@ patches:
       spec:
         patches:
           - target:
-              group: gateway.envoyproxy.io
-              kind: EnvoyProxy
+              group: gateway.networking.k8s.io
+              kind: Gateway
               name: envoy
             patch: |-
               - op: add
-                path: /spec/mergeGateways
-                value: true
+                path: /spec/listeners/-
+                value:
+                  name: gw-passthrough
+                  protocol: TLS
+                  port: 443
+                  hostname: "${GW_HOST}"
+                  tls:
+                    mode: Passthrough
+                  allowedRoutes:
+                    namespaces:
+                      from: All

--- a/kubernetes/clusters/staging/austin/cluster-settings.yaml
+++ b/kubernetes/clusters/staging/austin/cluster-settings.yaml
@@ -50,9 +50,10 @@ data:
   INGRESS_VIP: 10.10.10.16
   INGRESS_PUBLIC_IP: 97.77.242.205
   # michael's gw. route attaches to the dedicated gw Gateway, same as father —
-  # but Austin has one NAT'd entry, so mergeGateways serves it from the app
-  # fleet on this same VIP (see apps/staging/austin/{infra,gw-proxy}).
+  # but Austin has one NAT'd entry, so the app gateway SNI-passes ${GW_HOST}
+  # through to the gw fleet (see apps/staging/austin/{infra,gw-proxy}).
   GW_PARENT_GATEWAY: gw
+  GW_PROXY_REPLICAS: "2"
 
   # ─── App fleet sizing ────────────────────────────────────────────────
   MICHAEL_REPLICAS: "2"

--- a/kubernetes/components/observability/namespace.yaml
+++ b/kubernetes/components/observability/namespace.yaml
@@ -7,3 +7,7 @@ metadata:
   # pod logs — forbidden under Talos' default `baseline` PSS, so enforce privileged.
   labels:
     pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    # Never prune namespaces on restructure (openebs incident 2026-07-06; this
+    # one got GC'd 2026-08-20 when its owner moved to the observability Ks).
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/components/platform/gw-proxy.yaml
+++ b/kubernetes/components/platform/gw-proxy.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
 # Dedicated michael (restic) Gateway — apps/base/gw-proxy via the per-cluster
-# overlay: father adds the internal listener + BGP VIPs; staging folds the
-# fleet into the app gateway's single NAT'd VIP (mergeGateways).
+# overlay: father adds the internal listener + BGP VIPs; staging serves it
+# behind the app gateway's single NAT'd VIP via an SNI passthrough listener.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:


### PR DESCRIPTION
EG rejects mergeGateways under GatewayNamespace deploy mode (dropping the whole class EnvoyProxy → app fleet fell to replicas=1); the app gateway now SNI-passes ${GW\_HOST} through to the dedicated gw fleet (ClusterIP) instead.

- `main` <!-- branch-stack -->
  - \#516 :point\_left:
