### PR TITLE
feat(futo-backups-bot): /staff-notes links the paired staff thread

### DIFF
--- a/packages/futo-backups-bot/src/repositories/discord.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/discord.repository.ts
@@ -53,6 +53,10 @@ export class DiscordRepository {
           option.setName('user').setDescription('The user to open the ticket for').setRequired(true),
         )
         .toJSON(),
+      new SlashCommandBuilder()
+        .setName('staff-notes')
+        .setDescription("Link this ticket's staff-notes thread (staff only)")
+        .toJSON(),
     ]);
   }
 
@@ -137,7 +141,7 @@ export class DiscordRepository {
     return open;
   }
 
-  async findSupportThreadByName(name: string): Promise<AnyThreadChannel | undefined> {
+  async findSupportThreadByName(name: string, includeLocked = false): Promise<AnyThreadChannel | undefined> {
     const channel = await this.supportChannel();
     const active = await channel.threads.fetchActive();
     const match = [...active.threads.values()].find((thread) => thread.parentId === channel.id && thread.name === name);
@@ -145,7 +149,7 @@ export class DiscordRepository {
       return match;
     }
     const archived = await this.fetchAllArchivedThreads(channel, 'private');
-    return archived.find((thread) => thread.name === name && thread.locked !== true);
+    return archived.find((thread) => thread.name === name && (includeLocked || thread.locked !== true));
   }
 
   async closeThread(thread: AnyThreadChannel): Promise<void> {

--- a/packages/futo-backups-bot/src/services/support.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/support.service.spec.ts
@@ -152,7 +152,7 @@ describe(SupportService.name, () => {
         expect.stringContaining('someone@example.test'),
       );
       expect(mocks.discord.createStaffThread).toHaveBeenCalledWith(
-        'staff-someone-6789',
+        expect.stringMatching(/^staff-someone-6789-/),
         expect.stringContaining('/d/yucca-per-user?var-user=user-1'),
       );
       expect((interaction as { deferReply: jest.Mock }).deferReply).toHaveBeenCalled();
@@ -196,6 +196,38 @@ describe(SupportService.name, () => {
       );
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('thread-9') }),
+      );
+    });
+  });
+
+  describe('/staff-notes command', () => {
+    it('links the paired staff thread for staff inside a ticket', async () => {
+      const thread = asThread({ id: 'thread-1', name: 'ticket-someone-6789-x', parentId: 'support-channel' });
+      mocks.discord.findSupportThreadByName.mockResolvedValue(
+        asThread({ id: 'thread-2', name: 'staff-someone-6789-x' }),
+      );
+      const interaction = newCommandInteraction(
+        {},
+        { commandName: 'staff-notes', member: { roles: ['staff-role'] }, channel: thread },
+      );
+
+      await sut.handleInteraction(interaction);
+
+      expect(mocks.discord.findSupportThreadByName).toHaveBeenCalledWith('staff-someone-6789-x', true);
+      expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('thread-2') }),
+      );
+    });
+
+    it('rejects non-staff', async () => {
+      const thread = asThread({ id: 'thread-1', name: 'ticket-someone-6789-x', parentId: 'support-channel' });
+      const interaction = newCommandInteraction({}, { commandName: 'staff-notes', channel: thread });
+
+      await sut.handleInteraction(interaction);
+
+      expect(mocks.discord.findSupportThreadByName).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('staff') }),
       );
     });
   });

--- a/packages/futo-backups-bot/src/services/support.service.ts
+++ b/packages/futo-backups-bot/src/services/support.service.ts
@@ -89,6 +89,9 @@ export class SupportService implements OnApplicationBootstrap {
       if (interaction.isChatInputCommand() && interaction.commandName === 'ticket') {
         return await this.onStaffTicket(interaction);
       }
+      if (interaction.isChatInputCommand() && interaction.commandName === 'staff-notes') {
+        return await this.onStaffNotesRequested(interaction);
+      }
     } catch (error) {
       this.logger.error(error, 'failed to handle interaction');
       if (!interaction.isButton() && !interaction.isModalSubmit() && !interaction.isChatInputCommand()) {
@@ -258,6 +261,29 @@ export class SupportService implements OnApplicationBootstrap {
     );
 
     return thread;
+  }
+
+  private async onStaffNotesRequested(interaction: ChatInputCommandInteraction) {
+    if (!this.isStaff(interaction)) {
+      await interaction.reply({ content: 'Only staff can view staff notes.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const thread = interaction.channel;
+    if (
+      !(thread instanceof ThreadChannel) ||
+      thread.parentId !== env.DISCORD_SUPPORT_CHANNEL_ID ||
+      !thread.name.startsWith('ticket-')
+    ) {
+      await interaction.reply({ content: 'This channel is not a ticket.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const staffThread = await this.discord.findSupportThreadByName(thread.name.replace(/^ticket-/, 'staff-'), true);
+    await interaction.editReply({
+      content: staffThread ? `Staff notes: <#${staffThread.id}>` : 'No staff-notes thread found for this ticket.',
+    });
   }
 
   private async onCloseRequested(interaction: ButtonInteraction) {


### PR DESCRIPTION
Staff-only slash command inside a ticket thread; ephemeral reply with the sibling staff-notes mention (locked/archived included).

- `main` <!-- branch-stack -->
  - \#566 :point\_left:
