### PR TITLE
fix(futo-backups-bot): pull staff into the staff-notes thread

### DIFF
--- a/packages/futo-backups-bot/src/services/support.service.ts
+++ b/packages/futo-backups-bot/src/services/support.service.ts
@@ -248,7 +248,10 @@ export class SupportService implements OnApplicationBootstrap {
           return null;
         })
       : null;
-    await this.discord.createStaffThread(`staff-${suffix}`, this.staffNote(link, summary));
+    await this.discord.createStaffThread(
+      `staff-${suffix}`,
+      `<@&${env.DISCORD_STAFF_ROLE_ID}>\n${this.staffNote(link, summary)}`,
+    );
 
     return thread;
   }


### PR DESCRIPTION
Leading role mention adds Yucca members to staff-notes so it shows in their sidebars; closed tickets remain under the thread browser's Archived tab by design.

- `main` <!-- branch-stack -->
  - \#558 :point\_left:
