### PR TITLE
feat(web): discord link confirmation page

### DIFF
--- a/packages/web/src/locales/en.po
+++ b/packages/web/src/locales/en.po
@@ -152,6 +152,10 @@ msgstr "Continue"
 #~ msgid "Created {0} · expires {1}"
 #~ msgstr "Created {0} · expires {1}"
 
+#: src/routes/link/discord/+page.svelte
+msgid "Discord account linked. You can head back to Discord."
+msgstr "Discord account linked. You can head back to Discord."
+
 #: src/lib/components/connections/ResticResultModal.svelte
 #~ msgid "Done"
 #~ msgstr "Done"
@@ -218,8 +222,25 @@ msgstr "Invite code"
 #~ msgid "Key label"
 #~ msgstr "Key label"
 
+#: src/routes/link/discord/+page.svelte
+msgid "Link account"
+msgstr "Link account"
+
+#: src/routes/link/discord/+page.svelte
+msgid "Link Discord"
+msgstr "Link Discord"
+
+#: src/routes/link/discord/+page.svelte
+msgid "Link Discord account @{0} to {1}?"
+msgstr "Link Discord account @{0} to {1}?"
+
+#: src/routes/link/discord/+page.svelte
+msgid "Log in to link your Discord account."
+msgstr "Log in to link your Discord account."
+
 #: src/routes/+page.svelte
 #: src/routes/+page.svelte
+#: src/routes/link/discord/+page.svelte
 msgid "Login"
 msgstr "Login"
 
@@ -308,6 +329,14 @@ msgstr "Logout"
 #: src/lib/components/connections/NewConnectionModal.svelte
 #~ msgid "This connection type can't be added from here — see the note above."
 #~ msgstr "This connection type can't be added from here — see the note above."
+
+#: src/routes/link/discord/+page.svelte
+msgid "This link is invalid or has expired. Click the support button in Discord to get a new one."
+msgstr "This link is invalid or has expired. Click the support button in Discord to get a new one."
+
+#: src/routes/link/discord/+page.svelte
+msgid "Unable to link your Discord account."
+msgstr "Unable to link your Discord account."
 
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "Write-once (WORM)"

--- a/packages/web/src/locales/ja.po
+++ b/packages/web/src/locales/ja.po
@@ -152,6 +152,10 @@ msgstr ""
 #~ msgid "Created {0} · expires {1}"
 #~ msgstr ""
 
+#: src/routes/link/discord/+page.svelte
+msgid "Discord account linked. You can head back to Discord."
+msgstr ""
+
 #: src/lib/components/connections/ResticResultModal.svelte
 #~ msgid "Done"
 #~ msgstr ""
@@ -218,8 +222,25 @@ msgstr ""
 #~ msgid "Key label"
 #~ msgstr ""
 
+#: src/routes/link/discord/+page.svelte
+msgid "Link account"
+msgstr ""
+
+#: src/routes/link/discord/+page.svelte
+msgid "Link Discord"
+msgstr ""
+
+#: src/routes/link/discord/+page.svelte
+msgid "Link Discord account @{0} to {1}?"
+msgstr ""
+
+#: src/routes/link/discord/+page.svelte
+msgid "Log in to link your Discord account."
+msgstr ""
+
 #: src/routes/+page.svelte
 #: src/routes/+page.svelte
+#: src/routes/link/discord/+page.svelte
 msgid "Login"
 msgstr ""
 
@@ -308,6 +329,14 @@ msgstr ""
 #: src/lib/components/connections/NewConnectionModal.svelte
 #~ msgid "This connection type can't be added from here — see the note above."
 #~ msgstr ""
+
+#: src/routes/link/discord/+page.svelte
+msgid "This link is invalid or has expired. Click the support button in Discord to get a new one."
+msgstr ""
+
+#: src/routes/link/discord/+page.svelte
+msgid "Unable to link your Discord account."
+msgstr ""
 
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "Write-once (WORM)"

--- a/packages/web/src/routes/link/discord/+page.svelte
+++ b/packages/web/src/routes/link/discord/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { handleError } from "$lib/utils/handle-error";
+  import {
+    confirmDiscordLinkRequest,
+    defaults,
+  } from "@futo-org/backups-api-client";
+  import { Alert, Button, Card, CardBody, Heading, VStack } from "@immich/ui";
+  import { t } from "svelte-i18n-lingui";
+
+  let { data } = $props();
+
+  let linked = $state(false);
+  let busy = $state(false);
+
+  const login = () => {
+    location.href =
+      defaults.baseUrl +
+      "api/auth/oidc/login?redirect=" +
+      encodeURIComponent("/link/discord?code=" + data.code);
+  };
+
+  const confirm = async () => {
+    busy = true;
+    try {
+      await confirmDiscordLinkRequest(data.code);
+      linked = true;
+    } catch (error) {
+      handleError(error, $t`Unable to link your Discord account.`);
+    } finally {
+      busy = false;
+    }
+  };
+</script>
+
+<svelte:head
+  ><title>{$t`Link Discord`} &middot; FUTO Backups</title></svelte:head
+>
+
+<main class="flex min-h-screen items-center justify-center p-4">
+  <VStack gap={6} class="w-full max-w-sm items-center">
+    <Card>
+      <CardBody>
+        <VStack>
+          <Heading>FUTO Backups</Heading>
+          {#if linked}
+            <Alert color="success"
+              >{$t`Discord account linked. You can head back to Discord.`}</Alert
+            >
+          {:else if !data.user}
+            <p>{$t`Log in to link your Discord account.`}</p>
+            <Button onclick={login}>{$t`Login`}</Button>
+          {:else if !data.request}
+            <Alert color="warning"
+              >{$t`This link is invalid or has expired. Click the support button in Discord to get a new one.`}</Alert
+            >
+          {:else}
+            <p>
+              {$t`Link Discord account @${data.request.discordUsername} to ${data.user.email}?`}
+            </p>
+            <Button onclick={confirm} disabled={busy}>{$t`Link account`}</Button
+            >
+          {/if}
+        </VStack>
+      </CardBody>
+    </Card>
+  </VStack>
+</main>

--- a/packages/web/src/routes/link/discord/+page.ts
+++ b/packages/web/src/routes/link/discord/+page.ts
@@ -1,0 +1,23 @@
+import type { PageLoad } from './$types';
+import {
+  getDiscordLinkRequest,
+  type DiscordLinkRequestResponseDto,
+} from '@futo-org/backups-api-client';
+
+export const load: PageLoad = async ({ parent, url, fetch }) => {
+  const { user } = await parent();
+  const code = url.searchParams.get('code') ?? '';
+
+  let request: DiscordLinkRequestResponseDto | null = null;
+  if (user && code) {
+    try {
+      request = await getDiscordLinkRequest(code, { fetch });
+    } catch (error) {
+      if ((error as { status?: number }).status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  return { code, request };
+};


### PR DESCRIPTION
Stacked on #<api>: the /link/discord confirmation page.

- `main` <!-- branch-stack -->
  - \#542
    - \#543 :point\_left:
      - \#544
        - \#545
