### PR TITLE
feat(michael): budgeted cross-backend retries in the S3 pool

### DIFF
--- a/kubernetes/apps/base/michael/helmrelease.yaml
+++ b/kubernetes/apps/base/michael/helmrelease.yaml
@@ -78,6 +78,15 @@ spec:
         value: "3"
       - name: S3_RECONCILE_INTERVAL_MS
         value: "5000"
+      # Cross-backend retry budget (michael's defaults, surfaced likewise): a
+      # retry spends COST tokens, every success earns EARN back, CAP bounds how
+      # many retries a burst can spend before the budget must refill.
+      - name: S3_RETRY_TOKEN_EARN
+        value: "1"
+      - name: S3_RETRY_TOKEN_COST
+        value: "10"
+      - name: S3_RETRY_BUDGET_CAP
+        value: "200"
       - name: OTLP_METRICS_ENDPOINT
         value: ${VMAGENT_OTLP}
       - name: OTLP_METRICS_URL_PATH

--- a/packages/michael/internal/config/clusters_test.go
+++ b/packages/michael/internal/config/clusters_test.go
@@ -21,6 +21,9 @@ func testDefaultCluster() ClusterConfig {
 		S3ProbeBucket:       "michael-probe",
 		S3EjectThreshold:    3,
 		S3ReconcileInterval: 5 * time.Second,
+		S3RetryTokenEarn:    2,
+		S3RetryTokenCost:    12,
+		S3RetryBudgetCap:    120,
 	}
 }
 
@@ -44,7 +47,10 @@ func TestParseClustersFull(t *testing.T) {
 	      "tls_skip_verify": false,
 	      "probe_bucket": "spice-probe",
 	      "eject_threshold": 5,
-	      "reconcile_interval_ms": 250
+	      "reconcile_interval_ms": 250,
+	      "retry_token_earn": 3,
+	      "retry_token_cost": 30,
+	      "retry_budget_cap": 90
 	    }
 	  ]
 	}`
@@ -76,6 +82,9 @@ func TestParseClustersFull(t *testing.T) {
 		S3ProbeBucket:       "spice-probe",
 		S3EjectThreshold:    5,
 		S3ReconcileInterval: 250 * time.Millisecond,
+		S3RetryTokenEarn:    3,
+		S3RetryTokenCost:    30,
+		S3RetryBudgetCap:    90,
 	}
 	if got[0] != want {
 		t.Errorf("cluster mismatch:\n got %+v\nwant %+v", got[0], want)
@@ -99,6 +108,9 @@ func TestParseClustersInheritsDefaults(t *testing.T) {
 	}
 	if c.S3ProbeBucket != "michael-probe" || c.S3EjectThreshold != 3 || c.S3ReconcileInterval != 5*time.Second {
 		t.Errorf("expected the default pool tunables to be inherited, got %+v", c)
+	}
+	if c.S3RetryTokenEarn != 2 || c.S3RetryTokenCost != 12 || c.S3RetryBudgetCap != 120 {
+		t.Errorf("expected the default retry budget knobs to be inherited, got %+v", c)
 	}
 	if c.S3BackendSource != "" || c.S3BackendDNSHost != "" || c.S3BackendFile != "" {
 		t.Errorf("backend source must not be inherited from the default cluster, got %+v", c)

--- a/packages/michael/internal/config/config.go
+++ b/packages/michael/internal/config/config.go
@@ -42,6 +42,11 @@ type Config struct {
 	S3ProbeBucket       string // sentinel bucket for active health probes
 	S3EjectThreshold    int    // consecutive transport failures before ejection
 	S3ReconcileInterval time.Duration
+	// Cross-backend retry budget knobs; zero means the pool default (earn 1,
+	// cost 10, cap 20 retries' worth).
+	S3RetryTokenEarn int
+	S3RetryTokenCost int
+	S3RetryBudgetCap int
 
 	// S3DefaultCluster is the code of the storage cluster the flat S3_* fields
 	// above describe. Requests whose token carries no storageCluster claim are
@@ -92,6 +97,9 @@ type ClusterConfig struct {
 	S3ProbeBucket       string
 	S3EjectThreshold    int
 	S3ReconcileInterval time.Duration
+	S3RetryTokenEarn    int
+	S3RetryTokenCost    int
+	S3RetryBudgetCap    int
 }
 
 // DefaultCluster returns the cluster described by the flat S3_* configuration.
@@ -113,6 +121,9 @@ func (c Config) DefaultCluster() ClusterConfig {
 		S3ProbeBucket:       c.S3ProbeBucket,
 		S3EjectThreshold:    c.S3EjectThreshold,
 		S3ReconcileInterval: c.S3ReconcileInterval,
+		S3RetryTokenEarn:    c.S3RetryTokenEarn,
+		S3RetryTokenCost:    c.S3RetryTokenCost,
+		S3RetryBudgetCap:    c.S3RetryBudgetCap,
 	}
 }
 
@@ -191,6 +202,10 @@ func LoadConfig() Config {
 			log.Fatal().Msg("S3_EJECT_THRESHOLD must be a number >= 1")
 		}
 	}
+
+	retryTokenEarn := envPoolKnob("S3_RETRY_TOKEN_EARN")
+	retryTokenCost := envPoolKnob("S3_RETRY_TOKEN_COST")
+	retryBudgetCap := envPoolKnob("S3_RETRY_BUDGET_CAP")
 
 	reconcileInterval := 5 * time.Second
 	if v := os.Getenv("S3_RECONCILE_INTERVAL_MS"); v != "" {
@@ -275,6 +290,9 @@ func LoadConfig() Config {
 		S3ProbeBucket:       probeBucket,
 		S3EjectThreshold:    ejectThreshold,
 		S3ReconcileInterval: reconcileInterval,
+		S3RetryTokenEarn:    retryTokenEarn,
+		S3RetryTokenCost:    retryTokenCost,
+		S3RetryBudgetCap:    retryBudgetCap,
 		S3DefaultCluster:    defaultCluster,
 		ASNDatabasePath:     asnDatabasePath,
 		ClientIPHeader:      clientIPHeader,
@@ -372,6 +390,9 @@ type clusterEntry struct {
 	ProbeBucket         string `json:"probe_bucket"`
 	EjectThreshold      int    `json:"eject_threshold"`
 	ReconcileIntervalMS int    `json:"reconcile_interval_ms"`
+	RetryTokenEarn      int    `json:"retry_token_earn"`
+	RetryTokenCost      int    `json:"retry_token_cost"`
+	RetryBudgetCap      int    `json:"retry_budget_cap"`
 }
 
 // ParseClusters decodes the S3_CLUSTERS_FILE contents into the additional
@@ -519,6 +540,9 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 	if e.ReconcileIntervalMS < 0 {
 		return ClusterConfig{}, fmt.Errorf("cluster %q: reconcile_interval_ms must be >= 1", e.Code)
 	}
+	if e.RetryTokenEarn < 0 || e.RetryTokenCost < 0 || e.RetryBudgetCap < 0 {
+		return ClusterConfig{}, fmt.Errorf("cluster %q: retry budget knobs must be >= 1", e.Code)
+	}
 
 	scheme, port := schemeAndPort(e.Endpoint)
 	cc := ClusterConfig{
@@ -538,6 +562,9 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 		S3ProbeBucket:       firstNonEmpty(e.ProbeBucket, def.S3ProbeBucket),
 		S3EjectThreshold:    def.S3EjectThreshold,
 		S3ReconcileInterval: def.S3ReconcileInterval,
+		S3RetryTokenEarn:    intOr(e.RetryTokenEarn, def.S3RetryTokenEarn),
+		S3RetryTokenCost:    intOr(e.RetryTokenCost, def.S3RetryTokenCost),
+		S3RetryBudgetCap:    intOr(e.RetryBudgetCap, def.S3RetryBudgetCap),
 	}
 	if e.EjectThreshold > 0 {
 		cc.S3EjectThreshold = e.EjectThreshold
@@ -546,6 +573,27 @@ func (e clusterEntry) toConfig(def ClusterConfig, getenv func(string) string) (C
 		cc.S3ReconcileInterval = time.Duration(e.ReconcileIntervalMS) * time.Millisecond
 	}
 	return cc, nil
+}
+
+// envPoolKnob reads an optional positive-integer pool tunable; 0 (unset)
+// means "use the pool's default".
+func envPoolKnob(key string) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		log.Fatal().Msgf("%s must be a number >= 1", key)
+	}
+	return n
+}
+
+func intOr(v, fallback int) int {
+	if v > 0 {
+		return v
+	}
+	return fallback
 }
 
 func firstNonEmpty(v, fallback string) string {

--- a/packages/michael/internal/metrics/backend.go
+++ b/packages/michael/internal/metrics/backend.go
@@ -10,11 +10,12 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
-// BackendStatsProvider yields a per-backend snapshot. *storage.Pool implements
-// it. Kept as an interface so the metrics layer doesn't depend on the pool's
-// internals and can be tested with a stub.
+// BackendStatsProvider yields per-backend and pool-wide snapshots.
+// *storage.Pool implements it. Kept as an interface so the metrics layer
+// doesn't depend on the pool's internals and can be tested with a stub.
 type BackendStatsProvider interface {
 	Stats() []storage.BackendStat
+	PoolStats() storage.PoolStat
 }
 
 // RegisterBackendMetrics wires per-backend S3 load-balancer metrics onto meter,
@@ -61,6 +62,16 @@ func RegisterBackendMetrics(meter otelmetric.Meter, providers map[string]Backend
 	if err != nil {
 		return fmt.Errorf("creating s3.backend.healthy: %w", err)
 	}
+	retries, err := meter.Int64ObservableCounter("s3.pool.retries",
+		otelmetric.WithDescription("Cross-backend retries per pool, by outcome (success, failure, denied)"))
+	if err != nil {
+		return fmt.Errorf("creating s3.pool.retries: %w", err)
+	}
+	retryBudget, err := meter.Int64ObservableGauge("s3.pool.retry_budget",
+		otelmetric.WithDescription("Remaining cross-backend retry budget tokens per pool"))
+	if err != nil {
+		return fmt.Errorf("creating s3.pool.retry_budget: %w", err)
+	}
 
 	_, err = meter.RegisterCallback(
 		func(_ context.Context, o otelmetric.Observer) error {
@@ -77,10 +88,19 @@ func RegisterBackendMetrics(meter otelmetric.Meter, providers map[string]Backend
 					o.ObserveInt64(inflight, s.Inflight, attrs)
 					o.ObserveInt64(healthy, boolToInt64(s.Healthy), attrs)
 				}
+				ps := provider.PoolStats()
+				cluster := attribute.String("cluster", code)
+				retryOutcome := func(outcome string) otelmetric.MeasurementOption {
+					return otelmetric.WithAttributeSet(attribute.NewSet(cluster, attribute.String("outcome", outcome)))
+				}
+				o.ObserveInt64(retries, ps.RetrySuccesses, retryOutcome("success"))
+				o.ObserveInt64(retries, ps.RetryAttempts-ps.RetrySuccesses, retryOutcome("failure"))
+				o.ObserveInt64(retries, ps.RetryDenied, retryOutcome("denied"))
+				o.ObserveInt64(retryBudget, ps.RetryBudget, otelmetric.WithAttributeSet(attribute.NewSet(cluster)))
 			}
 			return nil
 		},
-		requests, requestErrors, downloaded, uploaded, inflight, healthy,
+		requests, requestErrors, downloaded, uploaded, inflight, healthy, retries, retryBudget,
 	)
 	if err != nil {
 		return fmt.Errorf("registering backend metrics callback: %w", err)

--- a/packages/michael/internal/metrics/backend_test.go
+++ b/packages/michael/internal/metrics/backend_test.go
@@ -11,9 +11,13 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-type stubProvider struct{ stats []storage.BackendStat }
+type stubProvider struct {
+	stats []storage.BackendStat
+	pool  storage.PoolStat
+}
 
 func (s stubProvider) Stats() []storage.BackendStat { return s.stats }
+func (s stubProvider) PoolStats() storage.PoolStat  { return s.pool }
 
 func TestRegisterBackendMetrics(t *testing.T) {
 	reader := metric.NewManualReader()
@@ -21,10 +25,13 @@ func TestRegisterBackendMetrics(t *testing.T) {
 	meter := mp.Meter("test")
 
 	providers := map[string]BackendStatsProvider{
-		"default": stubProvider{stats: []storage.BackendStat{
-			{Endpoint: "http://a:80", Healthy: true, Inflight: 2, Requests: 10, Errors: 1, DownloadedBytes: 100, UploadedBytes: 50},
-			{Endpoint: "http://b:80", Healthy: false, Inflight: 0, Requests: 3, Errors: 3, DownloadedBytes: 0, UploadedBytes: 7},
-		}},
+		"default": stubProvider{
+			stats: []storage.BackendStat{
+				{Endpoint: "http://a:80", Healthy: true, Inflight: 2, Requests: 10, Errors: 1, DownloadedBytes: 100, UploadedBytes: 50},
+				{Endpoint: "http://b:80", Healthy: false, Inflight: 0, Requests: 3, Errors: 3, DownloadedBytes: 0, UploadedBytes: 7},
+			},
+			pool: storage.PoolStat{RetryAttempts: 5, RetrySuccesses: 4, RetryDenied: 2, RetryBudget: 150},
+		},
 		// Same endpoint as the default cluster's first backend: only the cluster
 		// attribute keeps the two series apart.
 		"spice": stubProvider{stats: []storage.BackendStat{
@@ -73,6 +80,12 @@ func TestRegisterBackendMetrics(t *testing.T) {
 		// The second cluster's identically-addressed backend stays its own series.
 		{"s3.backend.requests", "spice/http://a:80", 4},
 		{"s3.backend.inflight", "spice/http://a:80", 1},
+		// Pool-wide retry series carry cluster+outcome, no backend.
+		{"s3.pool.retries", "default//success", 4},
+		{"s3.pool.retries", "default//failure", 1},
+		{"s3.pool.retries", "default//denied", 2},
+		{"s3.pool.retry_budget", "default/", 150},
+		{"s3.pool.retries", "spice//success", 0},
 	}
 	for _, c := range checks {
 		series, ok := got[c.metric]
@@ -87,7 +100,11 @@ func TestRegisterBackendMetrics(t *testing.T) {
 }
 
 func seriesKey(set attribute.Set) string {
-	return attrValue(set, "cluster") + "/" + attrValue(set, "backend")
+	key := attrValue(set, "cluster") + "/" + attrValue(set, "backend")
+	if outcome := attrValue(set, "outcome"); outcome != "" {
+		key += "/" + outcome
+	}
+	return key
 }
 
 func attrValue(set attribute.Set, key attribute.Key) string {

--- a/packages/michael/internal/storage/pool.go
+++ b/packages/michael/internal/storage/pool.go
@@ -18,6 +18,16 @@ const probeTimeout = 5 * time.Second
 // ErrNoBackends is returned when the pool has no backend to route a request to.
 var ErrNoBackends = errors.New("no S3 backends available")
 
+// Cross-backend retries are paid from a token budget refilled by successful
+// traffic (by default one token per success, ten per retry, so at most ~1
+// retry per 10 successes): a healthy pool masks isolated gateway failures,
+// while a cluster-wide brownout cannot be amplified by retrying into it.
+const (
+	defaultRetryTokenEarn       = 1
+	defaultRetryTokenCost       = 10
+	defaultRetryBudgetCapFactor = 20 // cap defaults to this many retries' worth
+)
+
 // Prober is implemented by backends that support an active liveness probe.
 // *S3Storage satisfies it; the reconciler skips probing for stores that don't.
 type Prober interface {
@@ -58,11 +68,14 @@ type backend struct {
 	uploadedBytes   atomic.Int64
 }
 
-// PoolConfig holds the tunables for a Pool.
+// PoolConfig holds the tunables for a Pool. Zero values take the defaults.
 type PoolConfig struct {
 	EjectThreshold    int           // consecutive transport failures before ejection
 	ProbeBucket       string        // sentinel bucket name for active health probes
 	ReconcileInterval time.Duration // how often Run re-resolves and probes
+	RetryTokenEarn    int           // budget tokens earned per successful request
+	RetryTokenCost    int           // budget tokens one cross-backend retry spends
+	RetryBudgetCap    int           // budget ceiling (bounds how many retries a burst can spend)
 }
 
 // Pool implements Storage by load-balancing requests across a set of
@@ -80,6 +93,23 @@ type Pool struct {
 	interval    time.Duration
 	pickCounter atomic.Uint64
 	logger      zerolog.Logger
+
+	budget         atomic.Int64
+	retryTokenEarn int64
+	retryTokenCost int64
+	retryBudgetCap int64
+	retries        atomic.Int64
+	retrySuccesses atomic.Int64
+	retryDenied    atomic.Int64
+}
+
+// PoolStat is a pool-wide snapshot of the cross-backend retry machinery,
+// consumed by the metrics layer.
+type PoolStat struct {
+	RetryAttempts  int64
+	RetrySuccesses int64
+	RetryDenied    int64
+	RetryBudget    int64
 }
 
 var _ Storage = (*Pool)(nil)
@@ -101,8 +131,21 @@ func NewPool(cfg PoolConfig, factory BackendFactory, resolver Resolver, logger z
 	if p.interval <= 0 {
 		p.interval = 5 * time.Second
 	}
+	p.retryTokenEarn = int64(cfg.RetryTokenEarn)
+	p.retryTokenCost = int64(cfg.RetryTokenCost)
+	p.retryBudgetCap = int64(cfg.RetryBudgetCap)
+	if p.retryTokenEarn < 1 {
+		p.retryTokenEarn = defaultRetryTokenEarn
+	}
+	if p.retryTokenCost < 1 {
+		p.retryTokenCost = defaultRetryTokenCost
+	}
+	if p.retryBudgetCap < 1 {
+		p.retryBudgetCap = defaultRetryBudgetCapFactor * p.retryTokenCost
+	}
 	empty := []*backend{}
 	p.backends.Store(&empty)
+	p.budget.Store(p.retryBudgetCap)
 
 	if err := p.Reconcile(context.Background()); err != nil {
 		return nil, err
@@ -263,10 +306,51 @@ func (p *Pool) pick() *backend {
 	return fallback
 }
 
+// pickHealthyOther returns the least-loaded healthy backend other than exclude,
+// or nil — a retry never fails open, it only moves to a backend believed good.
+func (p *Pool) pickHealthyOther(exclude *backend) *backend {
+	var best *backend
+	var bestLoad int64
+	for _, b := range p.snapshot() {
+		if b == exclude || !b.healthy.Load() {
+			continue
+		}
+		if load := b.inflight.Load(); best == nil || load < bestLoad {
+			best, bestLoad = b, load
+		}
+	}
+	return best
+}
+
+func (p *Pool) earnRetryToken() {
+	for {
+		cur := p.budget.Load()
+		if cur >= p.retryBudgetCap {
+			return
+		}
+		if p.budget.CompareAndSwap(cur, min(cur+p.retryTokenEarn, p.retryBudgetCap)) {
+			return
+		}
+	}
+}
+
+func (p *Pool) takeRetryTokens() bool {
+	for {
+		cur := p.budget.Load()
+		if cur < p.retryTokenCost {
+			return false
+		}
+		if p.budget.CompareAndSwap(cur, cur-p.retryTokenCost) {
+			return true
+		}
+	}
+}
+
 // recordResult updates a backend's counters and passive-ejection state after a
 // completed operation. A transport failure increments the consecutive-failure
 // streak and ejects once it crosses the threshold; any non-transport outcome
-// (success, or a normal 4xx like a missing blob) proves liveness and resets it.
+// (success, or a normal 4xx like a missing blob) proves liveness, resets the
+// streak, and refills the retry budget.
 func (p *Pool) recordResult(b *backend, err error) {
 	b.requests.Add(1)
 	if isBackendFailure(err) {
@@ -278,20 +362,48 @@ func (p *Pool) recordResult(b *backend, err error) {
 		return
 	}
 	b.failures.Store(0)
+	p.earnRetryToken()
 }
 
-// do runs an in-call operation (one that completes before returning) on a
-// picked backend, accounting inflight and recording the result.
-func (p *Pool) do(fn func(s Storage) error) error {
-	b := p.pick()
-	if b == nil {
-		return ErrNoBackends
-	}
+func (p *Pool) runOn(b *backend, fn func(s Storage) error) error {
 	b.inflight.Add(1)
 	err := fn(b.store)
 	b.inflight.Add(-1)
 	p.recordResult(b, err)
 	return err
+}
+
+func canAlwaysRetry() bool { return true }
+
+// do runs an in-call operation (one that completes before returning) on a
+// picked backend. On a transport-level failure, if canRetry allows it (nil
+// means never — the operation is not idempotent), the pool retries once on a
+// different healthy backend: restic would otherwise see a 500 for a blip a
+// sibling gateway would have absorbed, and its per-file Load breaker then
+// locks the affected blob out client-side for an hour (docs/restic-retries.md).
+func (p *Pool) do(ctx context.Context, canRetry func() bool, fn func(s Storage) error) error {
+	b := p.pick()
+	if b == nil {
+		return ErrNoBackends
+	}
+	err := p.runOn(b, fn)
+	if !isBackendFailure(err) || canRetry == nil || !canRetry() || ctx.Err() != nil {
+		return err
+	}
+	next := p.pickHealthyOther(b)
+	if next == nil {
+		return err
+	}
+	if !p.takeRetryTokens() {
+		p.retryDenied.Add(1)
+		return err
+	}
+	p.retries.Add(1)
+	rerr := p.runOn(next, fn)
+	if !isBackendFailure(rerr) {
+		p.retrySuccesses.Add(1)
+	}
+	return rerr
 }
 
 // Stats returns a per-backend snapshot for the metrics layer.
@@ -312,11 +424,21 @@ func (p *Pool) Stats() []BackendStat {
 	return stats
 }
 
+// PoolStats returns the pool-wide retry snapshot for the metrics layer.
+func (p *Pool) PoolStats() PoolStat {
+	return PoolStat{
+		RetryAttempts:  p.retries.Load(),
+		RetrySuccesses: p.retrySuccesses.Load(),
+		RetryDenied:    p.retryDenied.Load(),
+		RetryBudget:    p.budget.Load(),
+	}
+}
+
 // --- Storage interface ---
 
 func (p *Pool) CheckBucket(ctx context.Context, bucket string) (bool, error) {
 	var exists bool
-	err := p.do(func(s Storage) error {
+	err := p.do(ctx, canAlwaysRetry, func(s Storage) error {
 		var e error
 		exists, e = s.CheckBucket(ctx, bucket)
 		return e
@@ -325,14 +447,17 @@ func (p *Pool) CheckBucket(ctx context.Context, bucket string) (bool, error) {
 }
 
 func (p *Pool) CreateBucket(ctx context.Context, bucket string) error {
-	return p.do(func(s Storage) error {
+	// Never retried: an ambiguous first attempt may have created the bucket,
+	// and a second create then fails differently instead of surfacing the
+	// original error.
+	return p.do(ctx, nil, func(s Storage) error {
 		return s.CreateBucket(ctx, bucket)
 	})
 }
 
 func (p *Pool) HeadObject(ctx context.Context, bucket, key string) (int64, error) {
 	var size int64
-	err := p.do(func(s Storage) error {
+	err := p.do(ctx, canAlwaysRetry, func(s Storage) error {
 		var e error
 		size, e = s.HeadObject(ctx, bucket, key)
 		return e
@@ -340,18 +465,28 @@ func (p *Pool) HeadObject(ctx context.Context, bucket, key string) (int64, error
 	return size, err
 }
 
+// ListObjects retries only while nothing has been emitted: entries already
+// streamed to the caller cannot be taken back, and a fresh listing on another
+// backend would duplicate them.
 func (p *Pool) ListObjects(ctx context.Context, bucket, prefix string, fn func(BlobInfo) error) error {
-	return p.do(func(s Storage) error {
-		return s.ListObjects(ctx, bucket, prefix, fn)
+	var emitted atomic.Bool
+	return p.do(ctx, func() bool { return !emitted.Load() }, func(s Storage) error {
+		return s.ListObjects(ctx, bucket, prefix, func(b BlobInfo) error {
+			emitted.Store(true)
+			return fn(b)
+		})
 	})
 }
 
 func (p *Pool) DeleteObject(ctx context.Context, bucket, key string) error {
-	return p.do(func(s Storage) error {
+	return p.do(ctx, canAlwaysRetry, func(s Storage) error {
 		return s.DeleteObject(ctx, bucket, key)
 	})
 }
 
+// PutObject is never retried: the body is the client's stream and can only be
+// consumed once — restic re-drives failed uploads itself with a rewindable
+// pack (docs/restic-retries.md).
 func (p *Pool) PutObject(ctx context.Context, bucket, key string, body io.Reader, contentLength int64, writeOnce bool, sha256Hex string) error {
 	b := p.pick()
 	if b == nil {
@@ -369,11 +504,35 @@ func (p *Pool) PutObject(ctx context.Context, bucket, key string, body io.Reader
 	return err
 }
 
+// GetObject retries header-phase failures on a different healthy backend; once
+// headers are returned the body is streamed by the caller and a mid-stream
+// failure cannot be replayed.
 func (p *Pool) GetObject(ctx context.Context, bucket, key, rangeHeader string) (*S3Object, error) {
 	b := p.pick()
 	if b == nil {
 		return nil, ErrNoBackends
 	}
+	obj, err := p.getFrom(ctx, b, bucket, key, rangeHeader)
+	if !isBackendFailure(err) || ctx.Err() != nil {
+		return obj, err
+	}
+	next := p.pickHealthyOther(b)
+	if next == nil {
+		return nil, err
+	}
+	if !p.takeRetryTokens() {
+		p.retryDenied.Add(1)
+		return nil, err
+	}
+	p.retries.Add(1)
+	obj, rerr := p.getFrom(ctx, next, bucket, key, rangeHeader)
+	if !isBackendFailure(rerr) {
+		p.retrySuccesses.Add(1)
+	}
+	return obj, rerr
+}
+
+func (p *Pool) getFrom(ctx context.Context, b *backend, bucket, key, rangeHeader string) (*S3Object, error) {
 	// The SDK returns headers here but the body is streamed by the caller after
 	// we return, so inflight must stay counted until the body is closed.
 	b.inflight.Add(1)

--- a/packages/michael/internal/storage/pool_test.go
+++ b/packages/michael/internal/storage/pool_test.go
@@ -24,6 +24,9 @@ type fakeStore struct {
 	getBody   string
 	getErr    error // mid-stream read error to inject into the returned body
 	calls     atomic.Int64
+
+	listItems             []BlobInfo
+	listFailAfterEmitting *int
 }
 
 func (f *fakeStore) transportErr() error {
@@ -55,9 +58,20 @@ func (f *fakeStore) HeadObject(_ context.Context, _, _ string) (int64, error) {
 	return 0, nil
 }
 
-func (f *fakeStore) ListObjects(_ context.Context, _, _ string, _ func(BlobInfo) error) error {
+func (f *fakeStore) ListObjects(_ context.Context, _, _ string, fn func(BlobInfo) error) error {
 	f.calls.Add(1)
 	if f.opFail.Load() {
+		return f.transportErr()
+	}
+	for i, item := range f.listItems {
+		if f.listFailAfterEmitting != nil && i == *f.listFailAfterEmitting {
+			return f.transportErr()
+		}
+		if err := fn(item); err != nil {
+			return err
+		}
+	}
+	if f.listFailAfterEmitting != nil && *f.listFailAfterEmitting >= len(f.listItems) {
 		return f.transportErr()
 	}
 	return nil
@@ -141,6 +155,11 @@ func (r *testResolver) Describe() string { return "test" }
 // endpoint to its *fakeStore so the test can toggle failures.
 func newTestPool(t *testing.T, eps []string, threshold int) (*Pool, *testResolver, map[string]*fakeStore) {
 	t.Helper()
+	return newTestPoolCfg(t, eps, PoolConfig{EjectThreshold: threshold, ReconcileInterval: time.Hour})
+}
+
+func newTestPoolCfg(t *testing.T, eps []string, cfg PoolConfig) (*Pool, *testResolver, map[string]*fakeStore) {
+	t.Helper()
 	reg := map[string]*fakeStore{}
 	var mu sync.Mutex
 	factory := func(endpoint string) (Storage, error) {
@@ -151,7 +170,7 @@ func newTestPool(t *testing.T, eps []string, threshold int) (*Pool, *testResolve
 		return f, nil
 	}
 	res := &testResolver{eps: eps}
-	p, err := NewPool(PoolConfig{EjectThreshold: threshold, ReconcileInterval: time.Hour}, factory, res, zerolog.Nop())
+	p, err := NewPool(cfg, factory, res, zerolog.Nop())
 	if err != nil {
 		t.Fatalf("NewPool: %v", err)
 	}
@@ -447,6 +466,224 @@ func TestPool_StatsReflectActivity(t *testing.T) {
 	}
 }
 
+func intp(v int) *int { return &v }
+
+func forcePick(p *Pool, ep string) {
+	for _, b := range p.snapshot() {
+		if b.endpoint != ep {
+			b.inflight.Add(1)
+		}
+	}
+}
+
+func TestPool_RetryMasksSingleBackendFailure(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err != nil {
+		t.Fatalf("expected retry on 'b' to mask the failure, got %v", err)
+	}
+	if got := reg["b"].calls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 call on 'b', got %d", got)
+	}
+	st := p.PoolStats()
+	if st.RetryAttempts != 1 || st.RetrySuccesses != 1 || st.RetryDenied != 0 {
+		t.Errorf("stats = %+v, want 1 attempt / 1 success / 0 denied", st)
+	}
+	if e := backendByEndpoint(p, "a").errors.Load(); e != 1 {
+		t.Errorf("failed attempt must still count against 'a', got %d errors", e)
+	}
+}
+
+func TestPool_NoRetryWithoutAnotherHealthyBackend(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	backendByEndpoint(p, "b").healthy.Store(false)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err == nil {
+		t.Fatal("expected the failure to surface with no healthy sibling")
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("unhealthy 'b' must not receive the retry, got %d calls", got)
+	}
+	st := p.PoolStats()
+	if st.RetryAttempts != 0 || st.RetryDenied != 0 {
+		t.Errorf("stats = %+v, want no attempts and no budget spend", st)
+	}
+	if st.RetryBudget != p.retryBudgetCap {
+		t.Errorf("budget must be untouched when there is nothing to retry onto, got %d", st.RetryBudget)
+	}
+}
+
+func TestPool_RetryDeniedWhenBudgetExhausted(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	p.budget.Store(0)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err == nil {
+		t.Fatal("expected the failure to surface with an empty budget")
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("'b' must not be tried without budget, got %d calls", got)
+	}
+	if st := p.PoolStats(); st.RetryDenied != 1 || st.RetryAttempts != 0 {
+		t.Errorf("stats = %+v, want 1 denied / 0 attempts", st)
+	}
+}
+
+func TestPool_SuccessesRefillRetryBudget(t *testing.T) {
+	p, _, _ := newTestPool(t, []string{"a", "b"}, 3)
+	p.budget.Store(0)
+	for range p.retryTokenCost {
+		_, _ = p.HeadObject(context.Background(), "bucket", "k")
+	}
+	if got := p.PoolStats().RetryBudget; got != p.retryTokenCost*p.retryTokenEarn {
+		t.Errorf("budget after %d successes = %d, want %d", p.retryTokenCost, got, p.retryTokenCost*p.retryTokenEarn)
+	}
+
+	p.budget.Store(p.retryBudgetCap - 1)
+	for range 5 {
+		_, _ = p.HeadObject(context.Background(), "bucket", "k")
+	}
+	if got := p.PoolStats().RetryBudget; got != p.retryBudgetCap {
+		t.Errorf("budget must cap at %d, got %d", p.retryBudgetCap, got)
+	}
+}
+
+func TestPool_PutObjectNeverRetries(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+
+	err := p.PutObject(context.Background(), "bucket", "k", strings.NewReader("x"), 1, true, "")
+	if err == nil {
+		t.Fatal("expected PUT failure to surface")
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("PUT must never move to another backend (body already consumed), got %d calls", got)
+	}
+	if st := p.PoolStats(); st.RetryAttempts != 0 {
+		t.Errorf("stats = %+v, want no retry attempts", st)
+	}
+}
+
+func TestPool_CreateBucketNeverRetries(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+
+	if err := p.CreateBucket(context.Background(), "bucket"); err == nil {
+		t.Fatal("expected create failure to surface")
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("non-idempotent create must not retry, got %d calls", got)
+	}
+}
+
+func TestPool_ListRetriesWhenNothingEmitted(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].listFailAfterEmitting = intp(0)
+	reg["b"].listItems = []BlobInfo{{Name: "data/aa", Size: 1}}
+
+	var got []BlobInfo
+	err := p.ListObjects(context.Background(), "bucket", "data/", func(b BlobInfo) error {
+		got = append(got, b)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected retried listing to succeed, got %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "data/aa" {
+		t.Errorf("expected 'b' listing, got %v", got)
+	}
+	if st := p.PoolStats(); st.RetryAttempts != 1 || st.RetrySuccesses != 1 {
+		t.Errorf("stats = %+v, want 1 attempt / 1 success", st)
+	}
+}
+
+func TestPool_ListDoesNotRetryAfterEmitting(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].listItems = []BlobInfo{{Name: "data/aa", Size: 1}, {Name: "data/bb", Size: 2}}
+	reg["a"].listFailAfterEmitting = intp(1)
+
+	emitted := 0
+	err := p.ListObjects(context.Background(), "bucket", "data/", func(BlobInfo) error {
+		emitted++
+		return nil
+	})
+	if err == nil {
+		t.Fatal("mid-listing failure must surface: emitted entries cannot be taken back")
+	}
+	if emitted != 1 {
+		t.Errorf("expected 1 emitted entry before the failure, got %d", emitted)
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("'b' must not be tried after emission, got %d calls", got)
+	}
+}
+
+func TestPool_GetObjectRetriesHeaderPhase(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+
+	obj, err := p.GetObject(context.Background(), "bucket", "k", "")
+	if err != nil {
+		t.Fatalf("expected header-phase retry to succeed, got %v", err)
+	}
+	data, _ := io.ReadAll(obj.Body)
+	obj.Body.Close()
+	if string(data) != "blobdata" {
+		t.Errorf("body = %q, want 'b' backend's blob", data)
+	}
+	if st := p.PoolStats(); st.RetryAttempts != 1 || st.RetrySuccesses != 1 {
+		t.Errorf("stats = %+v, want 1 attempt / 1 success", st)
+	}
+}
+
+func TestPool_GetObjectMidStreamFailureDoesNotRetry(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].getErr = errors.New("connection reset")
+
+	obj, err := p.GetObject(context.Background(), "bucket", "k", "")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	_, _ = io.ReadAll(obj.Body)
+	obj.Body.Close()
+
+	if st := p.PoolStats(); st.RetryAttempts != 0 {
+		t.Errorf("mid-stream failure must not retry, stats = %+v", st)
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("'b' must not be called, got %d", got)
+	}
+}
+
+func TestPool_NoRetryAfterContextCancelled(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := p.HeadObject(ctx, "bucket", "k"); err == nil {
+		t.Fatal("expected failure")
+	}
+	if st := p.PoolStats(); st.RetryAttempts != 0 {
+		t.Errorf("a gone caller must not trigger retries, stats = %+v", st)
+	}
+	if got := reg["b"].calls.Load(); got != 0 {
+		t.Errorf("'b' must not be called, got %d", got)
+	}
+}
+
 // slowProbeStore blocks each probe until its context is cancelled — an
 // unreachable, blackholed backend that eats the whole probe budget.
 type slowProbeStore struct {
@@ -495,5 +732,26 @@ func TestPool_ProbesConcurrentAndBounded(t *testing.T) {
 		if b.healthy.Load() {
 			t.Errorf("backend %s should be unhealthy after timed-out probe", b.endpoint)
 		}
+	}
+}
+
+func TestPool_RetryBudgetKnobsConfigurable(t *testing.T) {
+	p, _, reg := newTestPoolCfg(t, []string{"a", "b"}, PoolConfig{
+		EjectThreshold:    3,
+		ReconcileInterval: time.Hour,
+		RetryTokenEarn:    5,
+		RetryTokenCost:    20,
+		RetryBudgetCap:    40,
+	})
+	if got := p.PoolStats().RetryBudget; got != 40 {
+		t.Fatalf("budget must start at the configured cap, got %d", got)
+	}
+	forcePick(p, "a")
+	reg["a"].opFail.Store(true)
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err != nil {
+		t.Fatalf("expected retry to succeed: %v", err)
+	}
+	if got := p.PoolStats().RetryBudget; got != 40-20+5 {
+		t.Errorf("budget after one retry (-20) and its success (+5) = %d, want 25", got)
 	}
 }

--- a/packages/michael/internal/storage/s3.go
+++ b/packages/michael/internal/storage/s3.go
@@ -109,6 +109,13 @@ func NewS3StorageForCluster(cc config.ClusterConfig, opts S3Options) *S3Storage 
 		BaseEndpoint: aws.String(opts.Endpoint),
 		UsePathStyle: cc.S3ForcePathStyle,
 
+		// One attempt per call, no silent SDK retry anywhere: PUT bodies are
+		// restic's non-seekable proxied streams (a retry fails rewinding them and
+		// masks the real error — see TestPutObject_NonSeekableBodyOn503_NoRewindRetry),
+		// and for every other operation retrying is the pool's job, where each
+		// attempt is visible, budgeted, and feeds backend health accounting.
+		RetryMaxAttempts: 1,
+
 		HTTPClient: buildHTTPClient(opts)}
 	return &S3Storage{client: s3.New(s3opts)}
 }
@@ -161,12 +168,8 @@ func buildHTTPClient(opts S3Options) *http.Client {
 // bucket is absent or access-denied) proves the gateway is serving, so only a
 // transport-level failure (dial refused, timeout, 5xx) is treated as unhealthy.
 func (s *S3Storage) Probe(ctx context.Context, bucket string) error {
-	// Single-shot: a probe must not be silently retried by the SDK, or a dead
-	// gateway would look slow-but-alive and add latency to every reconcile.
 	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
-	}, func(o *s3.Options) {
-		o.RetryMaxAttempts = 1
 	})
 	if err != nil && isBackendFailure(err) {
 		return err
@@ -268,18 +271,12 @@ func (s *S3Storage) PutObject(ctx context.Context, bucket, key string, body io.R
 	}
 
 	// Use unsigned payload so the SDK doesn't need to seek the body for signing.
-	// RetryMaxAttempts=1 (no SDK retry): the body is restic's non-seekable
-	// proxied stream, so any retry would try to rewind it and fail with "failed
-	// to rewind transport stream for retry, request stream is not seekable" —
-	// masking the real backend error and, under load, stalling clients on a
-	// large fraction of PUTs. With retries off, a transient gateway error
-	// surfaces cleanly and restic retries the pack itself (its body IS
-	// seekable). See TestPutObject_NonSeekableBodyOn503_NoRewindRetry.
+	// The client is built with SDK retries off (see NewS3StorageForCluster):
+	// crucial here, since a retry would try to rewind restic's non-seekable
+	// proxied stream and mask the real backend error.
 	_, err := s.client.PutObject(ctx, input, s3.WithAPIOptions(
 		v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
-	), func(o *s3.Options) {
-		o.RetryMaxAttempts = 1
-	})
+	))
 	if err != nil {
 		if isPreconditionFailed(err) {
 			// Only content-addressed writes converge: for keys that aren't the

--- a/packages/michael/main.go
+++ b/packages/michael/main.go
@@ -202,6 +202,9 @@ func buildStorage(cc config.ClusterConfig, tm *metrics.TransportMetrics) (storag
 		EjectThreshold:    cc.S3EjectThreshold,
 		ProbeBucket:       cc.S3ProbeBucket,
 		ReconcileInterval: cc.S3ReconcileInterval,
+		RetryTokenEarn:    cc.S3RetryTokenEarn,
+		RetryTokenCost:    cc.S3RetryTokenCost,
+		RetryBudgetCap:    cc.S3RetryBudgetCap,
 	}, factory, resolver, log.Logger.With().Str("cluster", cc.Code).Logger())
 	if err != nil {
 		log.Fatal().Err(err).Str("cluster", cc.Code).Msg("failed to initialize S3 backend pool")


### PR DESCRIPTION
SDK retries off everywhere; the pool retries idempotent ops once on a different healthy backend, capped by a success-refilled token budget, with retry/budget metrics. Stacked on #526.

- `main` <!-- branch-stack -->
  - \#526
    - \#527 :point\_left:
      - \#528
        - \#529
