### PR TITLE
fix(futo-backups-bot): dedupe the support sticky and survive pin failures

### DIFF
--- a/packages/futo-backups-bot/src/repositories/discord.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/discord.repository.ts
@@ -55,15 +55,39 @@ export class DiscordRepository {
     ]);
   }
 
-  async ensurePinnedSupportMessage(message: MessageCreateOptions): Promise<void> {
+  async ensurePinnedSupportMessage(message: MessageCreateOptions, buttonId: string): Promise<void> {
     const channel = await this.supportChannel();
-    const pinned = await channel.messages.fetchPinned();
+    const [pinned, recent] = await Promise.all([
+      channel.messages.fetchPinned(),
+      channel.messages.fetch({ limit: 100 }),
+    ]);
     const botId = this.requireClient().user?.id;
-    if (pinned.some((pin) => pin.author.id === botId)) {
-      return;
+    const candidates = new Map([...pinned.entries(), ...recent.entries()]);
+    const stickies = [...candidates.values()]
+      .filter(
+        (candidate) =>
+          candidate.author.id === botId &&
+          candidate.components.some(
+            (row) =>
+              'components' in row &&
+              row.components.some((component) => 'customId' in component && component.customId === buttonId),
+          ),
+      )
+      .toSorted((a, b) => a.createdTimestamp - b.createdTimestamp);
+
+    const keep = stickies[0] ?? (await channel.send(message));
+    for (const extra of stickies.slice(1)) {
+      await extra
+        .delete()
+        .catch((error: unknown) => this.logger.warn(error, 'could not delete a duplicate support message'));
     }
-    const sent = await channel.send(message);
-    await sent.pin();
+    if (!keep.pinned) {
+      await keep
+        .pin()
+        .catch((error: unknown) =>
+          this.logger.warn(error, 'could not pin the support message — is Pin Messages granted?'),
+        );
+    }
   }
 
   async createTicketThread(name: string, discordUserId: string): Promise<ThreadChannel> {

--- a/packages/futo-backups-bot/src/services/support.service.ts
+++ b/packages/futo-backups-bot/src/services/support.service.ts
@@ -61,10 +61,13 @@ export class SupportService implements OnApplicationBootstrap {
     } catch (error) {
       this.logger.error(error, 'failed to register slash commands — is the applications.commands scope granted?');
     }
-    await this.discord.ensurePinnedSupportMessage({
-      content: 'Need help with FUTO Backups? Click below to open a private ticket with our staff.',
-      components: [this.buttonRow(ComponentId.OpenTicket, 'Get support')],
-    });
+    await this.discord.ensurePinnedSupportMessage(
+      {
+        content: 'Need help with FUTO Backups? Click below to open a private ticket with our staff.',
+        components: [this.buttonRow(ComponentId.OpenTicket, 'Get support')],
+      },
+      ComponentId.OpenTicket,
+    );
   }
 
   async handleInteraction(interaction: Interaction): Promise<void> {


### PR DESCRIPTION
Sticky detection keys on the button component (not pins), duplicates get deleted, and a failed pin logs instead of crash-looping.

- `main` <!-- branch-stack -->
  - \#551 :point\_left:
