### PR TITLE
feat(o11y): watch the NetBird overlay and give spice networking a dashboard

### DIFF
--- a/ansible/ceph/roles/ceph_deploy/defaults/main.yml
+++ b/ansible/ceph/roles/ceph_deploy/defaults/main.yml
@@ -150,4 +150,7 @@ ceph_alertmanager_fix_route_tree: false
 #
 # Only meaningful when the receiver resolves annotations by name. Harmless
 # otherwise, but defaults false so no cluster changes alert content implicitly.
+#
+# The same gated override also drops alerts on the NetBird wt0 interface, whose
+# packet-error noise belongs to mesh monitoring.
 ceph_prometheus_drop_description_label: false

--- a/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
+++ b/ansible/ceph/roles/ceph_deploy/tasks/monitoring.yml
@@ -305,7 +305,14 @@
                                "    # EC profile) that shadows the same-named annotation in any\n"
                                "    # receiver that resolves by field name.\n"
                                "    - regex: 'description'\n"
-                               "      action: labeldrop\n",
+                               "      action: labeldrop\n"
+                               "    # yucca: wt0 is the NetBird management overlay; interface-error alerts\n"
+                               "    # on it are mesh weather, not ceph (2026-08-24: one relay bounce made\n"
+                               "    # CephNodeNetworkPacketErrors deliver 1000+ messages). Drop any alert\n"
+                               "    # scoped to that device.\n"
+                               "    - source_labels: ['device']\n"
+                               "      regex: 'wt0'\n"
+                               "      action: drop\n",
                 },
             ],
             "expect": lambda src: "alert_relabel_configs" not in src,

--- a/o11y/README.md
+++ b/o11y/README.md
@@ -31,6 +31,7 @@ victoria-logs-collector.
 | `yucca-spice-blockdb-bluefs.json` | block.db headroom: spillover tripwire, per-OSD utilization and growth, BlueFS internals | `ceph_bluefs_*`, `ceph_bluestore_onode_*`, `ceph_osd_metadata` |
 | `yucca-spice-recovery-backfill.json` | Rebalance throughput in bytes and work outstanding, during an OSD purge / reweight / host drain. Complements the recovery ops/s on `yucca-spice-ceph-health` | `ceph_pool_recovering_*`, `ceph_pg_{backfilling,backfill_wait,remapped}`, `ceph_num_objects_{misplaced,degraded}` |
 | `yucca-spice-scrub.json` | Scrub progress: which hosts are still scrubbing (regular vs deep, as scrub primary), PGs in flight per level, and work outstanding for the deep cycle (bytes scrubbed vs raw used over the configured interval; needs that much retention) | `ceph_pg_{scrubbing,deep,wait}`, `ceph_osd_scrub_{sh,dp}_*_chunk_selected`, `ceph_osd_scrub_*_read_bytes`, `ceph_osd_{num_scrubs_started,successful_scrubs,failed_scrubs}_*`, `ceph_osd_stat_bytes_used`, `ceph_osd_metadata` |
+| `yucca-spice-network.json` | Fleet networking: 25G bond fabric + balance, bond health, VLAN split, NetBird wt0 overlay (mirrors the `netbird.yaml` alert exprs), WAN, TCP retransmits/conntrack | `node_network_*`, `node_bonding_*`, `node_netstat_*`, `node_nf_conntrack_*` |
 | `yucca-father-kubernetes.json` | apiserver, coredns, workloads, PVCs, kubelet | `apiserver_*`, `container_*`, `kubelet_*`, `coredns_*` |
 | `yucca-fabric-htz-fsn1.json` | Switch fabric: sFlow 5s rates, NETCONF, BGP, alarms | `sflow_*`, `junos_*` (port of the in-cluster netops board) |
 | `yucca-telemetry-pipeline.json` | Is telemetry itself healthy: scrape + remote-write | `up`, `vmagent_remotewrite_*`, `vm_*` |
@@ -198,6 +199,7 @@ Conventions:
 | `kubernetes.yaml` | flux reconciliation, cert-manager expiry/readiness, node not ready, crashloops, PVC fill 90% warning / 95% critical (father+luke) |
 | `cilium.yaml` | agent daemonset, BGP control-plane sessions (k8s side of the fabric peering) |
 | `fabric.yaml` | transit BGP per-carrier (critical; peer IPs pinned from `fabric.tf`), all-transits-down, other BGP sessions, chassis alarms, interface errors, exporter/sFlow liveness |
+| `netbird.yaml` | NetBird wt0 overlay: cluster-scoped packet errors, hosts missing the interface (replaces the per-node ceph noise #539 drops) |
 | `telemetry.yaml` | per-cluster "stopped shipping metrics" (father/luke/netops/spice) |
 
 Known gaps (no metric exists yet): michael token-introspection outages and

--- a/o11y/alerts/netbird.yaml
+++ b/o11y/alerts/netbird.yaml
@@ -46,8 +46,8 @@ spec:
             maxDataPoints: 43200
             expr: >-
               sum by (cluster)
-              (rate(node_network_receive_errs_total{device="wt0"}[5m]) +
-              rate(node_network_transmit_errs_total{device="wt0"}[5m]))
+              (rate(node_network_receive_errs_total{device="wt0", project="yucca"}[5m]) +
+              rate(node_network_transmit_errs_total{device="wt0", project="yucca"}[5m]))
         - refId: B
           relativeTimeRange:
             from: 600
@@ -62,8 +62,9 @@ spec:
                   params: [1]
                   type: gt
     # node_network_up{device="wt0"} is permanently 0 for TUN interfaces (no
-    # carrier), so presence-of-series is the only honest down signal. 30d
-    # backtest: one borderline 15-minute blip.
+    # carrier), so presence-of-series is the only honest down signal. The unless
+    # join returns an empty vector when every scraped host has wt0, so
+    # noDataState OK is load-bearing. 30d backtest: clean.
     - uid: netbird-overlay-interface-missing
       title: NetBirdOverlayInterfaceMissing
       condition: B
@@ -93,9 +94,9 @@ spec:
             maxDataPoints: 43200
             expr: >-
               count by (cluster)
-              (last_over_time(up{job=~"(ceph-)?node-exporter"}[5m]) == 1) -
-              count by (cluster)
-              (last_over_time(node_network_receive_bytes_total{device="wt0"}[5m]))
+              (last_over_time(up{job=~"(ceph-)?node-exporter", project="yucca"}[5m]) == 1
+              unless on (cluster, instance)
+              last_over_time(node_network_receive_bytes_total{device="wt0", project="yucca"}[5m]))
         - refId: B
           relativeTimeRange:
             from: 600

--- a/o11y/alerts/netbird.yaml
+++ b/o11y/alerts/netbird.yaml
@@ -1,0 +1,111 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanaalertrulegroup_v1beta1.json
+# Cluster-scoped by design: the 2026-08-24 relay bounce re-keyed every peer at
+# once and the per-node ceph rule (CephNodeNetworkPacketErrors) delivered 1000+
+# messages saying the same thing. #539 drops device="wt0" from the ceph stack's
+# alerting entirely; these two rules are the replacement, one alert per cluster.
+# 30d backtest: threshold 1 pkt/s sustained 10m fires twice for spice (08-15,
+# 08-24), zero noise elsewhere.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: yucca-netbird
+spec:
+  folderRef: yucca
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  interval: 1m
+  rules:
+    - uid: netbird-overlay-packet-errors
+      title: NetBirdOverlayPacketErrors
+      condition: B
+      for: 10m
+      noDataState: OK
+      execErrState: Error
+      isPaused: false
+      labels:
+        severity: warning
+      annotations:
+        summary: NetBird overlay packet errors on {{ $labels.cluster }}
+        description: >-
+          Sustained WireGuard rx/tx errors ({{ humanize $values.A.Value }}
+          pkt/s) on the wt0 overlay across cluster {{ $labels.cluster }},
+          usually a NetBird relay or management event re-keying sessions; one
+          alert per cluster by design.
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: VictoriaMetricsFleet
+          model:
+            refId: A
+            instant: true
+            range: false
+            intervalMs: 300000
+            maxDataPoints: 43200
+            expr: >-
+              sum by (cluster)
+              (rate(node_network_receive_errs_total{device="wt0"}[5m]) +
+              rate(node_network_transmit_errs_total{device="wt0"}[5m]))
+        - refId: B
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            refId: B
+            type: threshold
+            expression: A
+            conditions:
+              - evaluator:
+                  params: [1]
+                  type: gt
+    # node_network_up{device="wt0"} is permanently 0 for TUN interfaces (no
+    # carrier), so presence-of-series is the only honest down signal. 30d
+    # backtest: one borderline 15-minute blip.
+    - uid: netbird-overlay-interface-missing
+      title: NetBirdOverlayInterfaceMissing
+      condition: B
+      for: 15m
+      noDataState: OK
+      execErrState: Error
+      isPaused: false
+      labels:
+        severity: warning
+      annotations:
+        summary: hosts missing the NetBird wt0 interface on {{ $labels.cluster }}
+        description: >-
+          {{ humanize $values.A.Value }} node(s) on cluster
+          {{ $labels.cluster }} are being scraped but expose no wt0 series;
+          the NetBird client is down or the interface is gone on those hosts.
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: VictoriaMetricsFleet
+          model:
+            refId: A
+            instant: true
+            range: false
+            intervalMs: 300000
+            maxDataPoints: 43200
+            expr: >-
+              count by (cluster)
+              (last_over_time(up{job=~"(ceph-)?node-exporter"}[5m]) == 1) -
+              count by (cluster)
+              (last_over_time(node_network_receive_bytes_total{device="wt0"}[5m]))
+        - refId: B
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            refId: B
+            type: threshold
+            expression: A
+            conditions:
+              - evaluator:
+                  params: [0]
+                  type: gt

--- a/o11y/dashboards/yucca-spice-network.json
+++ b/o11y/dashboards/yucca-spice-network.json
@@ -1,0 +1,1102 @@
+{
+  "uid": "yucca-spice-network",
+  "title": "Ceph / Network",
+  "description": "Fleet networking for the spice cluster: 25G bond fabric, VLAN split, NetBird wt0 overlay, WAN and TCP health. Companion to the o11y/alerts/netbird.yaml rules; provisioned from the repo, edit the file not the UI.",
+  "tags": [
+    "spice",
+    "ceph",
+    "network",
+    "prod"
+  ],
+  "timezone": "",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "version": 1,
+  "links": [],
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Data Source",
+        "refresh": 1,
+        "hide": 0,
+        "current": {
+          "text": "VictoriaMetrics Fleet",
+          "value": "VictoriaMetricsFleet"
+        },
+        "options": [],
+        "regex": "/^VictoriaMetrics Fleet$/",
+        "skipUrlSync": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "includeAll": true,
+        "label": "Env",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\"}, env)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "includeAll": true,
+        "label": "Provider",
+        "multi": true,
+        "name": "provider",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\"}, provider)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "includeAll": true,
+        "label": "Region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": "label_values(up{project=\"yucca\", env=~\"$env\", provider=~\"$provider\"}, region)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "name": "cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "query": "label_values(ceph_health_status{env=~\"$env\", provider=~\"$provider\", region=~\"$region\"}, cluster)",
+        "label": "Cluster",
+        "refresh": 1,
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "allValue": null,
+        "current": {},
+        "options": [],
+        "regex": "",
+        "sort": 1,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "25G fabric",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Fleet total (25G members)",
+      "description": "Aggregate over every 25G bond member in the fleet.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(node_network_receive_bytes_total{cluster=~\"$cluster\", device=~\"enp19[37]s0f[01]\"}[$__rate_interval])) * 8",
+          "refId": "A",
+          "legendFormat": "rx"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(node_network_transmit_bytes_total{cluster=~\"$cluster\", device=~\"enp19[37]s0f[01]\"}[$__rate_interval])) * 8",
+          "refId": "B",
+          "legendFormat": "tx"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Top 10 hosts by bond0 throughput",
+      "description": "rx+tx over the bond; a single host pinned here while the fleet idles is the interesting case.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "topk(10, sum by (instance) ((rate(node_network_receive_bytes_total{cluster=~\"$cluster\", device=\"bond0\"}[$__rate_interval]) + rate(node_network_transmit_bytes_total{cluster=~\"$cluster\", device=\"bond0\"}[$__rate_interval])) * 8))",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Per-member balance",
+      "description": "The two 25G members should carry comparable load; a skewed split means the LACP hash is unhappy.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (device) ((rate(node_network_receive_bytes_total{cluster=~\"$cluster\", device=~\"enp193s0f[01]\"}[$__rate_interval]) + rate(node_network_transmit_bytes_total{cluster=~\"$cluster\", device=~\"enp193s0f[01]\"}[$__rate_interval])) * 8)",
+          "refId": "A",
+          "legendFormat": "{{device}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Bond health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Degraded bonds",
+      "description": "Bonds running with fewer active members than configured.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "count(node_bonding_active{cluster=~\"$cluster\"} < node_bonding_slaves{cluster=~\"$cluster\"}) or vector(0)",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Carrier changes, top 10 devices",
+      "description": "Link flaps on the physical members; anything above zero repeats is cabling or optics.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 10
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "topk(10, rate(node_network_carrier_changes_total{cluster=~\"$cluster\", device=~\"enp.*\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{instance}} {{device}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "VLANs",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Traffic by VLAN subinterface",
+      "description": "Ceph public (bond0.120) vs replication (bond0.122) split.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 19
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (device) ((rate(node_network_receive_bytes_total{cluster=~\"$cluster\", device=~\"bond0\\\\..*\"}[$__rate_interval]) + rate(node_network_transmit_bytes_total{cluster=~\"$cluster\", device=~\"bond0\\\\..*\"}[$__rate_interval])) * 8)",
+          "refId": "A",
+          "legendFormat": "{{device}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "MTU by device",
+      "description": "Jumbo is VLAN-122 only; every host must agree per device.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "max by (device) (node_network_mtu_bytes{cluster=~\"$cluster\", device=~\"bond0\\\\..*|wt0\"})",
+          "refId": "A",
+          "legendFormat": "{{device}}"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "NetBird overlay",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "wt0 traffic",
+      "description": "Management-plane volume over the WireGuard overlay.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (cluster) (rate(node_network_receive_bytes_total{cluster=~\"$cluster\", device=\"wt0\"}[$__rate_interval])) * 8",
+          "refId": "A",
+          "legendFormat": "rx {{cluster}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (cluster) (rate(node_network_transmit_bytes_total{cluster=~\"$cluster\", device=\"wt0\"}[$__rate_interval])) * 8",
+          "refId": "B",
+          "legendFormat": "tx {{cluster}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "wt0 packet errors",
+      "description": "The NetBirdOverlayPacketErrors alert expression; the line marks its 1 pkt/s threshold.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (cluster) (rate(node_network_receive_errs_total{device=\"wt0\"}[5m]) + rate(node_network_transmit_errs_total{device=\"wt0\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{cluster}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none",
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Hosts missing wt0",
+      "description": "The NetBirdOverlayInterfaceMissing alert expression: scraped nodes exposing no wt0 series.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "count by (cluster) (last_over_time(up{job=~\"(ceph-)?node-exporter\"}[5m]) == 1) - count by (cluster) (last_over_time(node_network_receive_bytes_total{device=\"wt0\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{cluster}}"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "WAN + TCP",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "WAN (enp197s0) traffic",
+      "description": "The 1G WAN link; IaC, apt and Hetzner traffic only, the data plane lives on the bond.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(node_network_receive_bytes_total{cluster=~\"$cluster\", device=\"enp197s0\"}[$__rate_interval])) * 8",
+          "refId": "A",
+          "legendFormat": "rx"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(node_network_transmit_bytes_total{cluster=~\"$cluster\", device=\"enp197s0\"}[$__rate_interval])) * 8",
+          "refId": "B",
+          "legendFormat": "tx"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "TCP retransmits, top 10 hosts",
+      "description": "Sustained retransmits on a subset of hosts points at a fabric path, not the application.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "topk(10, rate(node_netstat_Tcp_RetransSegs{cluster=~\"$cluster\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Conntrack entries vs limit",
+      "description": "The limit is per host; the fleet max leading the pack toward it is early warning.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "max(node_nf_conntrack_entries{cluster=~\"$cluster\"})",
+          "refId": "A",
+          "legendFormat": "max entries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "min(node_nf_conntrack_entries_limit{cluster=~\"$cluster\"})",
+          "refId": "B",
+          "legendFormat": "limit"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisLabel": "",
+            "gradientMode": "none"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/o11y/dashboards/yucca-spice-network.json
+++ b/o11y/dashboards/yucca-spice-network.json
@@ -751,7 +751,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (cluster) (rate(node_network_receive_errs_total{device=\"wt0\"}[5m]) + rate(node_network_transmit_errs_total{device=\"wt0\"}[5m]))",
+          "expr": "sum by (cluster) (rate(node_network_receive_errs_total{device=\"wt0\", project=\"yucca\", cluster=~\"$cluster\"}[5m]) + rate(node_network_transmit_errs_total{device=\"wt0\", project=\"yucca\", cluster=~\"$cluster\"}[5m]))",
           "refId": "A",
           "legendFormat": "{{cluster}}"
         }
@@ -825,7 +825,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "count by (cluster) (last_over_time(up{job=~\"(ceph-)?node-exporter\"}[5m]) == 1) - count by (cluster) (last_over_time(node_network_receive_bytes_total{device=\"wt0\"}[5m]))",
+          "expr": "count by (cluster) (last_over_time(up{job=~\"(ceph-)?node-exporter\", project=\"yucca\", cluster=~\"$cluster\"}[5m]) == 1 unless on (cluster, instance) last_over_time(node_network_receive_bytes_total{device=\"wt0\", project=\"yucca\", cluster=~\"$cluster\"}[5m]))",
           "refId": "A",
           "legendFormat": "{{cluster}}"
         }
@@ -861,7 +861,8 @@
                 "value": 1
               }
             ]
-          }
+          },
+          "noValue": "0"
         },
         "overrides": []
       }


### PR DESCRIPTION
NetBird overlay alerting now lives in o11y, where the fleet metrics already are: `alerts/netbird.yaml` adds two cluster-scoped, 30d-backtested rules (sustained wt0 packet errors above 1 pkt/s, and scraped hosts exposing no wt0 series, the only honest down signal since `node_network_up` is always 0 on TUN interfaces). They replace the per-node ceph noise that #539 drops at the source; the 2026-08-24 relay bounce becomes one warning per cluster instead of 1000+ messages. `yucca-spice-network.json` (Ceph / Network) is the landing page for the same territory: 25G bond fabric and balance, bond health, VLAN split, the overlay panels mirroring the alert expressions, WAN and TCP. Delivery rides the existing yucca folder route to Discord; dropping the files in is the whole job.

- `main` <!-- branch-stack -->
  - \#539
    - \#540 :point\_left:
