### PR TITLE
fix(ceph): drop wt0 interface alerts before they reach alertmanager

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_deploy/defaults/main.yml
@@ -150,4 +150,7 @@ ceph_alertmanager_fix_route_tree: false
 #
 # Only meaningful when the receiver resolves annotations by name. Harmless
 # otherwise, but defaults false so no cluster changes alert content implicitly.
+#
+# The same gated override also drops alerts on the NetBird wt0 interface, whose
+# packet-error noise belongs to mesh monitoring.
 ceph_prometheus_drop_description_label: false

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -305,7 +305,14 @@
                                "    # EC profile) that shadows the same-named annotation in any\n"
                                "    # receiver that resolves by field name.\n"
                                "    - regex: 'description'\n"
-                               "      action: labeldrop\n",
+                               "      action: labeldrop\n"
+                               "    # yucca: wt0 is the NetBird management overlay; interface-error alerts\n"
+                               "    # on it are mesh weather, not ceph (2026-08-24: one relay bounce made\n"
+                               "    # CephNodeNetworkPacketErrors deliver 1000+ messages). Drop any alert\n"
+                               "    # scoped to that device.\n"
+                               "    - source_labels: ['device']\n"
+                               "      regex: 'wt0'\n"
+                               "      action: drop\n",
                 },
             ],
             "expect": lambda src: "alert_relabel_configs" not in src,


### PR DESCRIPTION
Alerts scoped to `device=wt0` are dropped at Prometheus alert relabeling, so ceph packet-error rules no longer page for NetBird overlay weather. The 2026-08-24 relay bounce produced 1000+ Zulip messages from `CephNodeNetworkPacketErrors` on wt0 across 37 hosts, all reporting mesh state ceph cannot act on; interface health on the overlay belongs to mesh monitoring. The rule lives in the derived prometheus override in `monitoring.yml`, rides the existing `ceph_prometheus_drop_description_label` gate, and lands on the next monitoring converge.

- `main` <!-- branch-stack -->
  - \#539 :point\_left:
    - \#540
