### PR TITLE
feat(yucca-admin-api): manage discord links via admin-api and yuctl

### DIFF
--- a/packages/yucca-admin-api/openapi-specs.json
+++ b/packages/yucca-admin-api/openapi-specs.json
@@ -279,6 +279,67 @@
         ]
       }
     },
+    "/api/user/{id}/discord": {
+      "put": {
+        "operationId": "linkUserDiscord",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserDiscordLinkRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDiscordLinkDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "User"
+        ]
+      },
+      "delete": {
+        "operationId": "unlinkUserDiscord",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "User"
+        ]
+      }
+    },
     "/api/user/{userId}/session": {
       "get": {
         "operationId": "listUserSessions",
@@ -1120,11 +1181,38 @@
           "items"
         ]
       },
+      "UserDiscordLinkDto": {
+        "type": "object",
+        "properties": {
+          "discordUserId": {
+            "type": "string"
+          },
+          "discordUsername": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "discordUserId",
+          "discordUsername",
+          "createdAt"
+        ]
+      },
       "UserGetResponseDto": {
         "type": "object",
         "properties": {
           "user": {
             "$ref": "#/components/schemas/UserDto"
+          },
+          "discordLink": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserDiscordLinkDto"
+              }
+            ]
           }
         },
         "required": [
@@ -1148,6 +1236,20 @@
         },
         "required": [
           "user"
+        ]
+      },
+      "UserDiscordLinkRequestDto": {
+        "type": "object",
+        "properties": {
+          "discordUserId": {
+            "type": "string"
+          },
+          "discordUsername": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "discordUserId"
         ]
       },
       "SessionDto": {
@@ -1422,6 +1524,7 @@
             "type": "string",
             "enum": [
               "immich",
+              "standalone",
               "restic"
             ],
             "description": "Connection type for the owning connection; defaults to 'restic' (manual use)"

--- a/packages/yucca-admin-api/src/app.module.ts
+++ b/packages/yucca-admin-api/src/app.module.ts
@@ -16,6 +16,7 @@ import { env } from './env';
 import { AuthGuard } from './middleware/auth.guard';
 import { ConnectionRepository } from './repositories/connection.repository';
 import { DatabaseRepository } from './repositories/database.repository';
+import { DiscordLinkRepository } from './repositories/discordLink.repository';
 import { FeatureFlagRepository } from './repositories/featureFlag.repository';
 import { OidcRepository } from './repositories/oidc.repository';
 import { RepositoryRepository } from './repositories/repository.repository';
@@ -64,6 +65,7 @@ export const providers = [
   LoggerRepository,
   EmailRepository,
   DatabaseRepository,
+  DiscordLinkRepository,
   DatabaseService,
   OidcRepository,
   UserRepository,

--- a/packages/yucca-admin-api/src/controllers/user.controller.ts
+++ b/packages/yucca-admin-api/src/controllers/user.controller.ts
@@ -5,6 +5,8 @@ import { ConnectionListResponseDto } from 'src/dto/connection.dto';
 import { FeatureOverrideDto, FeatureOverrideSetRequestDto, UserFeaturesResponseDto } from 'src/dto/features.dto';
 import { SessionListResponseDto } from 'src/dto/session.dto';
 import {
+  UserDiscordLinkDto,
+  UserDiscordLinkRequestDto,
   UserGetResponseDto,
   UserListQueryDto,
   UserListResponseDto,
@@ -52,6 +54,20 @@ export class UserController {
   @HttpCode(HttpStatus.NO_CONTENT)
   deleteUser(@Param('id') id: string): Promise<void> {
     return this.user.delete(id);
+  }
+
+  @Put('/:id/discord')
+  @AuthRoute()
+  @ApiOkResponse({ type: UserDiscordLinkDto })
+  linkUserDiscord(@Param('id') id: string, @Body() dto: UserDiscordLinkRequestDto): Promise<UserDiscordLinkDto> {
+    return this.user.linkDiscord(id, dto);
+  }
+
+  @Delete('/:id/discord')
+  @AuthRoute()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  unlinkUserDiscord(@Param('id') id: string): Promise<void> {
+    return this.user.unlinkDiscord(id);
   }
 
   @Get('/:userId/session')

--- a/packages/yucca-admin-api/src/dto/user.dto.ts
+++ b/packages/yucca-admin-api/src/dto/user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
 import { CursorPaginationDto } from 'src/dto/pagination.dto';
 
 export class UserDto {
@@ -29,9 +29,36 @@ export class UserListResponseDto {
   nextCursor!: string | null;
 }
 
+export class UserDiscordLinkDto {
+  @ApiProperty()
+  discordUserId!: string;
+
+  @ApiProperty()
+  discordUsername!: string;
+
+  @ApiProperty({ type: 'string' })
+  createdAt!: Date;
+}
+
 export class UserGetResponseDto {
   @ApiProperty()
   user!: UserDto;
+
+  @ApiProperty({ type: UserDiscordLinkDto, required: false, nullable: true })
+  discordLink!: UserDiscordLinkDto | null;
+}
+
+export class UserDiscordLinkRequestDto {
+  @ApiProperty()
+  @IsString()
+  @MaxLength(64)
+  discordUserId!: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  discordUsername?: string;
 }
 
 export class UserUpdateRequestDto {

--- a/packages/yucca-admin-api/src/repositories/discordLink.repository.ts
+++ b/packages/yucca-admin-api/src/repositories/discordLink.repository.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { Kysely, sql } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { DB } from 'src/schema';
+
+@Injectable()
+export class DiscordLinkRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
+
+  getByUserId(userId: string) {
+    return this.db.selectFrom('discordLinks').selectAll().where('userId', '=', userId).executeTakeFirst();
+  }
+
+  link(userId: string, discordUserId: string, discordUsername: string) {
+    return this.db.transaction().execute(async (trx) => {
+      await sql`SELECT pg_advisory_xact_lock(least(hashtext(${userId}), hashtext(${discordUserId}))),
+                       pg_advisory_xact_lock(greatest(hashtext(${userId}), hashtext(${discordUserId})))`.execute(trx);
+      await trx
+        .deleteFrom('discordLinks')
+        .where((eb) => eb.or([eb('userId', '=', userId), eb('discordUserId', '=', discordUserId)]))
+        .execute();
+      return trx
+        .insertInto('discordLinks')
+        .values({ userId, discordUserId, discordUsername })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    });
+  }
+
+  unlink(userId: string): Promise<boolean> {
+    return this.db.transaction().execute(async (trx) => {
+      await sql`SELECT pg_advisory_xact_lock(hashtext(${userId}))`.execute(trx);
+      const removed = await trx
+        .deleteFrom('discordLinks')
+        .where('userId', '=', userId)
+        .returning('id')
+        .executeTakeFirst();
+      return removed !== undefined;
+    });
+  }
+}

--- a/packages/yucca-admin-api/src/services/user.service.spec.ts
+++ b/packages/yucca-admin-api/src/services/user.service.spec.ts
@@ -1,0 +1,70 @@
+import { NotFoundException } from '@nestjs/common';
+import { UserService } from 'src/services/user.service';
+import { Mocks, newMocks } from '../../test/mocks';
+
+describe(UserService.name, () => {
+  let sut: UserService;
+  let mocks: Mocks;
+
+  const user = { id: 'user-1', sub: 'sub-1', name: 'Someone', email: 'someone@example.test', disabled: false };
+  const link = {
+    id: 'link-1',
+    userId: 'user-1',
+    discordUserId: '123456789',
+    discordUsername: 'someone',
+    createdAt: new Date('2026-08-26T00:00:00.000Z'),
+  };
+
+  beforeEach(() => {
+    mocks = newMocks();
+    sut = new UserService(mocks.user as never, mocks.session as never, mocks.discordLink as never);
+  });
+
+  describe('get', () => {
+    it('includes the discord link', async () => {
+      mocks.user.get.mockResolvedValue(user as never);
+      mocks.discordLink.getByUserId.mockResolvedValue(link);
+
+      await expect(sut.get('user-1')).resolves.toEqual({
+        user,
+        discordLink: { discordUserId: '123456789', discordUsername: 'someone', createdAt: link.createdAt },
+      });
+    });
+
+    it('returns a null link for unlinked users', async () => {
+      mocks.user.get.mockResolvedValue(user as never);
+      mocks.discordLink.getByUserId.mockResolvedValue(void 0);
+
+      await expect(sut.get('user-1')).resolves.toEqual({ user, discordLink: null });
+    });
+  });
+
+  describe('linkDiscord', () => {
+    it('links after verifying the user exists', async () => {
+      mocks.user.get.mockResolvedValue(user as never);
+      mocks.discordLink.link.mockResolvedValue(link);
+
+      await expect(sut.linkDiscord('user-1', { discordUserId: '123456789' })).resolves.toEqual({
+        discordUserId: '123456789',
+        discordUsername: 'someone',
+        createdAt: link.createdAt,
+      });
+
+      expect(mocks.discordLink.link).toHaveBeenCalledWith('user-1', '123456789', '');
+    });
+  });
+
+  describe('unlinkDiscord', () => {
+    it('rejects when no link exists', async () => {
+      mocks.discordLink.unlink.mockResolvedValue(false);
+
+      await expect(sut.unlinkDiscord('user-1')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('removes an existing link', async () => {
+      mocks.discordLink.unlink.mockResolvedValue(true);
+
+      await expect(sut.unlinkDiscord('user-1')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/yucca-admin-api/src/services/user.service.ts
+++ b/packages/yucca-admin-api/src/services/user.service.ts
@@ -1,11 +1,14 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import {
+  UserDiscordLinkDto,
+  UserDiscordLinkRequestDto,
   UserGetResponseDto,
   UserListQueryDto,
   UserListResponseDto,
   UserUpdateRequestDto,
   UserUpdateResponseDto,
 } from 'src/dto/user.dto';
+import { DiscordLinkRepository } from 'src/repositories/discordLink.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
 import { UserRepository } from 'src/repositories/user.repository';
 import { resolveLimit } from 'src/utils/pagination';
@@ -15,6 +18,7 @@ export class UserService {
   constructor(
     private readonly users: UserRepository,
     private readonly sessions: SessionRepository,
+    private readonly discordLinks: DiscordLinkRepository,
   ) {}
 
   list(query: UserListQueryDto): Promise<UserListResponseDto> {
@@ -22,7 +26,20 @@ export class UserService {
   }
 
   async get(id: string): Promise<UserGetResponseDto> {
-    return { user: await this.users.get(id) };
+    const [user, link] = await Promise.all([this.users.get(id), this.discordLinks.getByUserId(id)]);
+    return { user, discordLink: link ? toDiscordLinkDto(link) : null };
+  }
+
+  async linkDiscord(id: string, dto: UserDiscordLinkRequestDto): Promise<UserDiscordLinkDto> {
+    await this.users.get(id);
+    const link = await this.discordLinks.link(id, dto.discordUserId, dto.discordUsername ?? '');
+    return toDiscordLinkDto(link);
+  }
+
+  async unlinkDiscord(id: string): Promise<void> {
+    if (!(await this.discordLinks.unlink(id))) {
+      throw new NotFoundException(`No discord link for user ${id}`);
+    }
   }
 
   async update(id: string, dto: UserUpdateRequestDto): Promise<UserUpdateResponseDto> {
@@ -40,3 +57,13 @@ export class UserService {
     await this.users.delete(id);
   }
 }
+
+const toDiscordLinkDto = (link: {
+  discordUserId: string;
+  discordUsername: string;
+  createdAt: Date;
+}): UserDiscordLinkDto => ({
+  discordUserId: link.discordUserId,
+  discordUsername: link.discordUsername,
+  createdAt: link.createdAt,
+});

--- a/packages/yucca-admin-api/test/mocks.ts
+++ b/packages/yucca-admin-api/test/mocks.ts
@@ -1,7 +1,10 @@
 import type { EmailRepository } from '@common/server/email';
 import type { LoggerRepository, WideContextRepository } from '@common/server/otel';
 import type { DatabaseRepository } from 'src/repositories/database.repository';
+import type { DiscordLinkRepository } from 'src/repositories/discordLink.repository';
 import type { OidcRepository } from 'src/repositories/oidc.repository';
+import type { SessionRepository } from 'src/repositories/session.repository';
+import type { UserRepository } from 'src/repositories/user.repository';
 import type { UserAllowlistRepository } from 'src/repositories/userAllowlist.repository';
 
 export type RepositoryInterface<T extends object> = Pick<T, keyof T>;
@@ -40,6 +43,34 @@ export const newUserAllowlistRepositoryMock = (): jest.Mocked<RepositoryInterfac
   };
 };
 
+export const newDiscordLinkRepositoryMock = (): jest.Mocked<RepositoryInterface<DiscordLinkRepository>> => {
+  return {
+    getByUserId: jest.fn(),
+    link: jest.fn(),
+    unlink: jest.fn(),
+  };
+};
+
+export const newUserRepositoryMock = (): jest.Mocked<RepositoryInterface<UserRepository>> => {
+  return {
+    list: jest.fn(),
+    get: jest.fn(),
+    getBySub: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    hasRepositories: jest.fn(),
+  };
+};
+
+export const newSessionRepositoryMock = (): jest.Mocked<RepositoryInterface<SessionRepository>> => {
+  return {
+    delete: jest.fn(),
+    deleteByUser: jest.fn(),
+    getByUser: jest.fn(),
+  };
+};
+
 export const newLoggerRepositoryMock = (): jest.Mocked<RepositoryInterface<LoggerRepository>> => {
   return {
     debug: jest.fn(),
@@ -64,6 +95,9 @@ export const newMetricServiceMock = () => ({
 export const newMocks = () => {
   return {
     database: newDatabaseRepositoryMock(),
+    discordLink: newDiscordLinkRepositoryMock(),
+    user: newUserRepositoryMock(),
+    session: newSessionRepositoryMock(),
     oidc: newOidcRepositoryMock(),
     email: newEmailRepositoryMock(),
     allowlist: newUserAllowlistRepositoryMock(),

--- a/packages/yuctl/adminapi/users.go
+++ b/packages/yuctl/adminapi/users.go
@@ -159,3 +159,44 @@ func ParseLimit(s string) (int, error) {
 	}
 	return n, nil
 }
+
+// DiscordLink mirrors the admin-api UserDiscordLinkDto.
+type DiscordLink struct {
+	DiscordUserID   string `json:"discordUserId"`
+	DiscordUsername string `json:"discordUsername"`
+	CreatedAt       string `json:"createdAt"`
+}
+
+// UserDetail is the GET /api/user/:id envelope.
+type UserDetail struct {
+	User        User         `json:"user"`
+	DiscordLink *DiscordLink `json:"discordLink"`
+}
+
+// GetUser returns a user with everything the admin-api knows about them.
+func (c *Client) GetUser(ctx context.Context, userID string) (*UserDetail, error) {
+	var out UserDetail
+	if err := c.getJSON(ctx, "/api/user/"+url.PathEscape(userID), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// LinkDiscord binds a discord account to the user, replacing any existing link
+// on either side.
+func (c *Client) LinkDiscord(ctx context.Context, userID, discordID, discordUsername string) (*DiscordLink, error) {
+	body := map[string]string{"discordUserId": discordID}
+	if discordUsername != "" {
+		body["discordUsername"] = discordUsername
+	}
+	var out DiscordLink
+	if err := c.putJSON(ctx, "/api/user/"+url.PathEscape(userID)+"/discord", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UnlinkDiscord removes the user's discord link.
+func (c *Client) UnlinkDiscord(ctx context.Context, userID string) error {
+	return c.deleteReq(ctx, "/api/user/"+url.PathEscape(userID)+"/discord")
+}

--- a/packages/yuctl/cli/users/users.go
+++ b/packages/yuctl/cli/users/users.go
@@ -23,6 +23,9 @@ func New(f *cmdutil.Factory) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListCmd(f),
+		newGetCmd(f),
+		newLinkDiscordCmd(f),
+		newUnlinkDiscordCmd(f),
 		allowlist.New(f),
 		newViewDashboardCmd(f),
 		ufeatures.New(f),
@@ -119,6 +122,153 @@ func newViewDashboardCmd(f *cmdutil.Factory) *cobra.Command {
 	c.Flags().BoolVar(&noOpen, "no-open", false, "print the dashboard URL instead of opening the browser")
 	c.MarkFlagsOneRequired("id", "email")
 	c.MarkFlagsMutuallyExclusive("id", "email")
+	admin.Register(c)
+	return c
+}
+
+func registerUserSelector(c *cobra.Command, userID, email *string) {
+	c.Flags().StringVar(userID, "id", "", "user id (uuid)")
+	c.Flags().StringVar(email, "email", "", "user email; resolved to an id via the admin-api")
+	c.MarkFlagsOneRequired("id", "email")
+	c.MarkFlagsMutuallyExclusive("id", "email")
+}
+
+func resolveUser(cmd *cobra.Command, f *cmdutil.Factory, admin *cmdutil.AdminFlags, userID, email string) (*adminapi.Client, string, error) {
+	client, partition, err := admin.Client(cmd.Context(), f)
+	if err != nil {
+		return nil, "", err
+	}
+	if email == "" {
+		return client, userID, nil
+	}
+	id, err := client.ResolveUserID(cmd.Context(), email)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w in partition %s", err, partition)
+	}
+	return client, id, nil
+}
+
+func newGetCmd(f *cmdutil.Factory) *cobra.Command {
+	admin := &cmdutil.AdminFlags{}
+	var userID, email string
+	c := &cobra.Command{
+		Use:   "get",
+		Short: "Everything the admin-api knows about a user",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			client, id, err := resolveUser(cmd, f, admin, userID, email)
+			if err != nil {
+				return err
+			}
+			detail, err := client.GetUser(ctx, id)
+			if err != nil {
+				return err
+			}
+			connections, err := client.GetUserConnections(ctx, id)
+			if err != nil {
+				return err
+			}
+			features, err := client.GetUserFeatures(ctx, id)
+			if err != nil {
+				return err
+			}
+
+			w := tabwriter.NewWriter(f.IO.Out, 0, 2, 2, ' ', 0)
+			fmt.Fprintf(w, "ID\t%s\n", detail.User.ID)
+			fmt.Fprintf(w, "SUB\t%s\n", detail.User.Sub)
+			fmt.Fprintf(w, "NAME\t%s\n", detail.User.Name)
+			fmt.Fprintf(w, "EMAIL\t%s\n", detail.User.Email)
+			fmt.Fprintf(w, "DISABLED\t%t\n", detail.User.Disabled)
+			if detail.DiscordLink != nil {
+				fmt.Fprintf(w, "DISCORD\t%s (@%s), linked %s\n",
+					detail.DiscordLink.DiscordUserID, detail.DiscordLink.DiscordUsername, detail.DiscordLink.CreatedAt)
+			} else {
+				fmt.Fprintf(w, "DISCORD\tnot linked\n")
+			}
+			w.Flush()
+
+			fmt.Fprintln(f.IO.Out)
+			w = tabwriter.NewWriter(f.IO.Out, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(w, "CONNECTION\tTYPE\tNAME\tLAST SEEN")
+			for _, connection := range connections {
+				lastSeen := ""
+				if connection.LastSeenAt != nil {
+					lastSeen = *connection.LastSeenAt
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", connection.ID, connection.Type, connection.Name, lastSeen)
+			}
+			w.Flush()
+
+			if len(features.Overrides) > 0 {
+				fmt.Fprintln(f.IO.Out)
+				w = tabwriter.NewWriter(f.IO.Out, 0, 2, 2, ' ', 0)
+				fmt.Fprintln(w, "FEATURE OVERRIDE\tVALUE\tSET BY\tREASON")
+				for _, override := range features.Overrides {
+					reason := ""
+					if override.Reason != nil {
+						reason = *override.Reason
+					}
+					fmt.Fprintf(w, "%s\t%t\t%s\t%s\n", override.Flag, override.Value, override.SetBy, reason)
+				}
+				w.Flush()
+			}
+			return nil
+		},
+	}
+	registerUserSelector(c, &userID, &email)
+	admin.Register(c)
+	return c
+}
+
+func newLinkDiscordCmd(f *cmdutil.Factory) *cobra.Command {
+	admin := &cmdutil.AdminFlags{}
+	var userID, email, discordID, discordUsername string
+	c := &cobra.Command{
+		Use:   "link-discord",
+		Short: "Bind a discord account to a user (replaces any existing link on either side)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, id, err := resolveUser(cmd, f, admin, userID, email)
+			if err != nil {
+				return err
+			}
+			link, err := client.LinkDiscord(cmd.Context(), id, discordID, discordUsername)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(f.IO.Out, "linked user %s to discord %s (@%s)\n", id, link.DiscordUserID, link.DiscordUsername)
+			return nil
+		},
+	}
+	registerUserSelector(c, &userID, &email)
+	c.Flags().StringVar(&discordID, "discord-id", "", "discord user id (snowflake)")
+	c.Flags().StringVar(&discordUsername, "discord-username", "", "discord username (informational)")
+	_ = c.MarkFlagRequired("discord-id")
+	admin.Register(c)
+	return c
+}
+
+func newUnlinkDiscordCmd(f *cmdutil.Factory) *cobra.Command {
+	admin := &cmdutil.AdminFlags{}
+	var userID, email string
+	c := &cobra.Command{
+		Use:   "unlink-discord",
+		Short: "Remove a user's discord link",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, id, err := resolveUser(cmd, f, admin, userID, email)
+			if err != nil {
+				return err
+			}
+			if err := client.UnlinkDiscord(cmd.Context(), id); err != nil {
+				return err
+			}
+			fmt.Fprintf(f.IO.Out, "unlinked discord from user %s\n", id)
+			return nil
+		},
+	}
+	registerUserSelector(c, &userID, &email)
 	admin.Register(c)
 	return c
 }


### PR DESCRIPTION
GET /user/:id gains the discord link; PUT/DELETE /user/:id/discord manage it; yuctl grows users get / link-discord / unlink-discord.

- `main` <!-- branch-stack -->
  - \#562 :point\_left:
