### PR TITLE
feat(ceph): persist the HDD write-cache disable and guard it to rotational media

### DIFF
--- a/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
+++ b/ansible/ceph/inventories/prod-htz-fsn1/spice/group_vars/all/vars.yml
@@ -192,6 +192,13 @@ ceph_db_lvs_per_node: 14
 ceph_ssd_osd_lv: ssd-osd          # NVMe-backed OSD LV (fast replicated pool)
 ceph_ssd_osd_reserve_gib: 512     # vg0 free left unallocated for headroom/expansion
 
+# HDD volatile write cache off, fleet-wide. Measured on this cluster
+# 2026-08-17/19; the alyssa power cycle on 08-18 silently reverted 14 drives
+# for 30 hours, which is what the udev-side persistence exists to stop.
+# Rationale, rollout note and the day-2 tool live on the flag in
+# roles/hardware_tuning/defaults/main.yml.
+ceph_hdd_write_cache_disabled: true
+
 # Keep the OSD specs registered but inert. cephadm reconciles every MANAGED spec
 # on every serve-loop pass, and each pass costs a ceph-volume lvm list + raw list
 # per host; at spice's size that pinned one full loop iteration at ~35 minutes

--- a/ansible/ceph/roles/hardware_tuning/defaults/main.yml
+++ b/ansible/ceph/roles/hardware_tuning/defaults/main.yml
@@ -35,6 +35,33 @@ ceph_enable_fstrim_timer: true
 ceph_sata_link_pm_enabled: true
 ceph_sata_link_pm_policy: max_performance
 
+# HDD volatile write cache: disable it drive-side (hdparm -W 0) on rotational
+# ATA disks.
+#
+# BlueStore opens the data device O_DIRECT and issues one FLUSH CACHE EXT per
+# kv-sync batch. A FLUSH is non-NCQ, so libata drains the whole 32-deep queue
+# around it: measured on spice, ~100 flushes/s at 4-8 ms each during fill, a
+# flush outstanding 8% of wall time, and EC k16+m4 pays the slowest shard on
+# every write. With the cache off the flush completes at the block layer and
+# commit latency dropped ~2x (WD HC580) to ~4x (Seagate X22), reads unharmed.
+# Durability is unchanged: with WCE off a completed write is on media (the WD
+# ArmorCache drives were power-loss safe either way, but nothing in the kernel
+# or Ceph reads that; see the 2026-08-17 decision memo in Brain Box).
+#
+# The drive reverts to write back on every power cycle, silently. The udev add
+# rule + /usr/local/sbin/ceph-hdd-wcache re-apply it on boot coldplug and on a
+# hot-swapped replacement; a drive that resets in place (firmware crash,
+# internal power event) reverts with no uevent and is caught only by the drift
+# check. The script is also the day-2 tool: `ceph-hdd-wcache sdX` after a disk
+# swap, `ceph-hdd-wcache all` for a host, though udev normally beats you to
+# both. Rotational ATA whole disks only; SAS clusters (sietch) need sdparm
+# instead and stay off this flag.
+#
+# NOTE: like the LPM write below, the first application toggles SET FEATURES on
+# every disk and schedules a libata EH pass per port; roll per node, not
+# fleet-wide in one pass.
+ceph_hdd_write_cache_disabled: false
+
 # Transparent Huge Pages -- madvise is universally correct for BlueStore.
 # THP=always drives tcmalloc/BlueStore RSS bloat and allocation-stall latency.
 # Applied on all ceph clusters (not gated behind the CPU governor).

--- a/ansible/ceph/roles/hardware_tuning/files/ceph-hdd-wcache
+++ b/ansible/ceph/roles/hardware_tuning/files/ceph-hdd-wcache
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Disable the volatile write cache on rotational ATA disks, drive-side.
+#
+# Usage: ceph-hdd-wcache all
+#        ceph-hdd-wcache --udev <sdX>
+#        ceph-hdd-wcache <sdX|/dev/sdX|/dev/disk/by-*> [...]
+#
+# hdparm -W 0 issues SET FEATURES to the drive itself; libata revalidates on
+# completion, so the kernel's queue flag follows and BlueStore's fdatasync
+# becomes a no-op at this device. The setting does NOT survive a power cycle
+# (SSP preserves it across link resets only), which is why the udev rule
+# deployed next to this script re-runs it on every disk add: boot coldplug and
+# hot-swapped replacement drives get it without operator action.
+#
+# Guards: rotational ATA whole disks only. SAS (sietch) and the BMC's virtual
+# media never match. The udev rule is add-only, so a uevent loop is impossible
+# regardless of what this script does; the --udev sysfs fast path exists only
+# to keep the RUN program cheap and idempotent on every disk add. Explicitly
+# named devices that are missing or ineligible are hard errors; only `all` and
+# `--udev` skip them quietly. Exit codes: 0 converged, 1 any failure, 2 usage.
+#
+# The LVM/dm-crypt devices above a disk keep reporting `write back`; dm samples
+# the flag at table load only. Cosmetic. Judge state by this script's output,
+# /sys/block/sdX/queue/write_cache, or hdparm -W.
+set -u
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+fail=0
+changed=0
+udev_mode=0
+
+usage() {
+  echo "usage: ceph-hdd-wcache all | --udev <sdX> | <sdX|/dev/sdX|/dev/disk/by-*> [...]"
+}
+
+eligible() {
+  local d=$1 bus
+  [ -b "/dev/$d" ] || return 1
+  [ -e "/sys/block/$d/partition" ] && return 1
+  [ -e "/sys/block/$d/queue/rotational" ] || return 1
+  [ "$(cat "/sys/block/$d/queue/rotational")" = "1" ] || return 1
+  grep -qi "virtual" "/sys/block/$d/device/model" 2>/dev/null && return 1
+  # udev exports event properties to RUN programs, so only --udev may trust an
+  # inherited ID_BUS; any other mode could be inheriting a stale one from its
+  # caller's environment and always asks udevadm.
+  bus=""
+  [ "$udev_mode" = "1" ] && bus=${ID_BUS:-}
+  if [ -z "$bus" ]; then
+    bus=$(udevadm info -q property --name "/dev/$d" 2>/dev/null | sed -n 's/^ID_BUS=//p')
+  fi
+  [ "$bus" = "ata" ] || return 1
+  return 0
+}
+
+drive_wce() {
+  hdparm -W "/dev/$1" 2>/dev/null | awk '/write-caching/{print $3}'
+}
+
+apply() {
+  local d=$1 drive kernel
+  drive=$(drive_wce "$d")
+  kernel=$(cat "/sys/block/$d/queue/write_cache")
+  if [ "$drive" = "0" ] && [ "$kernel" = "write through" ]; then
+    echo "$d: write cache already disabled (drive=0)"
+    return 0
+  fi
+  if ! hdparm -q -W 0 "/dev/$d"; then
+    echo "$d: hdparm -W 0 FAILED" >&2
+    return 1
+  fi
+  # Completing the SET FEATURES schedules the libata revalidate that refreshes
+  # the kernel flag, which is why a drive already at 0 whose kernel flag still
+  # reads write back gets the idempotent re-issue above rather than an early
+  # return. Give the sd flag a moment to follow.
+  for _ in 1 2 3 4 5 6; do
+    [ "$(cat "/sys/block/$d/queue/write_cache")" = "write through" ] && break
+    sleep 0.3
+  done
+  drive=$(drive_wce "$d")
+  kernel=$(cat "/sys/block/$d/queue/write_cache")
+  if [ "$drive" = "0" ] && [ "$kernel" = "write through" ]; then
+    echo "$d: write cache disabled (drive=0 kernel=write_through)"
+    changed=1
+    return 0
+  fi
+  echo "$d: VERIFY FAILED drive=$drive kernel=$kernel" >&2
+  return 1
+}
+
+case ${1:-} in
+-h|--help)
+  usage
+  exit 0
+  ;;
+esac
+
+[ $# -ge 1 ] || { usage >&2; exit 2; }
+
+case $1 in
+all)
+  [ $# -eq 1 ] || { usage >&2; exit 2; }
+  for sys in /sys/block/sd*; do
+    [ -e "$sys" ] || continue
+    d=${sys##*/}
+    if ! eligible "$d"; then
+      echo "$d: skipped (not a rotational ATA disk)"
+      continue
+    fi
+    apply "$d" || fail=1
+  done
+  ;;
+--udev)
+  [ $# -eq 2 ] || { usage >&2; exit 2; }
+  udev_mode=1
+  d=$2
+  if ! eligible "$d"; then
+    echo "$d: skipped (not a rotational ATA disk)"
+  elif [ "$(cat "/sys/block/$d/queue/write_cache")" != "write through" ]; then
+    apply "$d" || fail=1
+  fi
+  ;;
+*)
+  for arg in "$@"; do
+    d=$arg
+    case $arg in
+    */*)
+      if ! d=$(readlink -f -- "$arg") || [ "${d%/*}" != "/dev" ] || [ ! -b "$d" ]; then
+        echo "$arg: no such block device" >&2
+        fail=1
+        continue
+      fi
+      ;;
+    esac
+    d=${d#/dev/}
+    if [ ! -b "/dev/$d" ]; then
+      echo "$arg: no such block device" >&2
+      fail=1
+      continue
+    fi
+    if ! eligible "$d"; then
+      echo "$arg: not a rotational ATA disk" >&2
+      fail=1
+      continue
+    fi
+    apply "$d" || fail=1
+  done
+  ;;
+esac
+
+[ "$changed" -eq 1 ] && echo CHANGED
+exit $fail

--- a/ansible/ceph/roles/hardware_tuning/tasks/drift.yml
+++ b/ansible/ceph/roles/hardware_tuning/tasks/drift.yml
@@ -92,3 +92,47 @@
                  in [ceph_sata_link_pm_policy, 'n/a']
       }] }}
   when: ceph_sata_link_pm_enabled | bool
+
+# HDD volatile write cache. Every disk matters, not a representative one: the
+# drive reverts to write back on a power cycle, EC pays the slowest shard, and
+# a single reverted disk taxes every PG it hosts. Same population rule as LPM;
+# the loop mirrors ceph-hdd-wcache's eligibility, so a rotational non-ATA disk
+# is neither counted here nor converged there. A probe that inspected zero
+# disks (udev database unavailable, or no eligible disks on a flagged host)
+# must fail the row, not pass it vacuously; every flagged host is expected to
+# have eligible HDDs.
+- name: Check HDD write cache
+  ansible.builtin.shell: |
+    set -o pipefail
+    total=0; back=0
+    for d in /sys/block/sd*; do
+      [ -e "$d/queue/rotational" ] || continue
+      [ "$(cat "$d/queue/rotational")" = "1" ] || continue
+      grep -qi "virtual" "$d/device/model" 2>/dev/null && continue
+      B=$(basename "$d")
+      bus=$(udevadm info -q property --name "/dev/$B" 2>/dev/null | sed -n "s/^ID_BUS=//p")
+      [ "$bus" = "ata" ] || continue
+      total=$((total+1))
+      [ "$(cat "$d/queue/write_cache")" = "write through" ] || back=$((back+1))
+    done
+    echo "$back of $total write back"
+  args:
+    executable: /bin/bash
+  register: hdd_wcache_drift
+  changed_when: false
+  # Read-only, so run it under --check too (health_gate precedent). Left to
+  # default the probe skips and the row below records '' as a false mismatch.
+  check_mode: false
+  when: ceph_hdd_write_cache_disabled | bool
+
+- name: Record HDD write cache drift
+  ansible.builtin.set_fact:
+    drift_results: >-
+      {{ drift_results + [{
+        'category': 'hardware',
+        'item': 'HDD volatile write cache',
+        'expected': '0 write back',
+        'actual': hdd_wcache_drift.stdout | trim,
+        'match': (hdd_wcache_drift.stdout | trim) is match('^0 of [1-9]')
+      }] }}
+  when: ceph_hdd_write_cache_disabled | bool

--- a/ansible/ceph/roles/hardware_tuning/tasks/main.yml
+++ b/ansible/ceph/roles/hardware_tuning/tasks/main.yml
@@ -1,7 +1,18 @@
 ---
 # Hardware-level tuning for Ceph OSD nodes.
-# Sets I/O scheduler, readahead, and queue depth per device class.
+# Sets I/O scheduler, readahead, and queue depth per device class, plus the
+# HDD volatile write cache.
 # All changes apply live and persist via udev rules (no reboot).
+
+# The RUN target must exist before the rules file that names it is deployed.
+- name: Deploy the HDD write-cache helper
+  ansible.builtin.copy:
+    src: ceph-hdd-wcache
+    dest: /usr/local/sbin/ceph-hdd-wcache
+    owner: root
+    group: root
+    mode: '0755'
+  when: ceph_hdd_write_cache_disabled | bool
 
 - name: Deploy udev rules for disk tuning
   ansible.builtin.template:
@@ -69,6 +80,12 @@
     executable: /bin/bash
   register: ssd_tuning
   changed_when: "'CHANGED' in (ssd_tuning.stdout | default(''))"
+
+- name: Disable the HDD volatile write cache on existing disks
+  ansible.builtin.command: /usr/local/sbin/ceph-hdd-wcache all
+  register: _hdd_wcache
+  changed_when: "'CHANGED' in (_hdd_wcache.stdout | default(''))"
+  when: ceph_hdd_write_cache_disabled | bool
 
 - name: Enable fstrim.timer for OS partitions
   ansible.builtin.systemd:

--- a/ansible/ceph/roles/hardware_tuning/templates/99-ceph-disk-tuning.rules.j2
+++ b/ansible/ceph/roles/hardware_tuning/templates/99-ceph-disk-tuning.rules.j2
@@ -22,3 +22,11 @@ ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="0", ATTR{queu
 # TEST== guards non-SATA hosts, which have no such attribute.
 ACTION=="add|change", SUBSYSTEM=="scsi_host", KERNEL=="host*", TEST=="link_power_management_policy", ATTR{link_power_management_policy}="{{ ceph_sata_link_pm_policy }}"
 {% endif %}
+{% if ceph_hdd_write_cache_disabled %}
+
+# HDD volatile write cache off, drive-side, on every disk add: boot coldplug
+# and hot-swapped replacements alike. The script re-checks rotational/ATA and
+# no-ops when already write through; see its header and the rationale on
+# ceph_hdd_write_cache_disabled in defaults/main.yml.
+ACTION=="add", SUBSYSTEM=="block", KERNEL=="sd[a-z]*", ENV{DEVTYPE}=="disk", ATTR{queue/rotational}=="1", RUN+="/usr/local/sbin/ceph-hdd-wcache --udev %k"
+{% endif %}


### PR DESCRIPTION
Every rotational ATA disk on a cluster that sets `ceph_hdd_write_cache_disabled` runs with its volatile write cache off, persistently: a udev add rule re-applies the drive-side disable on boot coldplug and on hot-swapped replacements, and `/usr/local/sbin/ceph-hdd-wcache` is both the rule's target and the day-2 tool for one disk or a whole host. The drift check fails loudly when any disk reverts or when the probe inspected nothing. spice turns the flag on; sietch's SAS fleet stays on the default off, and the guards (rotational, ATA bus, whole disk, no virtual media) hold at the rule, the script, and the drift probe independently. Measured on spice 2026-08-17/19: commit latency 2-4x down with no read-side cost, and the alyssa power cycle on 08-18 silently reverted 14 drives for 30 hours, which is the gap this closes. Rationale and the per-node rollout constraint live on the flag in roles/hardware\_tuning/defaults/main.yml.

- `main` <!-- branch-stack -->
  - \#531 :point\_left:
