### PR TITLE
feat(futo-backups-bot): wire transcript storage to the region RGW

### DIFF
--- a/kubernetes/apps/base/futo-backups-bot/helmrelease.yaml
+++ b/kubernetes/apps/base/futo-backups-bot/helmrelease.yaml
@@ -51,6 +51,23 @@ spec:
       - name: GRAFANA_USER_DASHBOARD_URL
         value: ${GRAFANA_USER_DASHBOARD_URL:=}
       - name: TRANSCRIPT_S3_ENDPOINT
-        value: ${TRANSCRIPT_S3_ENDPOINT:=}
+        value: ${S3_ENDPOINT:=}
       - name: TRANSCRIPT_S3_BUCKET
-        value: ${TRANSCRIPT_S3_BUCKET:=}
+        value: ${TRANSCRIPT_S3_BUCKET:=yucca-support-transcripts}
+      # The RGW serves a self-signed cert; trust exactly it instead of blanket
+      # NODE_TLS_REJECT_UNAUTHORIZED=0 (which would also disable TLS checks
+      # toward Discord). Node warns and continues if the file is absent.
+      - name: NODE_EXTRA_CA_CERTS
+        value: /etc/yucca/rgw-ca.crt
+    volumes:
+      - name: rgw-ca
+        secret:
+          secretName: futo-backups-bot
+          optional: true
+          items:
+            - key: TRANSCRIPT_S3_CA_CERT
+              path: rgw-ca.crt
+    volumeMounts:
+      - name: rgw-ca
+        mountPath: /etc/yucca
+        readOnly: true

--- a/tf/deployment/prod/htz-fsn1/talos/secrets.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/secrets.tf
@@ -255,6 +255,7 @@ resource "kubernetes_secret_v1" "futo_backups_bot" {
     DISCORD_SUPPORT_CHANNEL_ID      = var.yucca_discord_support_channel_id
     TRANSCRIPT_S3_ACCESS_KEY_ID     = var.spice_transcripts_access_key
     TRANSCRIPT_S3_SECRET_ACCESS_KEY = var.spice_transcripts_secret_key
+    TRANSCRIPT_S3_CA_CERT           = var.spice_rgw_tls_cert
   }
 }
 

--- a/tf/deployment/staging/austin/talos/secrets.tf
+++ b/tf/deployment/staging/austin/talos/secrets.tf
@@ -253,6 +253,7 @@ resource "kubernetes_secret_v1" "futo_backups_bot" {
     DISCORD_SUPPORT_CHANNEL_ID      = var.yucca_discord_support_channel_id
     TRANSCRIPT_S3_ACCESS_KEY_ID     = var.sietch_transcripts_access_key
     TRANSCRIPT_S3_SECRET_ACCESS_KEY = var.sietch_transcripts_secret_key
+    TRANSCRIPT_S3_CA_CERT           = var.sietch_rgw_tls_cert
   }
 }
 


### PR DESCRIPTION
Endpoint rides the generated S3\_ENDPOINT, bucket defaults to yucca-support-transcripts, and the RGW's self-signed cert is trusted via NODE\_EXTRA\_CA\_CERTS from the TF Secret.

- `main` <!-- branch-stack -->
  - \#555 :point\_left:
