### PR TITLE
fix(futo-backups-bot): unbreak the staff-thread spec after the suffix change

### DIFF
--- a/packages/futo-backups-bot/src/services/support.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/support.service.spec.ts
@@ -152,7 +152,7 @@ describe(SupportService.name, () => {
         expect.stringContaining('someone@example.test'),
       );
       expect(mocks.discord.createStaffThread).toHaveBeenCalledWith(
-        'staff-someone-6789',
+        expect.stringMatching(/^staff-someone-6789-/),
         expect.stringContaining('/d/yucca-per-user?var-user=user-1'),
       );
       expect((interaction as { deferReply: jest.Mock }).deferReply).toHaveBeenCalled();


### PR DESCRIPTION
The grafana assertion from #560 pinned the pre-#561 thread name; main's unit tests fail without this.

- `main` <!-- branch-stack -->
  - \#565 :point\_left:
