### PR TITLE
feat(michael): per-backend circuit breakers with fast-fail load shedding

### DIFF
--- a/packages/michael/internal/handlers/blob.go
+++ b/packages/michael/internal/handlers/blob.go
@@ -103,7 +103,7 @@ func (s *Server) listBlobs(w http.ResponseWriter, r *http.Request) {
 	if listErr != nil {
 		hlog.FromRequest(r).Error().Err(listErr).Msg("list blobs failed")
 		if first {
-			writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+			writeStorageError(w, r, listErr)
 			return
 		}
 		// The 200 and part of the body are already out; abort the connection
@@ -136,6 +136,14 @@ func (s *Server) checkBlob(w http.ResponseWriter, r *http.Request) {
 	key := blobType + "/" + name
 	size, err := s.store(r.Context()).HeadObject(r.Context(), a.Repository, key)
 	if err != nil {
+		// Only a genuine 404 may say "not found": that answer is permanent for
+		// restic, and an infra failure disguised as a missing blob would make it
+		// re-upload or mis-plan around data that exists (docs/restic-retries.md).
+		if !storage.IsNotFound(err) {
+			hlog.FromRequest(r).Error().Err(err).Msg("head blob failed")
+			writeStorageError(w, r, err)
+			return
+		}
 		writeError(w, r, http.StatusNotFound, "Not Found")
 		return
 	}
@@ -157,7 +165,7 @@ func (s *Server) getBlob(w http.ResponseWriter, r *http.Request) {
 		if s.Metrics != nil {
 			s.Metrics.StorageErrors.Add(r.Context(), 1, metrics.StorageErrorOption("get", metrics.BlobType(r)))
 		}
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
@@ -184,7 +192,7 @@ func (s *Server) saveBlob(w http.ResponseWriter, r *http.Request) {
 		if s.Metrics != nil {
 			s.Metrics.StorageErrors.Add(r.Context(), 1, metrics.StorageErrorOption("put", metrics.BlobType(r)))
 		}
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
@@ -216,13 +224,13 @@ func (s *Server) deleteBlob(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		hlog.FromRequest(r).Error().Err(err).Msg("head blob for delete failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
 	if err := s.store(r.Context()).DeleteObject(r.Context(), a.Repository, key); err != nil {
 		hlog.FromRequest(r).Error().Err(err).Msg("delete blob failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 

--- a/packages/michael/internal/handlers/blob_test.go
+++ b/packages/michael/internal/handlers/blob_test.go
@@ -38,7 +38,7 @@ func TestCheckBlob_Found(t *testing.T) {
 func TestCheckBlob_NotFound(t *testing.T) {
 	store := &mockStorage{
 		headObjectFn: func(_ context.Context, _, _ string) (int64, error) {
-			return 0, errors.New("not found")
+			return 0, &types.NotFound{}
 		},
 	}
 	srv := newTestServer(store)
@@ -365,5 +365,66 @@ func TestDeleteBlob_InvalidType(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestGetBlob_AllBackendsDown_Returns503WithRetryAfter(t *testing.T) {
+	store := &mockStorage{
+		getObjectFn: func(_ context.Context, _, _, _ string) (*storage.S3Object, error) {
+			return nil, storage.ErrBackendsUnavailable
+		},
+	}
+	srv := newTestServer(store)
+	rec := doRequest(t, srv, http.MethodGet, "/"+testRepository+"/data/"+testBlobName, nil, defaultAuth(), nil)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 while shedding, got %d", rec.Code)
+	}
+	if ra := rec.Header().Get("Retry-After"); ra == "" {
+		t.Error("expected a Retry-After header on shed responses")
+	}
+}
+
+func TestSaveBlob_AllBackendsDown_Returns503(t *testing.T) {
+	store := &mockStorage{
+		putObjectFn: func(_ context.Context, _, _ string, _ io.Reader, _ int64, _ bool, _ string) error {
+			return storage.ErrBackendsUnavailable
+		},
+	}
+	srv := newTestServer(store)
+	rec := doRequest(t, srv, http.MethodPost, "/"+testRepository+"/data/"+testBlobName, strings.NewReader("x"), defaultAuth(), nil)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 while shedding, got %d", rec.Code)
+	}
+}
+
+func TestCheckBlob_AllBackendsDown_IsNotA404(t *testing.T) {
+	// 404 is permanent for restic ("blob does not exist"); an outage must never
+	// wear that disguise.
+	store := &mockStorage{
+		headObjectFn: func(_ context.Context, _, _ string) (int64, error) {
+			return 0, storage.ErrBackendsUnavailable
+		},
+	}
+	srv := newTestServer(store)
+	rec := doRequest(t, srv, http.MethodHead, "/"+testRepository+"/data/"+testBlobName, nil, defaultAuth(), nil)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 while shedding, got %d", rec.Code)
+	}
+}
+
+func TestCheckBlob_StorageErrorIsNotA404(t *testing.T) {
+	store := &mockStorage{
+		headObjectFn: func(_ context.Context, _, _ string) (int64, error) {
+			return 0, errors.New("dial tcp: connection refused")
+		},
+	}
+	srv := newTestServer(store)
+	rec := doRequest(t, srv, http.MethodHead, "/"+testRepository+"/data/"+testBlobName, nil, defaultAuth(), nil)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 for a transport failure, got %d", rec.Code)
 	}
 }

--- a/packages/michael/internal/handlers/config.go
+++ b/packages/michael/internal/handlers/config.go
@@ -18,6 +18,13 @@ func (s *Server) checkConfig(w http.ResponseWriter, r *http.Request) {
 
 	size, err := s.store(r.Context()).HeadObject(r.Context(), a.Repository, "config")
 	if err != nil {
+		// Restic stats the config to decide whether the repository exists — an
+		// infra failure answered as 404 would present a live repo as absent.
+		if !storage.IsNotFound(err) {
+			hlog.FromRequest(r).Error().Err(err).Msg("head config failed")
+			writeStorageError(w, r, err)
+			return
+		}
 		writeError(w, r, http.StatusNotFound, "Not Found")
 		return
 	}
@@ -34,7 +41,7 @@ func (s *Server) getConfig(w http.ResponseWriter, r *http.Request) {
 	obj, err := s.store(r.Context()).GetObject(r.Context(), a.Repository, "config", rangeHeader)
 	if err != nil {
 		hlog.FromRequest(r).Error().Err(err).Msg("get config failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
@@ -52,7 +59,7 @@ func (s *Server) saveConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		hlog.FromRequest(r).Error().Err(err).Msg("save config failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
@@ -75,13 +82,13 @@ func (s *Server) deleteConfig(w http.ResponseWriter, r *http.Request) {
 	size, err := s.store(r.Context()).HeadObject(r.Context(), a.Repository, "config")
 	if err != nil {
 		hlog.FromRequest(r).Error().Err(err).Msg("head config for delete failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
 	if err := s.store(r.Context()).DeleteObject(r.Context(), a.Repository, "config"); err != nil {
 		hlog.FromRequest(r).Error().Err(err).Msg("delete config failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 

--- a/packages/michael/internal/handlers/config_test.go
+++ b/packages/michael/internal/handlers/config_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"michael/internal/storage"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 func TestCheckConfig_Found(t *testing.T) {
@@ -34,7 +36,7 @@ func TestCheckConfig_Found(t *testing.T) {
 func TestCheckConfig_NotFound(t *testing.T) {
 	store := &mockStorage{
 		headObjectFn: func(_ context.Context, _, _ string) (int64, error) {
-			return 0, errors.New("not found")
+			return 0, &types.NotFound{}
 		},
 	}
 	srv := newTestServer(store)

--- a/packages/michael/internal/handlers/helpers.go
+++ b/packages/michael/internal/handlers/helpers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"regexp"
@@ -26,6 +27,18 @@ var validBlobTypes = map[string]bool{
 var sha256HexPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
 
 var writeError = httputil.WriteError
+
+// writeStorageError maps a storage-layer failure onto the restic contract
+// (docs/restic-retries.md): a shedding pool answers 503 + Retry-After, which
+// restic retries with backoff, while anything else stays the generic 500.
+func writeStorageError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, storage.ErrBackendsUnavailable) {
+		w.Header().Set("Retry-After", "30")
+		writeError(w, r, http.StatusServiceUnavailable, "Storage temporarily unavailable")
+		return
+	}
+	writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+}
 
 func (s *Server) respondWithS3Object(w http.ResponseWriter, r *http.Request, obj *storage.S3Object) {
 	defer obj.Body.Close()

--- a/packages/michael/internal/handlers/repo.go
+++ b/packages/michael/internal/handlers/repo.go
@@ -26,7 +26,7 @@ func (s *Server) createRepository(w http.ResponseWriter, r *http.Request) {
 	exists, err := s.store(r.Context()).CheckBucket(r.Context(), a.Repository)
 	if err != nil {
 		hlog.FromRequest(r).Error().Err(err).Msg("check bucket failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 
@@ -37,7 +37,7 @@ func (s *Server) createRepository(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store(r.Context()).CreateBucket(r.Context(), a.Repository); err != nil {
 		hlog.FromRequest(r).Error().Err(err).Msg("create bucket failed")
-		writeError(w, r, http.StatusInternalServerError, "An error occurred with the storage server")
+		writeStorageError(w, r, err)
 		return
 	}
 

--- a/packages/michael/internal/metrics/backend.go
+++ b/packages/michael/internal/metrics/backend.go
@@ -62,6 +62,11 @@ func RegisterBackendMetrics(meter otelmetric.Meter, providers map[string]Backend
 	if err != nil {
 		return fmt.Errorf("creating s3.backend.healthy: %w", err)
 	}
+	state, err := meter.Int64ObservableGauge("s3.backend.state",
+		otelmetric.WithDescription("Backend circuit-breaker state (0 open, 1 half-open, 2 closed)"))
+	if err != nil {
+		return fmt.Errorf("creating s3.backend.state: %w", err)
+	}
 	retries, err := meter.Int64ObservableCounter("s3.pool.retries",
 		otelmetric.WithDescription("Cross-backend retries per pool, by outcome (success, failure, denied)"))
 	if err != nil {
@@ -71,6 +76,16 @@ func RegisterBackendMetrics(meter otelmetric.Meter, providers map[string]Backend
 		otelmetric.WithDescription("Remaining cross-backend retry budget tokens per pool"))
 	if err != nil {
 		return fmt.Errorf("creating s3.pool.retry_budget: %w", err)
+	}
+	sheds, err := meter.Int64ObservableCounter("s3.pool.sheds",
+		otelmetric.WithDescription("Requests fast-failed because every backend was unhealthy"))
+	if err != nil {
+		return fmt.Errorf("creating s3.pool.sheds: %w", err)
+	}
+	canaries, err := meter.Int64ObservableCounter("s3.pool.canaries",
+		otelmetric.WithDescription("Fail-open canary requests sent while every backend was unhealthy"))
+	if err != nil {
+		return fmt.Errorf("creating s3.pool.canaries: %w", err)
 	}
 
 	_, err = meter.RegisterCallback(
@@ -87,20 +102,24 @@ func RegisterBackendMetrics(meter otelmetric.Meter, providers map[string]Backend
 					o.ObserveInt64(uploaded, s.UploadedBytes, attrs)
 					o.ObserveInt64(inflight, s.Inflight, attrs)
 					o.ObserveInt64(healthy, boolToInt64(s.Healthy), attrs)
+					o.ObserveInt64(state, stateValue(s.State), attrs)
 				}
 				ps := provider.PoolStats()
 				cluster := attribute.String("cluster", code)
+				clusterAttrs := otelmetric.WithAttributeSet(attribute.NewSet(cluster))
 				retryOutcome := func(outcome string) otelmetric.MeasurementOption {
 					return otelmetric.WithAttributeSet(attribute.NewSet(cluster, attribute.String("outcome", outcome)))
 				}
 				o.ObserveInt64(retries, ps.RetrySuccesses, retryOutcome("success"))
 				o.ObserveInt64(retries, ps.RetryAttempts-ps.RetrySuccesses, retryOutcome("failure"))
 				o.ObserveInt64(retries, ps.RetryDenied, retryOutcome("denied"))
-				o.ObserveInt64(retryBudget, ps.RetryBudget, otelmetric.WithAttributeSet(attribute.NewSet(cluster)))
+				o.ObserveInt64(retryBudget, ps.RetryBudget, clusterAttrs)
+				o.ObserveInt64(sheds, ps.ShedRequests, clusterAttrs)
+				o.ObserveInt64(canaries, ps.CanaryRequests, clusterAttrs)
 			}
 			return nil
 		},
-		requests, requestErrors, downloaded, uploaded, inflight, healthy, retries, retryBudget,
+		requests, requestErrors, downloaded, uploaded, inflight, healthy, state, retries, retryBudget, sheds, canaries,
 	)
 	if err != nil {
 		return fmt.Errorf("registering backend metrics callback: %w", err)
@@ -113,4 +132,17 @@ func boolToInt64(b bool) int64 {
 		return 1
 	}
 	return 0
+}
+
+// stateValue orders breaker states by serviceability so dashboards can
+// threshold on them: 0 open, 1 half-open, 2 closed.
+func stateValue(state string) int64 {
+	switch state {
+	case "closed":
+		return 2
+	case "half_open":
+		return 1
+	default:
+		return 0
+	}
 }

--- a/packages/michael/internal/metrics/backend_test.go
+++ b/packages/michael/internal/metrics/backend_test.go
@@ -27,10 +27,10 @@ func TestRegisterBackendMetrics(t *testing.T) {
 	providers := map[string]BackendStatsProvider{
 		"default": stubProvider{
 			stats: []storage.BackendStat{
-				{Endpoint: "http://a:80", Healthy: true, Inflight: 2, Requests: 10, Errors: 1, DownloadedBytes: 100, UploadedBytes: 50},
-				{Endpoint: "http://b:80", Healthy: false, Inflight: 0, Requests: 3, Errors: 3, DownloadedBytes: 0, UploadedBytes: 7},
+				{Endpoint: "http://a:80", Healthy: true, State: "closed", Inflight: 2, Requests: 10, Errors: 1, DownloadedBytes: 100, UploadedBytes: 50},
+				{Endpoint: "http://b:80", Healthy: false, State: "half_open", Inflight: 0, Requests: 3, Errors: 3, DownloadedBytes: 0, UploadedBytes: 7},
 			},
-			pool: storage.PoolStat{RetryAttempts: 5, RetrySuccesses: 4, RetryDenied: 2, RetryBudget: 150},
+			pool: storage.PoolStat{RetryAttempts: 5, RetrySuccesses: 4, RetryDenied: 2, RetryBudget: 150, ShedRequests: 9, CanaryRequests: 3},
 		},
 		// Same endpoint as the default cluster's first backend: only the cluster
 		// attribute keeps the two series apart.
@@ -86,6 +86,10 @@ func TestRegisterBackendMetrics(t *testing.T) {
 		{"s3.pool.retries", "default//denied", 2},
 		{"s3.pool.retry_budget", "default/", 150},
 		{"s3.pool.retries", "spice//success", 0},
+		{"s3.backend.state", "default/http://a:80", 2},
+		{"s3.backend.state", "default/http://b:80", 1},
+		{"s3.pool.sheds", "default/", 9},
+		{"s3.pool.canaries", "default/", 3},
 	}
 	for _, c := range checks {
 		series, ok := got[c.metric]

--- a/packages/michael/internal/storage/pool.go
+++ b/packages/michael/internal/storage/pool.go
@@ -18,6 +18,92 @@ const probeTimeout = 5 * time.Second
 // ErrNoBackends is returned when the pool has no backend to route a request to.
 var ErrNoBackends = errors.New("no S3 backends available")
 
+// ErrBackendsUnavailable is returned while the pool sheds load fast because
+// every backend is unhealthy and real traffic recently failed. Handlers
+// surface it as 503 + Retry-After; restic retries that with backoff for up to
+// 15 minutes, which beats queueing requests onto dead gateways where each one
+// burns a dial timeout (docs/restic-retries.md).
+var ErrBackendsUnavailable = errors.New("all S3 backends unavailable")
+
+// Backend circuit-breaker states. A backend starts open (unproven) and is
+// closed by its first probe; traffic failures reopen it, and a traffic-tripped
+// backend must re-earn closed through half-open trial requests, since passing
+// a probe proves much less than serving real load.
+const (
+	stateOpen     int32 = iota // ejected, receives no regular traffic
+	stateClosed                // serving normally
+	stateHalfOpen              // admits one trial request at a time
+)
+
+// halfOpenCloseAfter consecutive trial successes close a half-open backend.
+const halfOpenCloseAfter = 3
+
+// shedWindow is how long after a real-traffic failure the pool fails fast when
+// nothing is serviceable. When it lapses, a single fail-open canary request is
+// let through: its failure re-arms the window, its success starts reinstating
+// the backend — so a dead cluster costs one probing request per window instead
+// of a pile-up, and a false alarm heals itself.
+const shedWindow = 30 * time.Second
+
+// One-second buckets back a sliding error-rate view. It ejects brownout
+// backends whose failures never run consecutively (each success resets the
+// streak) yet whose probes pass: at least windowMinRequests in the window and
+// windowFailurePercent of them failed.
+const (
+	windowBuckets        = 10
+	windowMinRequests    = 20
+	windowFailurePercent = 50
+)
+
+type windowBucket struct {
+	sec                int64
+	requests, failures int64
+}
+
+type window struct {
+	mu      sync.Mutex
+	buckets [windowBuckets]windowBucket
+}
+
+func (w *window) record(sec int64, failure bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	b := &w.buckets[sec%windowBuckets]
+	if b.sec != sec {
+		b.sec, b.requests, b.failures = sec, 0, 0
+	}
+	b.requests++
+	if failure {
+		b.failures++
+	}
+}
+
+func (w *window) failureRateExceeded(sec int64) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var requests, failures int64
+	for _, b := range w.buckets {
+		if b.sec > sec-windowBuckets {
+			requests += b.requests
+			failures += b.failures
+		}
+	}
+	return requests >= windowMinRequests && failures*100 >= requests*windowFailurePercent
+}
+
+// recentSuccess reports whether any request succeeded inside the window — the
+// signal that lets live traffic overrule a failing probe.
+func (w *window) recentSuccess(sec int64) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, b := range w.buckets {
+		if b.sec > sec-windowBuckets && b.requests > b.failures {
+			return true
+		}
+	}
+	return false
+}
+
 // Cross-backend retries are paid from a token budget refilled by successful
 // traffic (by default one token per success, ten per retry, so at most ~1
 // retry per 10 successes): a healthy pool masks isolated gateway failures,
@@ -43,6 +129,7 @@ type BackendFactory func(endpoint string) (Storage, error)
 type BackendStat struct {
 	Endpoint        string
 	Healthy         bool
+	State           string // "closed" | "half_open" | "open"
 	Inflight        int64
 	Requests        int64
 	Errors          int64
@@ -59,13 +146,31 @@ type backend struct {
 
 	inflight atomic.Int64 // outstanding requests (drives least-outstanding pick)
 	failures atomic.Int64 // consecutive transport failures (passive ejection)
-	healthy  atomic.Bool
+	state    atomic.Int32
+	trial    atomic.Int64 // the half-open state's single trial slot (0 free, 1 claimed)
+	window   window
+	// trafficTripped marks a backend that was ever ejected by real-traffic
+	// failures: it must re-earn closed through half-open trials, while a
+	// probe-only ejection (or a fresh backend) closes on a passing probe alone.
+	trafficTripped    atomic.Bool
+	halfOpenSuccesses atomic.Int64
 
 	// cumulative, for metrics
 	requests        atomic.Int64
 	errors          atomic.Int64
 	downloadedBytes atomic.Int64
 	uploadedBytes   atomic.Int64
+}
+
+func stateName(s int32) string {
+	switch s {
+	case stateClosed:
+		return "closed"
+	case stateHalfOpen:
+		return "half_open"
+	default:
+		return "open"
+	}
 }
 
 // PoolConfig holds the tunables for a Pool. Zero values take the defaults.
@@ -79,11 +184,14 @@ type PoolConfig struct {
 }
 
 // Pool implements Storage by load-balancing requests across a set of
-// interchangeable S3 gateway backends. It picks the backend with the fewest
-// outstanding requests, ejects backends after consecutive transport failures,
-// and actively probes to reinstate them. The pool never retries a failed
-// request — it records the failure and returns it, leaving retries to the
-// client (restic).
+// interchangeable S3 gateway backends. Each backend runs a circuit breaker:
+// consecutive or windowed traffic failures (and failed probes) open it,
+// passing probes and successful trial traffic close it again. Idempotent
+// operations that fail at the transport level are retried once on a different
+// closed backend, within a budget; uploads are never retried (the body is the
+// client's one-shot stream — restic re-drives those itself). With every
+// backend open, the pool fails fast for a shed window after real-traffic
+// failures rather than queueing requests onto dead gateways.
 type Pool struct {
 	backends    atomic.Pointer[[]*backend]
 	factory     BackendFactory
@@ -101,15 +209,23 @@ type Pool struct {
 	retries        atomic.Int64
 	retrySuccesses atomic.Int64
 	retryDenied    atomic.Int64
+
+	now             func() time.Time // injectable for deterministic tests
+	lastFailureNano atomic.Int64
+	canaryInflight  atomic.Int64
+	sheds           atomic.Int64
+	canaries        atomic.Int64
 }
 
-// PoolStat is a pool-wide snapshot of the cross-backend retry machinery,
+// PoolStat is a pool-wide snapshot of the retry and fast-fail machinery,
 // consumed by the metrics layer.
 type PoolStat struct {
 	RetryAttempts  int64
 	RetrySuccesses int64
 	RetryDenied    int64
 	RetryBudget    int64
+	ShedRequests   int64
+	CanaryRequests int64
 }
 
 var _ Storage = (*Pool)(nil)
@@ -146,6 +262,7 @@ func NewPool(cfg PoolConfig, factory BackendFactory, resolver Resolver, logger z
 	empty := []*backend{}
 	p.backends.Store(&empty)
 	p.budget.Store(p.retryBudgetCap)
+	p.now = time.Now
 
 	if err := p.Reconcile(context.Background()); err != nil {
 		return nil, err
@@ -217,7 +334,6 @@ func (p *Pool) applyEndpoints(endpoints []string) {
 			continue
 		}
 		b := &backend{endpoint: ep, store: store}
-		b.healthy.Store(false)
 		next = append(next, b)
 		added++
 	}
@@ -255,64 +371,131 @@ func (p *Pool) probeOne(ctx context.Context, b *backend) {
 	prober, ok := b.store.(Prober)
 	if !ok {
 		// Unprobeable store (e.g. a bare fake): assume healthy.
-		b.healthy.Store(true)
+		b.state.Store(stateClosed)
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 	if err := prober.Probe(ctx, p.probeBucket); err != nil {
-		if b.healthy.CompareAndSwap(true, false) {
+		// Live traffic outranks probes: a backend serving real requests is not
+		// ejected over a broken probe path (e.g. a misconfigured sentinel
+		// bucket), or the two signals would flap it open and closed forever.
+		if b.state.Load() == stateClosed && b.window.recentSuccess(p.now().Unix()) {
+			p.logger.Warn().Str("backend", b.endpoint).Err(err).Msg("probe failed but traffic is healthy; keeping backend")
+			return
+		}
+		if b.state.CompareAndSwap(stateClosed, stateOpen) {
 			p.logger.Warn().Str("backend", b.endpoint).Err(err).Msg("backend failed health probe; ejecting")
+		}
+		if b.state.CompareAndSwap(stateHalfOpen, stateOpen) {
+			b.halfOpenSuccesses.Store(0)
+			p.logger.Warn().Str("backend", b.endpoint).Err(err).Msg("half-open backend failed health probe; reopening")
 		}
 		return
 	}
 	b.failures.Store(0)
-	if b.healthy.CompareAndSwap(false, true) {
+	if b.trafficTripped.Load() {
+		if b.state.CompareAndSwap(stateOpen, stateHalfOpen) {
+			b.halfOpenSuccesses.Store(0)
+			p.logger.Info().Str("backend", b.endpoint).Msg("probe passed; admitting trial traffic")
+		}
+		return
+	}
+	if b.state.CompareAndSwap(stateOpen, stateClosed) {
 		p.logger.Info().Str("backend", b.endpoint).Msg("backend healthy; reinstated")
 	}
 }
 
-// pick selects the healthy backend with the fewest outstanding requests. Ties
-// are broken by a rotating offset so equal-load backends are used round-robin.
-// If nothing is healthy it fails open to the least-loaded backend overall,
-// degrading rather than refusing service.
-func (p *Pool) pick() *backend {
+// picked is one admitted request's routing decision. A canary holds the pool's
+// single fail-open slot, a trial holds its backend's single half-open slot;
+// both must be released when the operation completes.
+type picked struct {
+	b      *backend
+	canary bool
+	trial  bool
+}
+
+// pick selects the serving backend for a request. Closed backends compete by
+// fewest outstanding requests, ties broken by a rotating offset; a half-open
+// backend admits one trial request at a time via an atomically claimed slot,
+// held until the operation (a streaming GET included) completes. With nothing
+// serviceable, the pool fails fast inside the shed window and otherwise admits
+// one fail-open canary to the least-loaded open backend.
+func (p *Pool) pick() (picked, error) {
 	bs := p.snapshot()
 	n := len(bs)
 	if n == 0 {
-		return nil
+		return picked{}, ErrNoBackends
 	}
 	start := int(p.pickCounter.Add(1) % uint64(n))
 
-	var best, fallback *backend
-	var bestLoad, fallbackLoad int64
+	var best, trialCand *backend
+	var bestLoad int64
 	for i := range n {
 		b := bs[(start+i)%n]
-		load := b.inflight.Load()
-		if fallback == nil || load < fallbackLoad {
-			fallback, fallbackLoad = b, load
+		switch b.state.Load() {
+		case stateClosed:
+			if load := b.inflight.Load(); best == nil || load < bestLoad {
+				best, bestLoad = b, load
+			}
+		case stateHalfOpen:
+			if trialCand == nil && b.trial.Load() == 0 {
+				trialCand = b
+			}
 		}
-		if !b.healthy.Load() {
-			continue
-		}
-		if best == nil || load < bestLoad {
-			best, bestLoad = b, load
-		}
+	}
+	// The trial goes first even when closed backends are idle: on a quiet
+	// system trials are the only traffic a half-open backend ever sees, and
+	// without them it could stay half-open indefinitely.
+	if trialCand != nil && trialCand.trial.CompareAndSwap(0, 1) {
+		return picked{b: trialCand, trial: true}, nil
 	}
 	if best != nil {
-		return best
+		return picked{b: best}, nil
 	}
-	p.logger.Warn().Msg("no healthy S3 backends; failing open to least-loaded")
-	return fallback
+
+	if p.now().UnixNano()-p.lastFailureNano.Load() < int64(shedWindow) {
+		p.sheds.Add(1)
+		return picked{}, ErrBackendsUnavailable
+	}
+	// Canaries only probe fully-open backends: a half-open backend already has
+	// its own trial gate, and admitting canaries there would let every new
+	// request start an extra stream on it while a slow trial body is open.
+	var fallback *backend
+	var fallbackLoad int64
+	for _, b := range bs {
+		if b.state.Load() != stateOpen {
+			continue
+		}
+		if load := b.inflight.Load(); fallback == nil || load < fallbackLoad {
+			fallback, fallbackLoad = b, load
+		}
+	}
+	if fallback == nil || !p.canaryInflight.CompareAndSwap(0, 1) {
+		p.sheds.Add(1)
+		return picked{}, ErrBackendsUnavailable
+	}
+	p.canaries.Add(1)
+	p.logger.Warn().Str("backend", fallback.endpoint).Msg("no serviceable S3 backend; failing open with a canary request")
+	return picked{b: fallback, canary: true}, nil
 }
 
-// pickHealthyOther returns the least-loaded healthy backend other than exclude,
+func (p *Pool) release(pk picked) {
+	if pk.canary {
+		p.canaryInflight.Store(0)
+	}
+	if pk.trial {
+		pk.b.trial.Store(0)
+	}
+}
+
+// pickHealthyOther returns the least-loaded closed backend other than exclude,
 // or nil — a retry never fails open, it only moves to a backend believed good.
 func (p *Pool) pickHealthyOther(exclude *backend) *backend {
 	var best *backend
 	var bestLoad int64
 	for _, b := range p.snapshot() {
-		if b == exclude || !b.healthy.Load() {
+		if b == exclude || b.state.Load() != stateClosed {
 			continue
 		}
 		if load := b.inflight.Load(); best == nil || load < bestLoad {
@@ -346,23 +529,62 @@ func (p *Pool) takeRetryTokens() bool {
 	}
 }
 
-// recordResult updates a backend's counters and passive-ejection state after a
-// completed operation. A transport failure increments the consecutive-failure
-// streak and ejects once it crosses the threshold; any non-transport outcome
-// (success, or a normal 4xx like a missing blob) proves liveness, resets the
-// streak, and refills the retry budget.
+// recordResult drives a backend's breaker from a completed operation's
+// outcome. A transport failure trips closed→open on the consecutive-failure
+// streak or the windowed error rate, and any failure reopens a half-open
+// backend. A non-transport outcome (success, or a normal 4xx like a missing
+// blob) proves liveness: it resets the streak, refills the retry budget,
+// advances a half-open backend toward closed, and turns a successful fail-open
+// canary on an open backend into a half-open one.
 func (p *Pool) recordResult(b *backend, err error) {
 	b.requests.Add(1)
+	now := p.now()
 	if isBackendFailure(err) {
 		b.errors.Add(1)
+		b.window.record(now.Unix(), true)
+		p.lastFailureNano.Store(now.UnixNano())
+		if b.state.CompareAndSwap(stateHalfOpen, stateOpen) {
+			b.trafficTripped.Store(true)
+			b.halfOpenSuccesses.Store(0)
+			p.logger.Warn().Str("backend", b.endpoint).Msg("half-open S3 backend failed a trial; reopening")
+			return
+		}
 		n := b.failures.Add(1)
-		if n >= p.ejectThresh && b.healthy.CompareAndSwap(true, false) {
-			p.logger.Warn().Str("backend", b.endpoint).Int64("failures", n).Msg("ejecting S3 backend after consecutive failures")
+		if (n >= p.ejectThresh || b.window.failureRateExceeded(now.Unix())) && b.state.CompareAndSwap(stateClosed, stateOpen) {
+			b.trafficTripped.Store(true)
+			p.logger.Warn().Str("backend", b.endpoint).Int64("failures", n).Msg("ejecting S3 backend after traffic failures")
 		}
 		return
 	}
 	b.failures.Store(0)
+	b.window.record(now.Unix(), false)
 	p.earnRetryToken()
+	switch b.state.Load() {
+	case stateHalfOpen:
+		if b.halfOpenSuccesses.Add(1) >= halfOpenCloseAfter && b.state.CompareAndSwap(stateHalfOpen, stateClosed) {
+			p.logger.Info().Str("backend", b.endpoint).Msg("backend passed its trials; closing")
+		}
+	case stateOpen:
+		// The completed canary counts as the first trial. A GET canary takes the
+		// other path — noteCanaryLiveness at headers seeds the streak at zero and
+		// this switch sees stateHalfOpen when the body closes — so either way one
+		// canary request contributes exactly one success.
+		if p.noteCanaryLiveness(b) {
+			b.halfOpenSuccesses.Add(1)
+		}
+	}
+}
+
+// noteCanaryLiveness turns a response from an open backend (a fail-open
+// canary) into half-open: the gateway answered, so trial traffic may resume.
+// It reports whether this call made the transition.
+func (p *Pool) noteCanaryLiveness(b *backend) bool {
+	if b.state.CompareAndSwap(stateOpen, stateHalfOpen) {
+		b.halfOpenSuccesses.Store(0)
+		p.logger.Info().Str("backend", b.endpoint).Msg("open backend served a canary; admitting trial traffic")
+		return true
+	}
+	return false
 }
 
 func (p *Pool) runOn(b *backend, fn func(s Storage) error) error {
@@ -382,15 +604,16 @@ func canAlwaysRetry() bool { return true }
 // sibling gateway would have absorbed, and its per-file Load breaker then
 // locks the affected blob out client-side for an hour (docs/restic-retries.md).
 func (p *Pool) do(ctx context.Context, canRetry func() bool, fn func(s Storage) error) error {
-	b := p.pick()
-	if b == nil {
-		return ErrNoBackends
+	pk, perr := p.pick()
+	if perr != nil {
+		return perr
 	}
-	err := p.runOn(b, fn)
+	err := p.runOn(pk.b, fn)
+	p.release(pk)
 	if !isBackendFailure(err) || canRetry == nil || !canRetry() || ctx.Err() != nil {
 		return err
 	}
-	next := p.pickHealthyOther(b)
+	next := p.pickHealthyOther(pk.b)
 	if next == nil {
 		return err
 	}
@@ -411,9 +634,11 @@ func (p *Pool) Stats() []BackendStat {
 	bs := p.snapshot()
 	stats := make([]BackendStat, 0, len(bs))
 	for _, b := range bs {
+		state := b.state.Load()
 		stats = append(stats, BackendStat{
 			Endpoint:        b.endpoint,
-			Healthy:         b.healthy.Load(),
+			Healthy:         state == stateClosed,
+			State:           stateName(state),
 			Inflight:        b.inflight.Load(),
 			Requests:        b.requests.Load(),
 			Errors:          b.errors.Load(),
@@ -431,6 +656,8 @@ func (p *Pool) PoolStats() PoolStat {
 		RetrySuccesses: p.retrySuccesses.Load(),
 		RetryDenied:    p.retryDenied.Load(),
 		RetryBudget:    p.budget.Load(),
+		ShedRequests:   p.sheds.Load(),
+		CanaryRequests: p.canaries.Load(),
 	}
 }
 
@@ -488,10 +715,11 @@ func (p *Pool) DeleteObject(ctx context.Context, bucket, key string) error {
 // consumed once — restic re-drives failed uploads itself with a rewindable
 // pack (docs/restic-retries.md).
 func (p *Pool) PutObject(ctx context.Context, bucket, key string, body io.Reader, contentLength int64, writeOnce bool, sha256Hex string) error {
-	b := p.pick()
-	if b == nil {
-		return ErrNoBackends
+	pk, perr := p.pick()
+	if perr != nil {
+		return perr
 	}
+	b := pk.b
 	// The body is fully consumed and uploaded before PutObject returns, so the
 	// upload — the large transfer — is accounted end-to-end here.
 	b.inflight.Add(1)
@@ -501,6 +729,7 @@ func (p *Pool) PutObject(ctx context.Context, bucket, key string, body io.Reader
 		b.uploadedBytes.Add(contentLength)
 	}
 	p.recordResult(b, err)
+	p.release(pk)
 	return err
 }
 
@@ -508,15 +737,15 @@ func (p *Pool) PutObject(ctx context.Context, bucket, key string, body io.Reader
 // headers are returned the body is streamed by the caller and a mid-stream
 // failure cannot be replayed.
 func (p *Pool) GetObject(ctx context.Context, bucket, key, rangeHeader string) (*S3Object, error) {
-	b := p.pick()
-	if b == nil {
-		return nil, ErrNoBackends
+	pk, perr := p.pick()
+	if perr != nil {
+		return nil, perr
 	}
-	obj, err := p.getFrom(ctx, b, bucket, key, rangeHeader)
+	obj, err := p.getFrom(ctx, pk, bucket, key, rangeHeader)
 	if !isBackendFailure(err) || ctx.Err() != nil {
 		return obj, err
 	}
-	next := p.pickHealthyOther(b)
+	next := p.pickHealthyOther(pk.b)
 	if next == nil {
 		return nil, err
 	}
@@ -525,35 +754,46 @@ func (p *Pool) GetObject(ctx context.Context, bucket, key, rangeHeader string) (
 		return nil, err
 	}
 	p.retries.Add(1)
-	obj, rerr := p.getFrom(ctx, next, bucket, key, rangeHeader)
+	obj, rerr := p.getFrom(ctx, picked{b: next}, bucket, key, rangeHeader)
 	if !isBackendFailure(rerr) {
 		p.retrySuccesses.Add(1)
 	}
 	return obj, rerr
 }
 
-func (p *Pool) getFrom(ctx context.Context, b *backend, bucket, key, rangeHeader string) (*S3Object, error) {
+func (p *Pool) getFrom(ctx context.Context, pk picked, bucket, key, rangeHeader string) (*S3Object, error) {
 	// The SDK returns headers here but the body is streamed by the caller after
-	// we return, so inflight must stay counted until the body is closed.
+	// we return, so inflight (and a canary's fail-open slot) must stay held
+	// until the body is closed.
+	b := pk.b
 	b.inflight.Add(1)
 	obj, err := b.store.GetObject(ctx, bucket, key, rangeHeader)
 	if err != nil {
 		b.inflight.Add(-1)
 		p.recordResult(b, err)
+		p.release(pk)
 		return nil, err
 	}
-	obj.Body = &poolBody{ReadCloser: obj.Body, pool: p, backend: b}
+	if pk.canary {
+		// Headers back is liveness proven: free the pool-wide canary slot now
+		// rather than holding recovery hostage to an arbitrarily slow body
+		// stream. The body's outcome still reaches recordResult on Close.
+		p.noteCanaryLiveness(b)
+		p.release(pk)
+		pk = picked{b: b}
+	}
+	obj.Body = &poolBody{ReadCloser: obj.Body, pool: p, picked: pk}
 	return obj, nil
 }
 
-// poolBody wraps a GetObject body so that closing it releases the inflight slot,
-// records downloaded bytes, and reports any mid-stream read failure toward the
-// backend's health (a read error from a dead gateway has no HTTP status and so
-// counts as a transport failure).
+// poolBody wraps a GetObject body so that closing it releases the inflight
+// slot (and a canary's fail-open slot), records downloaded bytes, and reports
+// any mid-stream read failure toward the backend's health (a read error from a
+// dead gateway has no HTTP status and so counts as a transport failure).
 type poolBody struct {
 	io.ReadCloser
 	pool    *Pool
-	backend *backend
+	picked  picked
 	n       int64
 	readErr error
 	done    atomic.Bool
@@ -571,9 +811,10 @@ func (b *poolBody) Read(p []byte) (int, error) {
 func (b *poolBody) Close() error {
 	err := b.ReadCloser.Close()
 	if b.done.CompareAndSwap(false, true) {
-		b.backend.inflight.Add(-1)
-		b.backend.downloadedBytes.Add(b.n)
-		b.pool.recordResult(b.backend, b.readErr)
+		b.picked.b.inflight.Add(-1)
+		b.picked.b.downloadedBytes.Add(b.n)
+		b.pool.recordResult(b.picked.b, b.readErr)
+		b.pool.release(b.picked)
 	}
 	return err
 }

--- a/packages/michael/internal/storage/pool_test.go
+++ b/packages/michael/internal/storage/pool_test.go
@@ -202,9 +202,12 @@ func TestPool_PickLeastOutstanding(t *testing.T) {
 			b.inflight.Store(9)
 		}
 	}
-	got := p.pick()
-	if got.endpoint != "b" {
-		t.Errorf("pick: expected least-loaded 'b', got %q", got.endpoint)
+	got, err := p.pick()
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if got.b.endpoint != "b" {
+		t.Errorf("pick: expected least-loaded 'b', got %q", got.b.endpoint)
 	}
 }
 
@@ -213,60 +216,270 @@ func TestPool_PickTiebreakRotates(t *testing.T) {
 	// All equal load => tiebreak should rotate across backends.
 	seen := map[string]int{}
 	for range 30 {
-		seen[p.pick().endpoint]++
+		pk, err := p.pick()
+		if err != nil {
+			t.Fatalf("pick: %v", err)
+		}
+		seen[pk.b.endpoint]++
 	}
 	if len(seen) < 2 {
 		t.Errorf("tiebreak did not rotate; only hit %v", seen)
 	}
 }
 
-func TestPool_PickFailsOpenWhenAllUnhealthy(t *testing.T) {
-	p, _, _ := newTestPool(t, []string{"a", "b"}, 3)
+// tripAllByTraffic drives real traffic failures until every backend is open,
+// arming the shed window.
+func tripAllByTraffic(t *testing.T, p *Pool, reg map[string]*fakeStore, threshold int) {
+	t.Helper()
+	for _, f := range reg {
+		f.opFail.Store(true)
+	}
+	for range len(reg) * threshold * 2 {
+		_, _ = p.HeadObject(context.Background(), "bucket", "k")
+	}
 	for _, b := range p.snapshot() {
-		b.healthy.Store(false)
-		b.inflight.Store(7)
+		if b.state.Load() != stateOpen {
+			t.Fatalf("backend %s not open after traffic failures", b.endpoint)
+		}
 	}
-	backendByEndpoint(p, "b").inflight.Store(1) // least loaded
-	got := p.pick()
-	if got == nil {
-		t.Fatal("fail-open: expected a backend, got nil")
+}
+
+func TestPool_ShedsFastAfterTrafficFailures(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 1)
+	base := time.Now()
+	p.now = func() time.Time { return base }
+	tripAllByTraffic(t, p, reg, 1)
+
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); !errors.Is(err, ErrBackendsUnavailable) {
+		t.Fatalf("expected fast-fail inside the shed window, got %v", err)
 	}
-	if got.endpoint != "b" {
-		t.Errorf("fail-open: expected least-loaded 'b', got %q", got.endpoint)
+	if st := p.PoolStats(); st.ShedRequests == 0 {
+		t.Errorf("shed counter not incremented: %+v", st)
+	}
+	for _, f := range reg {
+		f.calls.Store(0)
+	}
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); !errors.Is(err, ErrBackendsUnavailable) {
+		t.Fatalf("expected continued shedding, got %v", err)
+	}
+	for ep, f := range reg {
+		if f.calls.Load() != 0 {
+			t.Errorf("shed request must not touch backend %s", ep)
+		}
+	}
+}
+
+func TestPool_CanaryAfterShedWindowRearmsOnFailure(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a", "b"}, 1)
+	base := time.Now()
+	now := base
+	p.now = func() time.Time { return now }
+	tripAllByTraffic(t, p, reg, 1)
+
+	now = base.Add(shedWindow + time.Second)
+	for _, f := range reg {
+		f.calls.Store(0)
+	}
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err == nil {
+		t.Fatal("canary against dead backends must fail")
+	}
+	var canaried int64
+	for _, f := range reg {
+		canaried += f.calls.Load()
+	}
+	if canaried != 1 {
+		t.Errorf("expected exactly 1 canary attempt, got %d", canaried)
+	}
+	if st := p.PoolStats(); st.CanaryRequests != 1 {
+		t.Errorf("stats = %+v, want 1 canary", st)
+	}
+	// The canary's failure re-arms the window: the next request sheds.
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); !errors.Is(err, ErrBackendsUnavailable) {
+		t.Fatalf("expected shedding after failed canary, got %v", err)
+	}
+	if p.canaryInflight.Load() != 0 {
+		t.Error("canary slot must be released after the attempt")
+	}
+}
+
+func TestPool_CanarySuccessReinstatesThroughHalfOpen(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a"}, 1)
+	base := time.Now()
+	now := base
+	p.now = func() time.Time { return now }
+	tripAllByTraffic(t, p, reg, 1)
+
+	// Backend recovers, but probes still fail (e.g. sentinel bucket broken).
+	reg["a"].opFail.Store(false)
+	reg["a"].probeFail.Store(true)
+	now = base.Add(shedWindow + time.Second)
+
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err != nil {
+		t.Fatalf("canary against recovered backend: %v", err)
+	}
+	b := backendByEndpoint(p, "a")
+	if b.state.Load() != stateHalfOpen {
+		t.Fatalf("canary success must move the backend to half-open, got %s", stateName(b.state.Load()))
+	}
+	if p.canaryInflight.Load() != 0 {
+		t.Error("canary slot must be released")
+	}
+	// Trial traffic closes it.
+	for range halfOpenCloseAfter {
+		if _, err := p.HeadObject(context.Background(), "bucket", "k"); err != nil {
+			t.Fatalf("trial request: %v", err)
+		}
+	}
+	if b.state.Load() != stateClosed {
+		t.Errorf("expected closed after %d trial successes, got %s", halfOpenCloseAfter, stateName(b.state.Load()))
 	}
 }
 
 func TestPool_EjectAfterThresholdThenReinstate(t *testing.T) {
 	p, _, reg := newTestPool(t, []string{"a"}, 3)
 	b := backendByEndpoint(p, "a")
-	if !b.healthy.Load() {
-		t.Fatal("backend should start healthy after initial probe")
+	if b.state.Load() != stateClosed {
+		t.Fatal("backend should start closed after initial probe")
 	}
 
-	// Two failures: still healthy (no immediate ejection).
+	// Two failures: still closed (no immediate ejection).
 	reg["a"].opFail.Store(true)
 	_, _ = p.HeadObject(context.Background(), "bucket", "k")
 	_, _ = p.HeadObject(context.Background(), "bucket", "k")
-	if !b.healthy.Load() {
+	if b.state.Load() != stateClosed {
 		t.Error("ejected before reaching threshold")
 	}
 	// Third consecutive failure: ejected.
 	_, _ = p.HeadObject(context.Background(), "bucket", "k")
-	if b.healthy.Load() {
+	if b.state.Load() != stateOpen {
 		t.Error("expected ejection after threshold failures")
 	}
 	if b.errors.Load() != 3 {
 		t.Errorf("expected 3 recorded errors, got %d", b.errors.Load())
 	}
 
-	// Active probe reinstates once the backend recovers.
+	// A traffic-tripped backend re-earns closed through half-open trials, not
+	// from the probe alone.
 	reg["a"].opFail.Store(false)
 	_ = p.Reconcile(context.Background())
-	if !b.healthy.Load() {
-		t.Error("expected reinstatement after healthy probe")
+	if b.state.Load() != stateHalfOpen {
+		t.Fatalf("expected half-open after healthy probe, got %s", stateName(b.state.Load()))
 	}
 	if b.failures.Load() != 0 {
 		t.Errorf("failure streak not reset, got %d", b.failures.Load())
+	}
+	for range halfOpenCloseAfter {
+		_, _ = p.HeadObject(context.Background(), "bucket", "k")
+	}
+	if b.state.Load() != stateClosed {
+		t.Errorf("expected closed after trials, got %s", stateName(b.state.Load()))
+	}
+}
+
+func TestPool_HalfOpenTrialFailureReopens(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a"}, 1)
+	tripAllByTraffic(t, p, reg, 1)
+	reg["a"].opFail.Store(false)
+	_ = p.Reconcile(context.Background())
+	b := backendByEndpoint(p, "a")
+	if b.state.Load() != stateHalfOpen {
+		t.Fatalf("expected half-open, got %s", stateName(b.state.Load()))
+	}
+
+	reg["a"].opFail.Store(true)
+	_, _ = p.HeadObject(context.Background(), "bucket", "k")
+	if b.state.Load() != stateOpen {
+		t.Errorf("trial failure must reopen the backend, got %s", stateName(b.state.Load()))
+	}
+}
+
+func TestPool_HalfOpenAdmitsOneTrialAtATime(t *testing.T) {
+	p, _, _ := newTestPool(t, []string{"a", "h"}, 1)
+	h := backendByEndpoint(p, "h")
+	h.state.Store(stateHalfOpen)
+
+	pk, err := p.pick()
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if pk.b.endpoint != "h" || !pk.trial {
+		t.Fatalf("expected the half-open backend to get a trial, got %q trial=%v", pk.b.endpoint, pk.trial)
+	}
+	for range 10 {
+		next, err := p.pick()
+		if err != nil {
+			t.Fatalf("pick: %v", err)
+		}
+		if next.b.endpoint != "a" {
+			t.Fatalf("only one concurrent trial is allowed, got %q", next.b.endpoint)
+		}
+	}
+	p.release(pk)
+	next, err := p.pick()
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if next.b.endpoint != "h" || !next.trial {
+		t.Errorf("freed trial slot must admit the next trial, got %q trial=%v", next.b.endpoint, next.trial)
+	}
+}
+
+func TestPool_WindowedErrorRateEjectsBrownout(t *testing.T) {
+	// Threshold high enough that the consecutive streak can never trip; the
+	// alternating failure pattern is exactly what the sliding window catches.
+	p, _, _ := newTestPool(t, []string{"a"}, 100)
+	base := time.Now()
+	p.now = func() time.Time { return base }
+	b := backendByEndpoint(p, "a")
+
+	for range windowMinRequests / 2 {
+		p.recordResult(b, nil)
+		p.recordResult(b, &genericError{msg: "dial tcp: connection refused"})
+	}
+	if b.state.Load() != stateOpen {
+		t.Errorf("expected windowed ejection at 50%% failures over %d requests, got %s",
+			windowMinRequests, stateName(b.state.Load()))
+	}
+	if !b.trafficTripped.Load() {
+		t.Error("windowed ejection must mark the backend traffic-tripped")
+	}
+}
+
+func TestPool_WindowForgetsOldFailures(t *testing.T) {
+	p, _, _ := newTestPool(t, []string{"a"}, 100)
+	base := time.Now()
+	now := base
+	p.now = func() time.Time { return now }
+	b := backendByEndpoint(p, "a")
+
+	for range (windowMinRequests / 2) - 1 {
+		p.recordResult(b, nil)
+		p.recordResult(b, &genericError{msg: "connection reset"})
+	}
+	if b.state.Load() != stateClosed {
+		t.Fatalf("below min volume must not eject, got %s", stateName(b.state.Load()))
+	}
+	// Much later, a single failure: the old window has aged out entirely.
+	now = base.Add(time.Hour)
+	p.recordResult(b, &genericError{msg: "connection reset"})
+	if b.state.Load() != stateClosed {
+		t.Errorf("aged-out failures must not count toward ejection, got %s", stateName(b.state.Load()))
+	}
+}
+
+func TestPool_ProbeFailureIgnoredWhileTrafficSucceeds(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a"}, 3)
+	b := backendByEndpoint(p, "a")
+	base := time.Now()
+	p.now = func() time.Time { return base }
+
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+	reg["a"].probeFail.Store(true)
+	_ = p.Reconcile(context.Background())
+	if b.state.Load() != stateClosed {
+		t.Errorf("probe failure must not eject a backend with healthy traffic, got %s", stateName(b.state.Load()))
 	}
 }
 
@@ -278,7 +491,7 @@ func TestPool_AppErrorDoesNotEject(t *testing.T) {
 	reg["a"].getErr = nil
 	// Simulate via recordResult directly with an HTTP 404 error.
 	p.recordResult(b, &httpError{statusCode: 404})
-	if !b.healthy.Load() {
+	if b.state.Load() != stateClosed {
 		t.Error("app-level 404 must not eject the backend")
 	}
 	if b.failures.Load() != 0 {
@@ -310,7 +523,7 @@ func TestPool_GetObjectBodyAccounting(t *testing.T) {
 	if b.downloadedBytes.Load() != int64(len("blobdata")) {
 		t.Errorf("downloadedBytes: got %d", b.downloadedBytes.Load())
 	}
-	if b.healthy.Load() != true {
+	if b.state.Load() != stateClosed {
 		t.Error("clean download must keep backend healthy")
 	}
 }
@@ -327,7 +540,7 @@ func TestPool_GetObjectMidStreamErrorCountsFailure(t *testing.T) {
 	_, _ = io.ReadAll(obj.Body) // drains data then hits the injected error
 	obj.Body.Close()
 
-	if b.healthy.Load() {
+	if b.state.Load() != stateOpen {
 		t.Error("mid-stream read failure should eject backend at threshold 1")
 	}
 	if b.errors.Load() != 1 {
@@ -352,13 +565,14 @@ func TestPool_ReconcileAddsAndRemoves(t *testing.T) {
 	if !eps["a"] || !eps["c"] || eps["b"] || len(eps) != 2 {
 		t.Errorf("after reconcile expected {a,c}, got %v", eps)
 	}
-	// 'a' must be reused (same pointer survives) and stay healthy.
-	if !backendByEndpoint(p, "a").healthy.Load() {
-		t.Error("surviving backend 'a' should remain healthy")
+	// 'a' must be reused (same pointer survives) and stay closed.
+	if backendByEndpoint(p, "a").state.Load() != stateClosed {
+		t.Error("surviving backend 'a' should remain closed")
 	}
-	// 'c' is newly added and promoted by the probe in the same reconcile.
-	if !backendByEndpoint(p, "c").healthy.Load() {
-		t.Error("new backend 'c' should be probed healthy")
+	// 'c' is newly added and promoted straight to closed by the probe in the
+	// same reconcile: a fresh backend has no traffic history to re-earn.
+	if backendByEndpoint(p, "c").state.Load() != stateClosed {
+		t.Error("new backend 'c' should be probed closed")
 	}
 }
 
@@ -367,17 +581,18 @@ func TestPool_ReconcileEjectsViaProbe(t *testing.T) {
 	reg["a"].probeFail.Store(true)
 	_ = p.Reconcile(context.Background())
 
-	if backendByEndpoint(p, "a").healthy.Load() {
+	if backendByEndpoint(p, "a").state.Load() != stateOpen {
 		t.Error("'a' should be ejected after failing probe")
 	}
-	if !backendByEndpoint(p, "b").healthy.Load() {
-		t.Error("'b' should remain healthy")
+	if backendByEndpoint(p, "b").state.Load() != stateClosed {
+		t.Error("'b' should remain closed")
 	}
 
-	// Recovery: probe passes again, backend reinstated.
+	// Recovery: probe passes again; a probe-only ejection closes directly,
+	// without half-open trials.
 	reg["a"].probeFail.Store(false)
 	_ = p.Reconcile(context.Background())
-	if !backendByEndpoint(p, "a").healthy.Load() {
+	if backendByEndpoint(p, "a").state.Load() != stateClosed {
 		t.Error("'a' should be reinstated after probe recovers")
 	}
 }
@@ -498,7 +713,7 @@ func TestPool_RetryMasksSingleBackendFailure(t *testing.T) {
 
 func TestPool_NoRetryWithoutAnotherHealthyBackend(t *testing.T) {
 	p, _, reg := newTestPool(t, []string{"a", "b"}, 3)
-	backendByEndpoint(p, "b").healthy.Store(false)
+	backendByEndpoint(p, "b").state.Store(stateOpen)
 	forcePick(p, "a")
 	reg["a"].opFail.Store(true)
 
@@ -729,8 +944,8 @@ func TestPool_ProbesConcurrentAndBounded(t *testing.T) {
 		t.Errorf("probes returned before the timeout cancelled them (%v)", elapsed)
 	}
 	for _, b := range p.snapshot() {
-		if b.healthy.Load() {
-			t.Errorf("backend %s should be unhealthy after timed-out probe", b.endpoint)
+		if b.state.Load() != stateOpen {
+			t.Errorf("backend %s should be open after timed-out probe", b.endpoint)
 		}
 	}
 }
@@ -754,4 +969,65 @@ func TestPool_RetryBudgetKnobsConfigurable(t *testing.T) {
 	if got := p.PoolStats().RetryBudget; got != 40-20+5 {
 		t.Errorf("budget after one retry (-20) and its success (+5) = %d, want 25", got)
 	}
+}
+
+func TestPool_CanaryGetReleasesSlotAtHeaders(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a"}, 1)
+	base := time.Now()
+	now := base
+	p.now = func() time.Time { return now }
+	tripAllByTraffic(t, p, reg, 1)
+	reg["a"].opFail.Store(false)
+	reg["a"].probeFail.Store(true)
+	now = base.Add(shedWindow + time.Second)
+
+	obj, err := p.GetObject(context.Background(), "bucket", "k", "")
+	if err != nil {
+		t.Fatalf("canary GetObject: %v", err)
+	}
+	if p.canaryInflight.Load() != 0 {
+		t.Error("canary slot must be freed once headers arrive, not held for the body stream")
+	}
+	b := backendByEndpoint(p, "a")
+	if b.state.Load() != stateHalfOpen {
+		t.Errorf("headers from an open backend must admit trial traffic, got %s", stateName(b.state.Load()))
+	}
+	_, _ = io.ReadAll(obj.Body)
+	obj.Body.Close()
+	if b.state.Load() != stateHalfOpen {
+		t.Errorf("clean body close must keep the backend half-open, got %s", stateName(b.state.Load()))
+	}
+	if got := b.halfOpenSuccesses.Load(); got != 1 {
+		t.Errorf("one canary GET must count exactly one trial success, got %d", got)
+	}
+}
+
+func TestPool_TrialsAndCanariesBoundedWhileStreaming(t *testing.T) {
+	p, _, reg := newTestPool(t, []string{"a"}, 1)
+	base := time.Now()
+	now := base
+	p.now = func() time.Time { return now }
+	tripAllByTraffic(t, p, reg, 1)
+	reg["a"].opFail.Store(false)
+	reg["a"].probeFail.Store(true)
+	now = base.Add(shedWindow + time.Second)
+
+	canary, err := p.GetObject(context.Background(), "bucket", "k", "")
+	if err != nil {
+		t.Fatalf("canary GetObject: %v", err)
+	}
+	trial, err := p.GetObject(context.Background(), "bucket", "k", "")
+	if err != nil {
+		t.Fatalf("trial GetObject: %v", err)
+	}
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); !errors.Is(err, ErrBackendsUnavailable) {
+		t.Fatalf("expected shed with the trial slot taken and no open backend left, got %v", err)
+	}
+	_, _ = io.ReadAll(trial.Body)
+	trial.Body.Close()
+	if _, err := p.HeadObject(context.Background(), "bucket", "k"); err != nil {
+		t.Fatalf("freed trial slot must admit the next trial: %v", err)
+	}
+	_, _ = io.ReadAll(canary.Body)
+	canary.Body.Close()
 }


### PR DESCRIPTION
Windowed error-rate ejection, half-open trial traffic, and a traffic-confirmed cluster-wide fast-503 (+Retry-After, canary re-probe) replacing unbounded fail-open; HEAD errors no longer masquerade as 404. Stacked on #527.

- `main` <!-- branch-stack -->
  - \#526
    - \#527
      - \#528 :point\_left:
        - \#529
