### PR TITLE
feat(infra): activate futo-backups-bot staging creds

### DIFF
--- a/tf/.env
+++ b/tf/.env
@@ -85,12 +85,11 @@ export TF_VAR_netbird_talos_setup_key="op://yucca_tf_staging/NETBIRD_YUCCA_STAGI
 
 # futo-backups-bot (Discord support, docs/discord-support.md). The internal-API
 # secret is TF-generated (secrets.tf); the transcripts keys are TF-minted by the
-# ceph stack (rgw-users.tf svc-yucca-transcripts) — uncomment after its first
-# apply. The token item comes from core-infra-tf's yucca-manual-secrets. Until
-# then the Secret lands with empty values and the bot idles.
-# export TF_VAR_yucca_discord_bot_token="op://yucca_tf_staging/YUCCA_DISCORD_BOT_TOKEN/password"
-# export TF_VAR_yucca_discord_guild_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/guild_id"
-# export TF_VAR_yucca_discord_staff_role_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/staff_role_id"
-# export TF_VAR_yucca_discord_support_channel_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/support_channel_id"
-# export TF_VAR_sietch_transcripts_access_key="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_ACCESS_KEY/password"
-# export TF_VAR_sietch_transcripts_secret_key="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_SECRET_KEY/password"
+# ceph stack (rgw-users.tf svc-yucca-transcripts); the token is the manual
+# YUCCA_DISCORD_BOT_TOKEN item; the ids come from core-infra-tf's discord apply.
+export TF_VAR_yucca_discord_bot_token="op://yucca_tf_staging/YUCCA_DISCORD_BOT_TOKEN/password"
+export TF_VAR_yucca_discord_guild_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/guild_id"
+export TF_VAR_yucca_discord_staff_role_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/staff_role_id"
+export TF_VAR_yucca_discord_support_channel_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/support_channel_id"
+export TF_VAR_sietch_transcripts_access_key="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_ACCESS_KEY/password"
+export TF_VAR_sietch_transcripts_secret_key="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_SECRET_KEY/password"


### PR DESCRIPTION
All the 1P items exist now; wiring them into the staging talos apply brings the bot live on the dev Immich server.

- `main` <!-- branch-stack -->
  - \#549 :point\_left:
