### PR TITLE
feat(infra): force_apply dispatch input for prod/staging

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -124,6 +124,15 @@ on:
         description: 'Apply the fabric (switch) stack'
         type: boolean
         default: false
+      force_apply:
+        description: "Force-apply a partition's TF stacks without a code change (fabric/ceph/mgmt still need their own toggles)"
+        type: choice
+        options:
+          - none
+          - staging
+          - prod
+          - both
+        default: none
 
 # Serialize: the OVH S3 backend has no state locking (single-operator model),
 # so never let two infra runs apply concurrently. This workflow-wide concurrency
@@ -252,6 +261,7 @@ jobs:
           DISPATCH_CEPH: ${{ inputs.run_ceph_ansible }}
           DISPATCH_MGMT: ${{ inputs.run_mgmt_ansible }}
           DISPATCH_FABRIC: ${{ inputs.run_fabric }}
+          DISPATCH_FORCE: ${{ inputs.force_apply }}
           CEPH_CLUSTER: ${{ inputs.ceph_cluster }}
         run: |
           set -euo pipefail
@@ -276,6 +286,13 @@ jobs:
             fi
             [ "$DISPATCH_MGMT" = "true" ] && active[prod]=1
             [ "$DISPATCH_FABRIC" = "true" ] && active[prod]=1
+            # force_apply -> the named partition(s), full TF apply, no code change
+            # needed; the fabric/ceph/mgmt step-level gates still hold.
+            case "${DISPATCH_FORCE:-none}" in
+              staging) active[staging]=1 ;;
+              prod)    active[prod]=1 ;;
+              both)    active[staging]=1; active[prod]=1 ;;
+            esac
             if [ "${#active[@]}" -eq 0 ]; then
               active[staging]=1; active[prod]=1   # bare dispatch = plan-only preview
             fi
@@ -512,15 +529,16 @@ jobs:
     name: Apply ${{ matrix.partition }}@${{ matrix.region }}/${{ matrix.stack }} (gated)
     needs: [changes, discover, plan-staging]
     # Only on merge to main (or a SCOPED manual dispatch) -- never on PRs. A bare
-    # workflow_dispatch (no run_ceph_ansible / run_mgmt_ansible / run_fabric) is
-    # plan-only: the apply job is skipped so a manual "just look" run can never
-    # apply every emitted stack unreviewed.
+    # workflow_dispatch (no run_ceph_ansible / run_mgmt_ansible / run_fabric /
+    # force_apply) is plan-only: the apply job is skipped so a manual "just look"
+    # run can never apply every emitted stack unreviewed.
     if: >-
       needs.discover.outputs.has_staging == 'true'
       && (
         github.event_name == 'push'
         || (github.event_name == 'workflow_dispatch'
-            && (inputs.run_ceph_ansible || inputs.run_mgmt_ansible || inputs.run_fabric))
+            && (inputs.run_ceph_ansible || inputs.run_mgmt_ansible || inputs.run_fabric
+                || inputs.force_apply == 'staging' || inputs.force_apply == 'both'))
       )
     runs-on: ubuntu-latest
     # Ceiling for a worst-case entry (TF apply + up to 90-min ceph converge).
@@ -743,7 +761,8 @@ jobs:
       && (
         github.event_name == 'push'
         || (github.event_name == 'workflow_dispatch'
-            && (inputs.run_ceph_ansible || inputs.run_mgmt_ansible || inputs.run_fabric))
+            && (inputs.run_ceph_ansible || inputs.run_mgmt_ansible || inputs.run_fabric
+                || inputs.force_apply == 'prod' || inputs.force_apply == 'both'))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 120


### PR DESCRIPTION
Manual dispatch can force a partition's TF applies without a code change; fabric/ceph/mgmt Ansible keep their own toggles.

- `main` <!-- branch-stack -->
  - \#548 :point\_left:
