### PR TITLE
fix(michael): converge retried WORM puts when the existing blob matches

### DIFF
--- a/docs/restic-retries.md
+++ b/docs/restic-retries.md
@@ -1,0 +1,77 @@
+# Restic client retry behavior
+
+What the restic client does when michael returns an error. Michael's own
+resilience mechanisms (the S3 backend pool, its retries and circuit breakers)
+are designed around this contract, so status-code decisions in
+`packages/michael` should be checked against this document — and this document
+against restic's source when it moves.
+
+Sourced from restic `internal/backend/retry/backend_retry.go` and
+`internal/backend/rest/rest.go` as of August 2026 (restic ≥ 0.17 semantics; the
+`backend-error-redesign` feature flag is Beta and therefore **on by default**).
+
+## The retry envelope
+
+Every backend operation (Load, Save, Stat, Remove, List) is wrapped in a retry
+layer: exponential backoff starting at 1s, doubling per attempt, capped at 60s
+per interval, retrying until **15 minutes** have elapsed (hardcoded). There is
+no attempt cap. A cancelled context aborts immediately.
+
+Consequences for michael:
+
+- An outage shorter than ~15 minutes is invisible to users **if** michael fails
+  fast: the operation succeeds on a later retry and the backup completes.
+- Every response that hangs (e.g. waiting on a dead gateway's dial timeout)
+  burns the client's fixed 15-minute window without advancing it.
+
+## Permanent vs retryable status codes
+
+`IsPermanentError` for the REST backend: **404, 401, 403, 416, 507** abort the
+operation immediately. Everything else — 500, 502, **503**, timeouts, resets,
+any transport error — is retried for the full window.
+
+| michael returns | restic does |
+|---|---|
+| 500 / 503 | retries with backoff, up to 15 min |
+| 403 (WORM violation, "already exists") | fails the operation permanently |
+| 404 on HEAD | treats as "does not exist" (permanent, but often the expected answer) |
+| 400 | retried (not in the permanent set) — avoid for terminal conditions |
+
+Restic does **not** read `Retry-After`; its backoff is fixed client-side. The
+header is still worth sending for other clients, but it cannot pace restic.
+
+## The per-file Load breaker
+
+Restic keeps its own circuit breaker per file: a `Load` that exhausts retries
+on a *non-permanent* error marks that file failed for **one hour**, and every
+further read of it fails instantly. A transient gateway blip surfaced as a 500
+can therefore lock a client out of a pack file for an hour mid-restore — which
+is why michael masks single-gateway failures instead of forwarding them.
+
+## Save failure recovery, and the WORM trap
+
+On a failed `Save`, restic issues a cleanup `Remove` for the possibly-partial
+upload (errors ignored — rest-server reports `HasAtomicReplace=false`), rewinds
+its pack (restic's own body IS seekable) and re-POSTs.
+
+On a WORM repository this recovery used to be a trap. If the failure was
+*ambiguous* — michael reported an error but the gateway committed the object:
+
+1. the cleanup `Remove` is refused (WORM forbids deleting data blobs);
+2. the re-POST hits the `If-None-Match: *` precondition → 412;
+3. michael surfaced that as 403 "Blob already exists";
+4. 403 is permanent → the backup failed hard, with the blob stored correctly.
+
+Michael therefore converges this case: a write-once PUT that fails its
+precondition, for a content-addressed key, where the existing object's size
+matches the incoming one, returns 200 (see `S3Storage.PutObject`). Blob keys
+are the content's sha256 and michael verified that hash when the object was
+first written, so the size check identifies the same blob without re-reading
+it. The config object's key is not content-addressed and is excluded.
+
+## Save bodies vs michael's PUT path
+
+Restic retries `Save` with a rewindable body — but the stream michael proxies
+to S3 is **not** seekable, which is why the aws-sdk retryer is disabled on
+michael's PUT path and michael never retries an upload itself: any transient
+failure surfaces once, cleanly, and restic re-drives the upload end-to-end.

--- a/packages/michael/internal/storage/s3.go
+++ b/packages/michael/internal/storage/s3.go
@@ -282,6 +282,11 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 	})
 	if err != nil {
 		if isPreconditionFailed(err) {
+			// Only content-addressed writes converge: for keys that aren't the
+			// content's hash (the config object) a size match proves nothing.
+			if sha256Hex != "" && s.existingBlobMatches(ctx, bucket, key, contentLength) {
+				return nil
+			}
 			return ErrPreconditionFailed
 		}
 		return fmt.Errorf("put object: %w", err)
@@ -297,6 +302,23 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 	}
 
 	return nil
+}
+
+// existingBlobMatches reports whether the object that failed a write-once
+// PUT's precondition already holds this exact blob. Restic recovers from an
+// ambiguously-failed upload (michael reported an error but the gateway
+// committed the object) by re-POSTing the pack — on a WORM repository that
+// lands here as a 412, and surfacing it as an error would turn a healed
+// transient into a permanent backup failure (403 is permanent for restic; see
+// docs/restic-retries.md). Blob keys are the content's sha256 and every object
+// written through michael had that hash verified on the wire, so a size match
+// identifies the same blob without re-reading it.
+func (s *S3Storage) existingBlobMatches(ctx context.Context, bucket, key string, contentLength int64) bool {
+	if contentLength <= 0 {
+		return false
+	}
+	size, err := s.HeadObject(ctx, bucket, key)
+	return err == nil && size == contentLength
 }
 
 // sha256Writer wraps a hash.Hash for use with io.TeeReader.

--- a/packages/michael/internal/storage/s3_test.go
+++ b/packages/michael/internal/storage/s3_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -217,6 +218,92 @@ func TestPutObject_NonSeekableBodyOn503_NoRewindRetry(t *testing.T) {
 	// And with retries off, the gateway must see exactly one upload attempt.
 	if n := puts.Load(); n != 1 {
 		t.Fatalf("expected exactly 1 upload attempt (no retry on a non-seekable body), got %d", n)
+	}
+}
+
+// worm412Server simulates a WORM gateway mid restic-Save-recovery: every PUT
+// hits the If-None-Match precondition (the ambiguously-failed upload actually
+// committed), and HEAD reports the committed object's size.
+func worm412Server(headStatus int, headSize int64, puts, heads *atomic.Int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			puts.Add(1)
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodHead:
+			heads.Add(1)
+			if headStatus != http.StatusOK {
+				w.WriteHeader(headStatus)
+				return
+			}
+			w.Header().Set("Content-Length", strconv.FormatInt(headSize, 10))
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+const testBlobName = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestPutObject_PreconditionWithMatchingBlob_ConvergesToSuccess(t *testing.T) {
+	body := "restic-pack-bytes"
+	var puts, heads atomic.Int32
+	srv := worm412Server(http.StatusOK, int64(len(body)), &puts, &heads)
+	defer srv.Close()
+
+	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
+	err := s.PutObject(context.Background(), "bucket", "data/"+testBlobName, readOnly{strings.NewReader(body)}, int64(len(body)), true, testBlobName)
+	if err != nil {
+		t.Fatalf("expected converged success for matching existing blob, got %v", err)
+	}
+	if heads.Load() != 1 {
+		t.Errorf("expected 1 HEAD to verify the existing blob, got %d", heads.Load())
+	}
+}
+
+func TestPutObject_PreconditionWithDifferentSize_Fails(t *testing.T) {
+	body := "restic-pack-bytes"
+	var puts, heads atomic.Int32
+	srv := worm412Server(http.StatusOK, 999, &puts, &heads)
+	defer srv.Close()
+
+	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
+	err := s.PutObject(context.Background(), "bucket", "data/"+testBlobName, readOnly{strings.NewReader(body)}, int64(len(body)), true, testBlobName)
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed for size mismatch, got %v", err)
+	}
+}
+
+func TestPutObject_PreconditionHeadError_Fails(t *testing.T) {
+	body := "restic-pack-bytes"
+	var puts, heads atomic.Int32
+	srv := worm412Server(http.StatusInternalServerError, 0, &puts, &heads)
+	defer srv.Close()
+
+	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
+	err := s.PutObject(context.Background(), "bucket", "data/"+testBlobName, readOnly{strings.NewReader(body)}, int64(len(body)), true, testBlobName)
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed when verification HEAD fails, got %v", err)
+	}
+}
+
+func TestPutObject_PreconditionWithoutContentHash_Fails(t *testing.T) {
+	// The config object's key is not a content hash, so a size match proves
+	// nothing and the 412 must surface.
+	body := "repo-config"
+	var puts, heads atomic.Int32
+	srv := worm412Server(http.StatusOK, int64(len(body)), &puts, &heads)
+	defer srv.Close()
+
+	s := NewS3StorageForEndpoint(probeConfig(), srv.URL)
+	err := s.PutObject(context.Background(), "bucket", "config", readOnly{strings.NewReader(body)}, int64(len(body)), true, "")
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed for non-content-addressed key, got %v", err)
+	}
+	if heads.Load() != 0 {
+		t.Errorf("expected no verification HEAD for non-content-addressed key, got %d", heads.Load())
 	}
 }
 


### PR DESCRIPTION
Restic's Save recovery re-POSTs after ambiguous failures; on WORM repos the resulting 412 must converge to 200 for matching blobs instead of failing the backup permanently (docs/restic-retries.md).

- `main` <!-- branch-stack -->
  - \#526 :point\_left:
    - \#527
      - \#528
        - \#529
