### PR TITLE
feat(ceph): log firewall drops over nflog and ship them to o11y

### DIFF
--- a/ansible/ceph/docs/runbooks/triage-dead-root-filesystem.md
+++ b/ansible/ceph/docs/runbooks/triage-dead-root-filesystem.md
@@ -156,10 +156,12 @@ head -1 /tmp/<host>-kmsg.txt
 
 On philip the buffer held 5170 messages covering only the last **2.1 hours** of
 a 499-hour uptime, so the original NVMe/PCIe failure messages were already gone
-five hours after the event. Two things evict them: the EXT4 error storm the
-failure itself produces, and `nftables-drop` logging from the security role,
-which fills the buffer continuously with internet background noise. Capture
-kmsg early or accept that you will not get the root-cause line.
+five hours after the event. Two things evicted them: the EXT4 error storm the
+failure itself produces, and `nftables-drop` kernel logging filling the buffer
+with internet background noise. The security role has since moved drop logging
+off printk (NFLOG to ulogd2), which removes the second source; the storm from
+the failure itself remains. Capture kmsg early or accept that you will not get
+the root-cause line.
 
 ## 4. Concluding
 

--- a/ansible/ceph/docs/security-model.md
+++ b/ansible/ceph/docs/security-model.md
@@ -136,8 +136,11 @@ chain forward { policy drop; }  # no forwarding
 chain output { policy accept; } # outbound unrestricted
 ```
 
-Dropped packets are logged at rate 5/minute with prefix `nftables-drop: ` for
-forensic review.
+Every dropped packet is counted and logged in full over NFLOG: ulogd2 turns
+the netlink stream into JSON events in `/var/log/ulog/nft-drop.json` (rotated,
+14 days), and roles/fluentbit ships them to o11y. Nothing goes through printk
+or the journal, so scanner noise cannot crowd real kernel messages out of the
+kmsg or the journal.
 
 ### Optional gateways (disabled by default)
 
@@ -203,7 +206,7 @@ Rotation procedure: [runbooks/rotate-sa-token.md](runbooks/rotate-sa-token.md).
 | Ceph audit log | Enabled (`ceph config set global log_to_cluster_level audit`) |
 | Ceph manager log | `mgr/cephadm/log_to_cluster true` |
 | View audit log | `ceph log last -W audit` |
-| Firewall logging | Dropped packets logged at 5/min with `nftables-drop:` prefix |
+| Firewall logging | Every drop as a JSON event via NFLOG + ulogd2, shipped to o11y |
 | Prometheus alerts | 89 built-in rules across 16 groups covering OSD, MON, PG, pool, MDS, hardware, network |
 
 The audit channel records all `ceph` admin commands executed against the

--- a/ansible/ceph/logging.yml
+++ b/ansible/ceph/logging.yml
@@ -1,7 +1,8 @@
 ---
-# Ship each ceph node's journald to o11y's VictoriaLogs over the NetBird overlay.
-# journald is the whole source: cephadm daemons write there via libsystemd
-# (log_to_journald true, log_to_file false), and so does the mon cluster channel.
+# Ship each ceph node's logs to o11y's VictoriaLogs over the NetBird overlay.
+# Two sources: journald, where cephadm daemons write via libsystemd
+# (log_to_journald true, log_to_file false) along with the mon cluster channel,
+# and the nftables drop events ulogd2 writes (roles/security).
 #
 # Needs the node enrolled in NetBird and the ceph-to-o11y-gateway policy applied;
 # without the policy there is no route to the gateway VIP.

--- a/ansible/ceph/roles/fluentbit/defaults/main.yml
+++ b/ansible/ceph/roles/fluentbit/defaults/main.yml
@@ -58,3 +58,8 @@ ceph_fluentbit_http_listen: "{{ ceph_public_ip }}"
 # How long the ExecStartPre drop-in waits for that address at boot. LACP and
 # MLAG convergence on the 25G bond is seconds; this is slack, not a real budget.
 ceph_fluentbit_bind_wait_secs: 60
+
+# nftables drop events, written by roles/security's ulogd2 as JSON lines.
+# Must match ceph_firewall_droplog_file (roles/security): the roles run in
+# different playbooks, so neither default can reference the other.
+ceph_fluentbit_droplog_file: /var/log/ulog/nft-drop.json

--- a/ansible/ceph/roles/fluentbit/defaults/main.yml
+++ b/ansible/ceph/roles/fluentbit/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-# Ship each node's journald to o11y's VictoriaLogs over the NetBird overlay.
+# Ship each node's journald and nftables drop events to o11y's VictoriaLogs
+# over the NetBird overlay.
 # One agent per node, straight to the mesh vmauth. No aggregation tier.
 ceph_fluentbit_enabled: false
 

--- a/ansible/ceph/roles/fluentbit/files/nft-drop-message.lua
+++ b/ansible/ceph/roles/fluentbit/files/nft-drop-message.lua
@@ -1,0 +1,17 @@
+-- Managed by ansible (roles/fluentbit) - do not edit on the node.
+-- ulogd2 drop events have no MESSAGE; VictoriaLogs wants one for _msg.
+-- Synthesize a human-readable line from the decoded header fields (ulogd2's
+-- JSON output normalizes them to src_ip/dest_ip/src_port/dest_port). The
+-- structured fields all still ship alongside it.
+local proto_names = { [1] = "icmp", [6] = "tcp", [17] = "udp", [58] = "icmpv6" }
+
+function nft_drop_message(tag, ts, record)
+    local proto = proto_names[record["ip.protocol"]]
+        or tostring(record["ip.protocol"] or "?")
+    record["MESSAGE"] = string.format("%s %s %s:%s -> %s:%s in=%s",
+        record["oob.prefix"] or "drop", proto,
+        record["src_ip"] or "?", tostring(record["src_port"] or "-"),
+        record["dest_ip"] or "?", tostring(record["dest_port"] or "-"),
+        record["oob.in"] or "?")
+    return 2, ts, record
+end

--- a/ansible/ceph/roles/fluentbit/files/parsers-nftables.conf
+++ b/ansible/ceph/roles/fluentbit/files/parsers-nftables.conf
@@ -1,0 +1,9 @@
+# Managed by ansible (roles/fluentbit) - do not edit on the node.
+[PARSER]
+    # ulogd2's JSON drop events (roles/security). Its timestamp has no zone
+    # suffix ("2026-08-20T14:43:16.179896"); the parser then assumes agent
+    # local time, and the nodes run UTC, so _time is the true event time.
+    Name        nft_drop_json
+    Format      json
+    Time_Key    timestamp
+    Time_Format %Y-%m-%dT%H:%M:%S.%L

--- a/ansible/ceph/roles/fluentbit/tasks/main.yml
+++ b/ansible/ceph/roles/fluentbit/tasks/main.yml
@@ -108,6 +108,24 @@
     mode: '0644'
   notify: Restart fluent-bit
 
+- name: Install the nftables drop-event parser
+  ansible.builtin.copy:
+    src: parsers-nftables.conf
+    dest: /etc/fluent-bit/parsers-nftables.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart fluent-bit
+
+- name: Install the drop-event MESSAGE synthesizer
+  ansible.builtin.copy:
+    src: nft-drop-message.lua
+    dest: /etc/fluent-bit/nft-drop-message.lua
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart fluent-bit
+
 - name: Template the fluent-bit config
   ansible.builtin.template:
     src: fluent-bit.conf.j2

--- a/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
+++ b/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
@@ -1,5 +1,6 @@
 # Managed by ansible (roles/fluentbit) - do not edit on the node.
-# journald -> drop noise -> tag -> o11y VictoriaLogs over the NetBird overlay.
+# journald + nftables drop events -> filter -> tag -> o11y VictoriaLogs over
+# the NetBird overlay.
 
 [SERVICE]
     Flush                     5

--- a/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
+++ b/ansible/ceph/roles/fluentbit/templates/fluent-bit.conf.j2
@@ -9,6 +9,7 @@
     HTTP_Port                 {{ ceph_fluentbit_http_port }}
     storage.path              /var/lib/fluent-bit/storage
     storage.backlog.mem_limit 64M
+    parsers_file              /etc/fluent-bit/parsers-nftables.conf
 
 [INPUT]
     Name              systemd
@@ -20,6 +21,16 @@
     # First start skips the existing journal (1.9G/node) rather than
     # backfilling it into o11y.
     Read_From_Tail    On
+    storage.type      filesystem
+
+# nftables drop events: ulogd2 (roles/security) decodes NFLOG into JSON lines.
+# Same output, own tag, so the journald noise filter cannot touch them.
+[INPUT]
+    Name              tail
+    Tag               host.nftables
+    Path              {{ ceph_fluentbit_droplog_file }}
+    Parser            nft_drop_json
+    DB                /var/lib/fluent-bit/nft-drop.db
     storage.type      filesystem
 
 # ~2.4M lines/hour fleet-wide is nearly all mon/mgr status chatter. The mon
@@ -35,6 +46,21 @@
     Record cluster {{ ceph_fluentbit_cluster_label }}
     Record site {{ ceph_fluentbit_site_label }}
     Record env {{ ceph_fluentbit_env_label }}
+
+# Drop events carry ulogd2 field names, not journald ones. Synthesize MESSAGE
+# (VictoriaLogs _msg) and both stream fields so they land in the same schema
+# as the journald stream and join it per host.
+[FILTER]
+    Name   lua
+    Match  host.nftables
+    script /etc/fluent-bit/nft-drop-message.lua
+    call   nft_drop_message
+
+[FILTER]
+    Name   record_modifier
+    Match  host.nftables
+    Record HOSTNAME {{ inventory_hostname }}
+    Record SYSLOG_IDENTIFIER nftables-drop
 
 [OUTPUT]
     Name                     http

--- a/ansible/ceph/roles/security/defaults/main.yml
+++ b/ansible/ceph/roles/security/defaults/main.yml
@@ -64,6 +64,20 @@ ceph_firewall_nfs_enabled: false
 ceph_firewall_nfs_port: 2049
 ceph_firewall_nfs_mgmt_port: 12049
 
+# --- Firewall drop logging (NFLOG -> ulogd2) ---
+# The drop rule logs over NFLOG, not printk, so the journal and the kmsg ring
+# buffer never see scanner noise. ulogd2 listens on the group and writes one
+# JSON event per drop; roles/fluentbit tails that file to o11y.
+ceph_firewall_droplog_group: 0
+# Headers only: 64 bytes covers IP + TCP/UDP, which is all ulogd2 decodes.
+ceph_firewall_droplog_snaplen: 64
+# Packets per netlink datagram. The kernel still flushes partial batches on
+# its ~1s nfnetlink_log timer, so batching costs at most ~1s of latency.
+ceph_firewall_droplog_threshold: 64
+# roles/fluentbit's ceph_fluentbit_droplog_file default must match this path;
+# the roles run in different playbooks, so neither can reference the other.
+ceph_firewall_droplog_file: /var/log/ulog/nft-drop.json
+
 # Allow SSH from any source (true) or restrict to trusted networks (false).
 # Default true for dev/bootstrapping. Set false in production once
 # management networks are confirmed.

--- a/ansible/ceph/roles/security/handlers/main.yml
+++ b/ansible/ceph/roles/security/handlers/main.yml
@@ -3,3 +3,8 @@
   ansible.builtin.systemd:
     name: sshd
     state: restarted
+
+- name: Restart ulogd2
+  ansible.builtin.systemd:
+    name: ulogd2
+    state: restarted

--- a/ansible/ceph/roles/security/tasks/main.yml
+++ b/ansible/ceph/roles/security/tasks/main.yml
@@ -10,6 +10,49 @@
     name: nftables
     state: present
 
+# --- Firewall drop logging (ulogd2) ---
+# ulogd2 listens on the NFLOG group the drop rule logs to (role defaults have
+# the why). It converges BEFORE the ruleset so the group never emits into the
+# void, and the handler flush below applies a config-change restart now rather
+# than at end of play, where old-config ulogd2 would listen the whole play.
+
+- name: Install ulogd2 (NFLOG listener + JSON output)
+  ansible.builtin.apt:
+    name:
+      - ulogd2
+      - ulogd2-json
+    state: present
+  when: ceph_firewall_enabled | bool
+
+- name: Deploy ulogd2 config
+  ansible.builtin.template:
+    src: ulogd.conf.j2
+    dest: /etc/ulogd.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart ulogd2
+  when: ceph_firewall_enabled | bool
+
+- name: Rotate the drop log
+  ansible.builtin.template:
+    src: nft-drop.logrotate.j2
+    dest: /etc/logrotate.d/nft-drop
+    owner: root
+    group: root
+    mode: '0644'
+  when: ceph_firewall_enabled | bool
+
+- name: Enable and start ulogd2
+  ansible.builtin.systemd:
+    name: ulogd2
+    enabled: true
+    state: started
+  when: ceph_firewall_enabled | bool
+
+- name: Apply any pending ulogd2 restart before the ruleset goes live
+  ansible.builtin.meta: flush_handlers
+
 - name: Deploy nftables ruleset
   ansible.builtin.template:
     src: nftables.conf.j2
@@ -29,12 +72,14 @@
 # state is normalized by loading the config into a throwaway network namespace --
 # fully isolated, it never touches the live firewall -- then its table inet filter
 # is compared to the live one. Both sides go through nft's own output formatting,
-# so the match is on effective rules, not file text. Anything inconclusive falls
+# so the match is on effective rules, not file text. Counter VALUES are masked
+# before comparing: the live rule has counted packets, the netns one never has,
+# and that difference is not drift. Anything inconclusive falls
 # back to reloading (DIFF), so the firewall is never left stale or drifted.
 - name: Compare the live nftables ruleset against the desired one
   ansible.builtin.shell: |
     set -o pipefail
-    norm() { grep -vE '^[[:space:]]*#' | sed -E 's/[[:space:]]+/ /g; s/^ +//; s/ +$//' | grep -v '^$'; }
+    norm() { grep -vE '^[[:space:]]*#' | sed -E 's/counter packets [0-9]+ bytes [0-9]+/counter/; s/[[:space:]]+/ /g; s/^ +//; s/ +$//' | grep -v '^$'; }
     live="$(nft list table inet filter 2>/dev/null | norm)"
     ns="nft-cmp-$$"
     ip netns add "$ns"

--- a/ansible/ceph/roles/security/templates/nft-drop.logrotate.j2
+++ b/ansible/ceph/roles/security/templates/nft-drop.logrotate.j2
@@ -1,0 +1,15 @@
+# Managed by Ansible (security role). Rotation for the nftables drop log
+# written by ulogd2. Not copytruncate: ulogd2 reopens on HUP and fluent-bit's
+# tail input follows the rename, so nothing is lost at the boundary.
+{{ ceph_firewall_droplog_file }} {
+    daily
+    rotate 14
+    maxsize 512M
+    compress
+    delaycompress
+    missingok
+    notifempty
+    postrotate
+        systemctl kill -s HUP ulogd2.service
+    endscript
+}

--- a/ansible/ceph/roles/security/templates/nftables.conf.j2
+++ b/ansible/ceph/roles/security/templates/nftables.conf.j2
@@ -85,8 +85,9 @@ table inet filter {
 {% endif %}
 {% endfor %}
 
-        # Log + drop everything else
-        limit rate 5/minute log prefix "nftables-drop: " level warn
+        # Count + log every drop over NFLOG to ulogd2 (role defaults have
+        # the why); no printk, so nothing lands in kmsg or the journal.
+        counter log prefix "nftables-drop" group {{ ceph_firewall_droplog_group }} snaplen {{ ceph_firewall_droplog_snaplen }} queue-threshold {{ ceph_firewall_droplog_threshold }}
         drop
     }
 

--- a/ansible/ceph/roles/security/templates/ulogd.conf.j2
+++ b/ansible/ceph/roles/security/templates/ulogd.conf.j2
@@ -1,0 +1,25 @@
+# Firewall drop logging - managed by Ansible (security role).
+# NFLOG group {{ ceph_firewall_droplog_group }} (the nftables drop rule) in,
+# one JSON event per dropped packet out. roles/fluentbit tails the file to o11y.
+
+[global]
+logfile="syslog"
+loglevel=3
+
+plugin="/usr/lib/x86_64-linux-gnu/ulogd/ulogd_inppkt_NFLOG.so"
+plugin="/usr/lib/x86_64-linux-gnu/ulogd/ulogd_raw2packet_BASE.so"
+plugin="/usr/lib/x86_64-linux-gnu/ulogd/ulogd_filter_IFINDEX.so"
+plugin="/usr/lib/x86_64-linux-gnu/ulogd/ulogd_filter_IP2STR.so"
+plugin="/usr/lib/x86_64-linux-gnu/ulogd/ulogd_output_JSON.so"
+
+stack=drop1:NFLOG,base1:BASE,ifi1:IFINDEX,ip2str1:IP2STR,json1:JSON
+
+[drop1]
+group={{ ceph_firewall_droplog_group }}
+
+[json1]
+# Flush per event: fluent-bit tails this file, and a page-cache-buffered write
+# would sit unshipped indefinitely at low drop rates.
+sync=1
+file="{{ ceph_firewall_droplog_file }}"
+timestamp=1


### PR DESCRIPTION
Firewall drops on ceph nodes now log over NFLOG to ulogd2, which writes one JSON event per dropped packet to /var/log/ulog/nft-drop.json (rotated, 14 days); fluent-bit tails the file and ships every event to o11y with a synthesized \_msg and the same stream schema as the journald pipeline. Nothing goes through printk anymore, so scanner noise stops filling the journal and the kmsg ring buffer, and full fidelity replaces the old 5/minute sample: the rule's counter shows the sample was hiding roughly 99% of drops. Verified end to end on spice-ceph-adelia: zero kernel drop lines since the reload, events queryable in VictoriaLogs seconds after the packet, at roughly 500-800 events/node/hour. See ansible/ceph/docs/security-model.md.

- `main` <!-- branch-stack -->
  - \#518 :point\_left:
