### PR TITLE
feat(futo-backups-bot): sync the stored discord username from interactions

### DIFF
--- a/packages/futo-backups-bot/src/repositories/yuccaApi.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/yuccaApi.repository.ts
@@ -50,6 +50,15 @@ export class YuccaApiRepository {
     return linkSchema.parse(await response.json());
   }
 
+  async updateLinkUsername(discordUserId: string, discordUsername: string): Promise<void> {
+    await this.request(
+      'PATCH',
+      `/api/internal/discord/links/${encodeURIComponent(discordUserId)}`,
+      { discordUsername },
+      [404],
+    );
+  }
+
   async getUserSummary(userId: string): Promise<UserSummary> {
     const response = await this.request('GET', `/api/internal/discord/users/${encodeURIComponent(userId)}/summary`);
     return userSummarySchema.parse(await response.json());

--- a/packages/futo-backups-bot/src/services/support.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/support.service.spec.ts
@@ -113,6 +113,16 @@ describe(SupportService.name, () => {
 
       expect((interaction as { showModal: jest.Mock }).showModal).toHaveBeenCalled();
     });
+
+    it('backfills a stale stored username', async () => {
+      mocks.api.getLink.mockResolvedValue({ ...link, discordUsername: '' });
+      mocks.api.updateLinkUsername.mockResolvedValue(void 0);
+      const interaction = newButtonInteraction(ComponentId.OpenTicket);
+
+      await sut.handleInteraction(interaction);
+
+      expect(mocks.api.updateLinkUsername).toHaveBeenCalledWith('123456789', 'Someone');
+    });
   });
 
   describe('ticket modal', () => {
@@ -152,7 +162,7 @@ describe(SupportService.name, () => {
         expect.stringContaining('someone@example.test'),
       );
       expect(mocks.discord.createStaffThread).toHaveBeenCalledWith(
-        'staff-someone-6789',
+        expect.stringMatching(/^staff-someone-6789-/),
         expect.stringContaining('/d/yucca-per-user?var-user=user-1'),
       );
       expect((interaction as { deferReply: jest.Mock }).deferReply).toHaveBeenCalled();

--- a/packages/futo-backups-bot/src/services/support.service.ts
+++ b/packages/futo-backups-bot/src/services/support.service.ts
@@ -119,6 +119,7 @@ export class SupportService implements OnApplicationBootstrap {
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
       return this.startLinkFlow(interaction);
     }
+    this.syncUsername(link, interaction.user);
 
     await interaction.showModal(
       new ModalBuilder()
@@ -246,6 +247,9 @@ export class SupportService implements OnApplicationBootstrap {
       this.logger.error(error, 'failed to look up link for staff note');
       return null;
     });
+    if (link) {
+      this.syncUsername(link, user);
+    }
     const summary = link
       ? await this.api.getUserSummary(link.userId).catch((error: unknown) => {
           this.logger.error(error, 'failed to fetch user summary');
@@ -294,6 +298,15 @@ export class SupportService implements OnApplicationBootstrap {
     return Array.isArray(roles)
       ? roles.includes(env.DISCORD_STAFF_ROLE_ID)
       : roles.cache.has(env.DISCORD_STAFF_ROLE_ID);
+  }
+
+  private syncUsername(link: DiscordLink, user: User) {
+    if (!user.username || link.discordUsername === user.username) {
+      return;
+    }
+    void this.api
+      .updateLinkUsername(user.id, user.username)
+      .catch((error: unknown) => this.logger.warn(error, 'failed to sync discord username'));
   }
 
   private ticketSuffix(username: string, discordUserId: string): string {

--- a/packages/futo-backups-bot/test/mocks.ts
+++ b/packages/futo-backups-bot/test/mocks.ts
@@ -35,6 +35,7 @@ export const newYuccaApiRepositoryMock = (): jest.Mocked<RepositoryInterface<Yuc
   return {
     createLinkRequest: jest.fn(),
     getLink: jest.fn(),
+    updateLinkUsername: jest.fn().mockResolvedValue(void 0),
     getUserSummary: jest.fn(),
   };
 };

--- a/packages/yucca-api/src/controllers/discordInternal.controller.ts
+++ b/packages/yucca-api/src/controllers/discordInternal.controller.ts
@@ -1,9 +1,21 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import {
   DiscordLinkDto,
   DiscordLinkRequestCreateDto,
   DiscordLinkRequestCreatedDto,
+  DiscordLinkUsernameUpdateDto,
   DiscordUserSummaryDto,
 } from 'src/dto/discord.dto';
 import { InternalGuard } from 'src/middleware/internal.guard';
@@ -23,6 +35,15 @@ export class DiscordInternalController {
   @Get('/links/:discordUserId')
   getLink(@Param('discordUserId') discordUserId: string): Promise<DiscordLinkDto> {
     return this.discord.getLink(discordUserId);
+  }
+
+  @Patch('/links/:discordUserId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  updateLinkUsername(
+    @Param('discordUserId') discordUserId: string,
+    @Body() dto: DiscordLinkUsernameUpdateDto,
+  ): Promise<void> {
+    return this.discord.updateLinkUsername(discordUserId, dto);
   }
 
   @Get('/users/:userId/summary')

--- a/packages/yucca-api/src/dto/discord.dto.ts
+++ b/packages/yucca-api/src/dto/discord.dto.ts
@@ -16,6 +16,12 @@ export class DiscordLinkRequestCreateDto {
   discordUsername!: string;
 }
 
+export class DiscordLinkUsernameUpdateDto {
+  @IsString()
+  @MaxLength(120)
+  discordUsername!: string;
+}
+
 export class DiscordLinkRequestCreatedDto {
   code!: string;
   expiresAt!: Date;

--- a/packages/yucca-api/src/repositories/discord.repository.ts
+++ b/packages/yucca-api/src/repositories/discord.repository.ts
@@ -53,6 +53,16 @@ export class DiscordRepository {
     });
   }
 
+  async updateUsername(discordUserId: string, discordUsername: string): Promise<boolean> {
+    const updated = await this.db
+      .updateTable('discordLinks')
+      .set({ discordUsername })
+      .where('discordUserId', '=', discordUserId)
+      .returning('id')
+      .executeTakeFirst();
+    return updated !== undefined;
+  }
+
   getUserSummary(userId: string) {
     return this.db
       .selectFrom('users')

--- a/packages/yucca-api/src/services/discord.service.spec.ts
+++ b/packages/yucca-api/src/services/discord.service.spec.ts
@@ -91,6 +91,24 @@ describe(DiscordService.name, () => {
     });
   });
 
+  describe('updateLinkUsername', () => {
+    it('updates the stored username', async () => {
+      mocks.discord.updateUsername.mockResolvedValue(true);
+
+      await sut.updateLinkUsername('123456789', { discordUsername: 'renamed' });
+
+      expect(mocks.discord.updateUsername).toHaveBeenCalledWith('123456789', 'renamed');
+    });
+
+    it('rejects an unlinked discord user', async () => {
+      mocks.discord.updateUsername.mockResolvedValue(false);
+
+      await expect(sut.updateLinkUsername('123456789', { discordUsername: 'renamed' })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
   describe('getLink', () => {
     it('rejects an unlinked discord user', async () => {
       mocks.discord.getLinkByDiscordUserId.mockResolvedValue(void 0);

--- a/packages/yucca-api/src/services/discord.service.ts
+++ b/packages/yucca-api/src/services/discord.service.ts
@@ -6,6 +6,7 @@ import {
   DiscordLinkRequestCreateDto,
   DiscordLinkRequestCreatedDto,
   DiscordLinkRequestResponseDto,
+  DiscordLinkUsernameUpdateDto,
   DiscordUserSummaryDto,
 } from 'src/dto/discord.dto';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
@@ -58,6 +59,12 @@ export class DiscordService {
       throw new NotFoundException(`No link for Discord user ${discordUserId}`);
     }
     return link;
+  }
+
+  async updateLinkUsername(discordUserId: string, dto: DiscordLinkUsernameUpdateDto): Promise<void> {
+    if (!(await this.discord.updateUsername(discordUserId, dto.discordUsername))) {
+      throw new NotFoundException(`No link for Discord user ${discordUserId}`);
+    }
   }
 
   async getUserSummary(userId: string): Promise<DiscordUserSummaryDto> {

--- a/packages/yucca-api/test/mocks.ts
+++ b/packages/yucca-api/test/mocks.ts
@@ -34,6 +34,7 @@ export const newDiscordRepositoryMock = (): jest.Mocked<RepositoryInterface<Disc
     getLinkByDiscordUserId: jest.fn(),
     getLinkByUserId: jest.fn(),
     link: jest.fn(),
+    updateUsername: jest.fn(),
     getUserSummary: jest.fn(),
   };
 };


### PR DESCRIPTION
PATCH /internal/discord/links/:discordUserId updates the stored username; the bot fires it whenever a linked interaction shows a different (or missing) handle.

- `main` <!-- branch-stack -->
  - \#563 :point\_left:
