### PR TITLE
fix(netbird): grant CI tcp/443 to the cls1 networks

### DIFF
--- a/tf/deployment/prod/htz-fsn1/netbird/netbird.auto.tfvars
+++ b/tf/deployment/prod/htz-fsn1/netbird/netbird.auto.tfvars
@@ -103,6 +103,23 @@ policies = {
     }]
   }
 
+  # CI plans/applies the ceph TF stack: the radosgw provider refreshes RGW users
+  # against s3.<domain> (cls1_public VIPs). ceph_nets is split from `resources`,
+  # so ci-to-resources does not cover it; without this grant the refresh
+  # blackholes and every prod ceph plan hangs until cancelled. The route
+  # installs on the ephemeral CI peers only.
+  ci-to-ceph-nets = {
+    description = "CI -> cls1 networks, RGW S3 endpoint only."
+    rules = [{
+      name          = "ci-to-ceph-nets"
+      protocol      = "tcp"
+      bidirectional = false
+      sources       = ["ci"]
+      destinations  = ["ceph_nets"]
+      ports         = ["443"]
+    }]
+  }
+
   # Talos nodes → o11y's prod mesh gateway (external group, resolved in
   # netbird.tf): vmagent + victoria-logs-collector remote-write to the
   # UNAUTHENTICATED mesh vmauth (vmauth.o11y.futo.network:443) — this ACL is


### PR DESCRIPTION
CI runners can now reach the cls1 networks on tcp/443 over the overlay, via a ci-to-ceph-nets policy mirroring the SSH-only ci-to-ceph grant. The ceph TF stack's radosgw provider (#541) refreshes RGW users against s3.prod.fsn1.htz.futo.cloud, whose VIPs live in cls1\_public; ceph\_nets is deliberately split from resources, so ci-to-resources never covered it and every prod ceph plan since the merge has hung at refresh until cancelled (staging never hit this: sietch's S3 resolves publicly). The route installs on ephemeral CI peers only; ceph and talos nodes receive no new routes, so the fabric-path guarantee in netbird.tf is untouched.

- `main` <!-- branch-stack -->
  - \#547 :point\_left:
