### PR TITLE
feat(yucca-api): discord closed-beta invite claims and nonced redemption

### DIFF
--- a/packages/yucca-admin-api/src/dto/allowlist.dto.ts
+++ b/packages/yucca-admin-api/src/dto/allowlist.dto.ts
@@ -6,8 +6,8 @@ export class AllowlistEntryDto {
   @ApiProperty()
   id!: string;
 
-  @ApiProperty()
-  email!: string;
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  email!: string | null;
 
   @ApiProperty()
   inviteCode!: string;

--- a/packages/yucca-admin-api/src/services/allowlist.service.ts
+++ b/packages/yucca-admin-api/src/services/allowlist.service.ts
@@ -77,7 +77,9 @@ export class AllowlistService {
   }
 
   private async sendInviteEmails(items: AllowlistEntryDto[]): Promise<AllowlistEntryDto[]> {
-    const pending = items.filter((entry) => !entry.inviteEmailSentAt);
+    const pending = items.filter(
+      (entry): entry is AllowlistEntryDto & { email: string } => Boolean(entry.email) && !entry.inviteEmailSentAt,
+    );
     if (pending.length === 0) {
       return items;
     }

--- a/packages/yucca-api-client/openapi-specs.json
+++ b/packages/yucca-api-client/openapi-specs.json
@@ -66,6 +66,15 @@
             }
           },
           {
+            "name": "discord_invite",
+            "required": false,
+            "in": "query",
+            "description": "Discord beta-invite token",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "invite_code",
             "required": false,
             "in": "query",
@@ -286,6 +295,36 @@
         },
         "tags": [
           "Connection"
+        ]
+      }
+    },
+    "/api/discord/invites/{code}": {
+      "get": {
+        "operationId": "getDiscordInvite",
+        "parameters": [
+          {
+            "name": "code",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscordInviteResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Discord"
         ]
       }
     },
@@ -961,6 +1000,17 @@
         },
         "required": [
           "repositoryIds"
+        ]
+      },
+      "DiscordInviteResponseDto": {
+        "type": "object",
+        "properties": {
+          "discordUsername": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "discordUsername"
         ]
       },
       "DiscordLinkRequestResponseDto": {

--- a/packages/yucca-api-client/src/fetch-client.ts
+++ b/packages/yucca-api-client/src/fetch-client.ts
@@ -87,6 +87,9 @@ export type ConnectionAdoptRequestDto = {
     /** Repositories to move from the default connection to this one */
     repositoryIds: string[];
 };
+export type DiscordInviteResponseDto = {
+    discordUsername: string;
+};
 export type DiscordLinkRequestResponseDto = {
     discordUsername: string;
 };
@@ -177,14 +180,16 @@ export function logout(opts?: Oazapfts.RequestOpts) {
         ...opts
     }));
 }
-export function oidcAuthorize(codeChallenge: string, state: string, { redirect, inviteCode }: {
+export function oidcAuthorize(codeChallenge: string, state: string, { redirect, discordInvite, inviteCode }: {
     redirect?: string;
+    discordInvite?: string;
     inviteCode?: string;
 } = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchText(`/api/auth/oidc/login${QS.query(QS.explode({
         code_challenge: codeChallenge,
         state,
         redirect,
+        discord_invite: discordInvite,
         invite_code: inviteCode
     }))}`, {
         ...opts
@@ -251,6 +256,14 @@ export function adoptRepositories(id: string, connectionAdoptRequestDto: Connect
         method: "POST",
         body: connectionAdoptRequestDto
     })));
+}
+export function getDiscordInvite(code: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: DiscordInviteResponseDto;
+    }>(`/api/discord/invites/${encodeURIComponent(code)}`, {
+        ...opts
+    }));
 }
 export function getDiscordLinkRequest(code: string, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{

--- a/packages/yucca-api/src/controllers/auth.controller.ts
+++ b/packages/yucca-api/src/controllers/auth.controller.ts
@@ -33,11 +33,13 @@ export class AuthController {
   @ApiQuery({ name: 'code_challenge', type: String })
   @ApiQuery({ name: 'state', type: String })
   @ApiQuery({ name: 'invite_code', type: String, required: false })
+  @ApiQuery({ name: 'discord_invite', type: String, required: false, description: 'Discord beta-invite token' })
   @ApiQuery({ name: 'redirect', type: String, required: false, description: 'In-app path to land on after login' })
   async oidcAuthorize(
     @Query('code_challenge') codeChallenge: string,
     @Query('state') state: string,
     @Query('invite_code') inviteCode: string | undefined,
+    @Query('discord_invite') discordInvite: string | undefined,
     @Query('redirect') redirect: string | undefined,
     @Res({ passthrough: true }) response: Response,
   ) {
@@ -48,6 +50,14 @@ export class AuthController {
 
     if (inviteCode) {
       response.cookie(CookieName.InviteCode, inviteCode, {
+        httpOnly: true,
+        sameSite: 'lax',
+        maxAge: Duration.fromObject({ minutes: 10 }).toMillis(),
+      });
+    }
+
+    if (discordInvite) {
+      response.cookie(CookieName.DiscordInvite, discordInvite, {
         httpOnly: true,
         sameSite: 'lax',
         maxAge: Duration.fromObject({ minutes: 10 }).toMillis(),
@@ -74,6 +84,7 @@ export class AuthController {
       response.clearCookie(CookieName.OidcState);
       response.clearCookie(CookieName.OidcCodeVerifier);
       response.clearCookie(CookieName.InviteCode);
+      response.clearCookie(CookieName.DiscordInvite);
       response.clearCookie(CookieName.RedirectPath);
 
       if (error instanceof EmailNotAllowedException) {
@@ -89,6 +100,7 @@ export class AuthController {
     response.clearCookie(CookieName.OidcState);
     response.clearCookie(CookieName.OidcCodeVerifier);
     response.clearCookie(CookieName.InviteCode);
+    response.clearCookie(CookieName.DiscordInvite);
     response.clearCookie(CookieName.RedirectPath);
 
     response.cookie(CookieName.AccessToken, accessToken, {

--- a/packages/yucca-api/src/controllers/discord.controller.ts
+++ b/packages/yucca-api/src/controllers/discord.controller.ts
@@ -1,13 +1,19 @@
 import { Controller, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
 import { ApiOkResponse } from '@nestjs/swagger';
 import { AuthDto } from 'src/dto/auth.dto';
-import { DiscordLinkRequestResponseDto } from 'src/dto/discord.dto';
+import { DiscordInviteResponseDto, DiscordLinkRequestResponseDto } from 'src/dto/discord.dto';
 import { Auth, AuthRoute } from 'src/middleware/auth.guard';
 import { DiscordService } from 'src/services/discord.service';
 
 @Controller('/discord')
 export class DiscordController {
   constructor(private readonly discord: DiscordService) {}
+
+  @Get('/invites/:code')
+  @ApiOkResponse({ type: DiscordInviteResponseDto })
+  getDiscordInvite(@Param('code') code: string): Promise<DiscordInviteResponseDto> {
+    return this.discord.getInvite(code);
+  }
 
   @Get('/link-requests/:code')
   @AuthRoute()

--- a/packages/yucca-api/src/controllers/discordInternal.controller.ts
+++ b/packages/yucca-api/src/controllers/discordInternal.controller.ts
@@ -12,6 +12,11 @@ import {
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import {
+  DiscordInviteBatchCreateDto,
+  DiscordInviteBatchDto,
+  DiscordInviteBatchMessageDto,
+  DiscordInviteCreateDto,
+  DiscordInviteCreatedDto,
   DiscordLinkDto,
   DiscordLinkRequestCreateDto,
   DiscordLinkRequestCreatedDto,
@@ -44,6 +49,25 @@ export class DiscordInternalController {
     @Body() dto: DiscordLinkUsernameUpdateDto,
   ): Promise<void> {
     return this.discord.updateLinkUsername(discordUserId, dto);
+  }
+
+  @Post('/invite-batches')
+  createInviteBatch(@Body() dto: DiscordInviteBatchCreateDto): Promise<DiscordInviteBatchDto> {
+    return this.discord.createInviteBatch(dto);
+  }
+
+  @Patch('/invite-batches/:batchId/message')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  setInviteBatchMessage(
+    @Param('batchId', ParseUUIDPipe) batchId: string,
+    @Body() dto: DiscordInviteBatchMessageDto,
+  ): Promise<void> {
+    return this.discord.setInviteBatchMessage(batchId, dto);
+  }
+
+  @Post('/invites')
+  createInvite(@Body() dto: DiscordInviteCreateDto): Promise<DiscordInviteCreatedDto> {
+    return this.discord.createInvite(dto);
   }
 
   @Get('/users/:userId/summary')

--- a/packages/yucca-api/src/dto/discord.dto.ts
+++ b/packages/yucca-api/src/dto/discord.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MaxLength } from 'class-validator';
+import { IsInt, IsOptional, IsString, IsUUID, Max, MaxLength, Min } from 'class-validator';
 
 export class DiscordLinkRequestResponseDto {
   @ApiProperty()
@@ -32,6 +32,62 @@ export class DiscordLinkDto {
   discordUserId!: string;
   discordUsername!: string;
   createdAt!: Date;
+}
+
+export class DiscordInviteBatchCreateDto {
+  @IsString()
+  @MaxLength(64)
+  guildId!: string;
+
+  @IsString()
+  @MaxLength(64)
+  channelId!: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  maxClaims!: number;
+
+  @IsString()
+  @MaxLength(64)
+  createdByDiscordUserId!: string;
+}
+
+export class DiscordInviteBatchMessageDto {
+  @IsString()
+  @MaxLength(64)
+  messageId!: string;
+}
+
+export class DiscordInviteBatchDto {
+  id!: string;
+  maxClaims!: number;
+  claimed!: number;
+}
+
+export class DiscordInviteCreateDto {
+  @IsString()
+  @MaxLength(64)
+  discordUserId!: string;
+
+  @IsString()
+  @MaxLength(120)
+  discordUsername!: string;
+
+  @IsOptional()
+  @IsUUID()
+  batchId?: string;
+}
+
+export class DiscordInviteCreatedDto {
+  code!: string;
+  expiresAt!: Date;
+  remaining!: number | null;
+}
+
+export class DiscordInviteResponseDto {
+  @ApiProperty()
+  discordUsername!: string;
 }
 
 export class DiscordUserSummaryDto {

--- a/packages/yucca-api/src/enum.ts
+++ b/packages/yucca-api/src/enum.ts
@@ -3,6 +3,7 @@ export enum CookieName {
   OidcState = 'yucca-oidc-state',
   OidcCodeVerifier = 'yucca-oidc-code-verifier',
   InviteCode = 'yucca-invite-code',
+  DiscordInvite = 'yucca-discord-invite',
   RedirectPath = 'yucca-redirect-path',
 }
 

--- a/packages/yucca-api/src/repositories/discord.repository.ts
+++ b/packages/yucca-api/src/repositories/discord.repository.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { Insertable, Kysely, sql } from 'kysely';
+import { Insertable, Kysely, Selectable, sql } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { DB } from 'src/schema';
+import { DiscordInviteBatchTable } from 'src/schema/tables/discordInviteBatch.table';
 import { DiscordLinkRequestTable } from 'src/schema/tables/discordLinkRequest.table';
+import { UserAllowlistTable } from 'src/schema/tables/userAllowlist.table';
+
+export type InviteClaimResult =
+  | { status: 'linked' | 'used' | 'unknownBatch' | 'exhausted' }
+  | { status: 'ok'; entry: Selectable<UserAllowlistTable>; remaining: number | null };
 
 @Injectable()
 export class DiscordRepository {
@@ -18,6 +24,16 @@ export class DiscordRepository {
 
   async deleteExpiredRequests() {
     await this.db.deleteFrom('discordLinkRequests').where('expiresAt', '<', new Date()).execute();
+  }
+
+  consumeInviteRequest(code: string) {
+    return this.db
+      .deleteFrom('discordLinkRequests')
+      .where('code', '=', code)
+      .where('allowlistId', 'is not', null)
+      .where('expiresAt', '>', new Date())
+      .returningAll()
+      .executeTakeFirst();
   }
 
   getLinkByDiscordUserId(discordUserId: string) {
@@ -53,6 +69,22 @@ export class DiscordRepository {
     });
   }
 
+  linkDirect(userId: string, discordUserId: string, discordUsername: string) {
+    return this.db.transaction().execute(async (trx) => {
+      await sql`SELECT pg_advisory_xact_lock(least(hashtext(${userId}), hashtext(${discordUserId}))),
+                       pg_advisory_xact_lock(greatest(hashtext(${userId}), hashtext(${discordUserId})))`.execute(trx);
+      await trx
+        .deleteFrom('discordLinks')
+        .where((eb) => eb.or([eb('userId', '=', userId), eb('discordUserId', '=', discordUserId)]))
+        .execute();
+      return trx
+        .insertInto('discordLinks')
+        .values({ userId, discordUserId, discordUsername })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    });
+  }
+
   async updateUsername(discordUserId: string, discordUsername: string): Promise<boolean> {
     const updated = await this.db
       .updateTable('discordLinks')
@@ -61,6 +93,74 @@ export class DiscordRepository {
       .returning('id')
       .executeTakeFirst();
     return updated !== undefined;
+  }
+
+  createBatch(batch: Insertable<DiscordInviteBatchTable>) {
+    return this.db.insertInto('discordInviteBatches').values(batch).returningAll().executeTakeFirstOrThrow();
+  }
+
+  async setBatchMessage(batchId: string, messageId: string): Promise<boolean> {
+    const updated = await this.db
+      .updateTable('discordInviteBatches')
+      .set({ messageId })
+      .where('id', '=', batchId)
+      .returning('id')
+      .executeTakeFirst();
+    return updated !== undefined;
+  }
+
+  claimInvite(discordUserId: string, batchId: string | null, inviteCode: string): Promise<InviteClaimResult> {
+    return this.db.transaction().execute(async (trx): Promise<InviteClaimResult> => {
+      const lockKey = batchId ?? discordUserId;
+      await sql`SELECT pg_advisory_xact_lock(least(hashtext(${discordUserId}), hashtext(${lockKey}))),
+                       pg_advisory_xact_lock(greatest(hashtext(${discordUserId}), hashtext(${lockKey})))`.execute(trx);
+
+      const link = await trx
+        .selectFrom('discordLinks')
+        .select('id')
+        .where('discordUserId', '=', discordUserId)
+        .executeTakeFirst();
+      if (link) {
+        return { status: 'linked' };
+      }
+
+      const existing = await trx
+        .selectFrom('userAllowlist')
+        .selectAll()
+        .where('discordUserId', '=', discordUserId)
+        .executeTakeFirst();
+      if (existing) {
+        return existing.inviteUsed ? { status: 'used' } : { status: 'ok', entry: existing, remaining: null };
+      }
+
+      let remaining: number | null = null;
+      if (batchId) {
+        const batch = await trx
+          .selectFrom('discordInviteBatches')
+          .selectAll()
+          .where('id', '=', batchId)
+          .executeTakeFirst();
+        if (!batch) {
+          return { status: 'unknownBatch' };
+        }
+        const { claimed } = await trx
+          .selectFrom('userAllowlist')
+          .select((eb) => eb.fn.countAll<number>().as('claimed'))
+          .where('batchId', '=', batchId)
+          .executeTakeFirstOrThrow();
+        if (Number(claimed) >= batch.maxClaims) {
+          return { status: 'exhausted' };
+        }
+        remaining = batch.maxClaims - Number(claimed) - 1;
+      }
+
+      const entry = await trx
+        .insertInto('userAllowlist')
+        .values({ inviteCode, invited: true, discordUserId, batchId })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      return { status: 'ok', entry, remaining };
+    });
   }
 
   getUserSummary(userId: string) {

--- a/packages/yucca-api/src/schema/index.ts
+++ b/packages/yucca-api/src/schema/index.ts
@@ -1,6 +1,7 @@
 import { Database } from '@immich/sql-tools';
 import { ConnectionTable } from './tables/connection.table';
 import { ConnectionMetricsTable } from './tables/connectionMetrics.table';
+import { DiscordInviteBatchTable } from './tables/discordInviteBatch.table';
 import { DiscordLinkTable } from './tables/discordLink.table';
 import { DiscordLinkRequestTable } from './tables/discordLinkRequest.table';
 import { RepositoryTable } from './tables/repository.table';
@@ -31,6 +32,7 @@ export class ImmichDatabase {
     UserFeatureFlagOverrideTable,
     DiscordLinkTable,
     DiscordLinkRequestTable,
+    DiscordInviteBatchTable,
   ];
 
   functions = [];
@@ -53,4 +55,5 @@ export interface DB {
   userFeatureFlagOverride: UserFeatureFlagOverrideTable;
   discordLinks: DiscordLinkTable;
   discordLinkRequests: DiscordLinkRequestTable;
+  discordInviteBatches: DiscordInviteBatchTable;
 }

--- a/packages/yucca-api/src/schema/migrations/20260826120000-AddDiscordInvites.ts
+++ b/packages/yucca-api/src/schema/migrations/20260826120000-AddDiscordInvites.ts
@@ -1,0 +1,41 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE TABLE "discordInviteBatches" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "guildId" character varying NOT NULL,
+  "channelId" character varying NOT NULL,
+  "messageId" character varying,
+  "maxClaims" integer NOT NULL,
+  "createdByDiscordUserId" character varying NOT NULL,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "discordInviteBatches_pkey" PRIMARY KEY ("id")
+);`.execute(db);
+
+  await sql`ALTER TABLE "userAllowlist" ALTER COLUMN "email" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" ADD "discordUserId" character varying;`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" ADD "batchId" uuid;`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" ADD CONSTRAINT "userAllowlist_discordUserId_uq" UNIQUE ("discordUserId");`.execute(
+    db,
+  );
+  await sql`ALTER TABLE "userAllowlist" ADD CONSTRAINT "userAllowlist_batchId_fkey" FOREIGN KEY ("batchId") REFERENCES "discordInviteBatches" ("id") ON UPDATE CASCADE ON DELETE SET NULL;`.execute(
+    db,
+  );
+
+  await sql`ALTER TABLE "discordLinkRequests" ADD "allowlistId" uuid;`.execute(db);
+  await sql`ALTER TABLE "discordLinkRequests" ADD CONSTRAINT "discordLinkRequests_allowlistId_fkey" FOREIGN KEY ("allowlistId") REFERENCES "userAllowlist" ("id") ON UPDATE CASCADE ON DELETE CASCADE;`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "discordLinkRequests" DROP CONSTRAINT "discordLinkRequests_allowlistId_fkey";`.execute(db);
+  await sql`ALTER TABLE "discordLinkRequests" DROP COLUMN "allowlistId";`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" DROP CONSTRAINT "userAllowlist_batchId_fkey";`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" DROP CONSTRAINT "userAllowlist_discordUserId_uq";`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" DROP COLUMN "batchId";`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" DROP COLUMN "discordUserId";`.execute(db);
+  await sql`DELETE FROM "userAllowlist" WHERE "email" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "userAllowlist" ALTER COLUMN "email" SET NOT NULL;`.execute(db);
+  await sql`DROP TABLE "discordInviteBatches";`.execute(db);
+}

--- a/packages/yucca-api/src/schema/tables/discordInviteBatch.table.ts
+++ b/packages/yucca-api/src/schema/tables/discordInviteBatch.table.ts
@@ -1,0 +1,25 @@
+import { Column, type Generated, Table } from '@immich/sql-tools';
+
+@Table({ name: 'discordInviteBatches' })
+export class DiscordInviteBatchTable {
+  @Column({ primary: true, type: 'uuid', default: () => 'gen_random_uuid()' })
+  id!: Generated<string>;
+
+  @Column()
+  guildId!: string;
+
+  @Column()
+  channelId!: string;
+
+  @Column({ nullable: true })
+  messageId!: string | null;
+
+  @Column({ type: 'integer' })
+  maxClaims!: number;
+
+  @Column()
+  createdByDiscordUserId!: string;
+
+  @Column({ type: 'timestamp with time zone', default: () => 'now()' })
+  createdAt!: Generated<Date>;
+}

--- a/packages/yucca-api/src/schema/tables/discordLinkRequest.table.ts
+++ b/packages/yucca-api/src/schema/tables/discordLinkRequest.table.ts
@@ -1,4 +1,5 @@
-import { Column, type Generated, Table } from '@immich/sql-tools';
+import { Column, ForeignKeyColumn, type Generated, Table } from '@immich/sql-tools';
+import { UserAllowlistTable } from './userAllowlist.table';
 
 @Table({ name: 'discordLinkRequests' })
 export class DiscordLinkRequestTable {
@@ -7,6 +8,14 @@ export class DiscordLinkRequestTable {
 
   @Column({ unique: true })
   code!: string;
+
+  @ForeignKeyColumn(() => UserAllowlistTable, {
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+    nullable: true,
+    index: false,
+  })
+  allowlistId!: string | null;
 
   @Column()
   discordUserId!: string;

--- a/packages/yucca-api/src/schema/tables/userAllowlist.table.ts
+++ b/packages/yucca-api/src/schema/tables/userAllowlist.table.ts
@@ -1,12 +1,13 @@
-import { Column, type Generated, Table } from '@immich/sql-tools';
+import { Column, ForeignKeyColumn, type Generated, Table } from '@immich/sql-tools';
+import { DiscordInviteBatchTable } from './discordInviteBatch.table';
 
 @Table({ name: 'userAllowlist' })
 export class UserAllowlistTable {
   @Column({ primary: true, type: 'uuid', default: () => 'gen_random_uuid()' })
   id!: Generated<string>;
 
-  @Column({ unique: true })
-  email!: string;
+  @Column({ unique: true, nullable: true })
+  email!: string | null;
 
   @Column({ unique: true })
   inviteCode!: string;
@@ -22,6 +23,17 @@ export class UserAllowlistTable {
 
   @Column({ type: 'timestamp with time zone', nullable: true })
   inviteEmailSentAt!: Date | null;
+
+  @Column({ unique: true, nullable: true })
+  discordUserId!: string | null;
+
+  @ForeignKeyColumn(() => DiscordInviteBatchTable, {
+    onUpdate: 'CASCADE',
+    onDelete: 'SET NULL',
+    nullable: true,
+    index: false,
+  })
+  batchId!: string | null;
 
   @Column({ type: 'timestamp with time zone', default: () => 'now()' })
   createdAt!: Generated<Date>;

--- a/packages/yucca-api/src/services/auth.service.spec.ts
+++ b/packages/yucca-api/src/services/auth.service.spec.ts
@@ -37,6 +37,7 @@ describe(AuthService.name, () => {
       mocks.session as never,
       mocks.wideContext,
       mocks.connection as never,
+      mocks.discord as never,
     );
     allowedEmailDomains = env.ALLOWED_EMAIL_DOMAINS;
     env.ALLOWED_EMAIL_DOMAINS = [];
@@ -465,6 +466,49 @@ describe(AuthService.name, () => {
 
       expect(mocks.userAllowlist.getByEmail).not.toHaveBeenCalled();
       expect(mocks.user.update).toHaveBeenCalledWith(mockUser.id, { name: claims.name, email: claims.email });
+    });
+
+    describe('discord invites', () => {
+      const inviteRequest = {
+        id: 'request-id',
+        code: 'token',
+        allowlistId: 'entry',
+        discordUserId: '123456789',
+        discordUsername: 'someone',
+        expiresAt: new Date(Date.now() + 60_000),
+        createdAt: new Date(),
+      };
+
+      it('should allow a new user with a valid discord invite, link the account, and mark the claim used', async () => {
+        mocks.discord.consumeInviteRequest.mockResolvedValue(inviteRequest);
+
+        await expect(sut.getOrCreateUser(claims, undefined, 'token')).resolves.toBe(mockUser);
+
+        expect(mocks.discord.consumeInviteRequest).toHaveBeenCalledWith('token');
+        expect(mocks.userAllowlist.getByEmail).not.toHaveBeenCalled();
+        expect(mocks.discord.linkDirect).toHaveBeenCalledWith(mockUser.id, '123456789', 'someone');
+        expect(mocks.userAllowlist.markUsed).toHaveBeenCalledWith('entry');
+      });
+
+      it('should consume the token before creating the user so a lost race falls back to the allowlist', async () => {
+        mocks.discord.consumeInviteRequest.mockResolvedValue(void 0);
+
+        await expect(sut.getOrCreateUser(claims, undefined, 'token')).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Email is not allowed during the beta"`,
+        );
+        expect(mocks.discord.linkDirect).not.toHaveBeenCalled();
+        expect(mocks.user.create).not.toHaveBeenCalled();
+      });
+
+      it('should link an existing user who redeems a discord invite', async () => {
+        mocks.user.getBySub.mockResolvedValue(mockUser);
+        mocks.discord.consumeInviteRequest.mockResolvedValue(inviteRequest);
+
+        await expect(sut.getOrCreateUser(claims, undefined, 'token')).resolves.toEqual(mockUser);
+
+        expect(mocks.discord.linkDirect).toHaveBeenCalledWith(mockUser.id, '123456789', 'someone');
+        expect(mocks.userAllowlist.markUsed).toHaveBeenCalledWith('entry');
+      });
     });
   });
 });

--- a/packages/yucca-api/src/services/auth.service.ts
+++ b/packages/yucca-api/src/services/auth.service.ts
@@ -12,6 +12,7 @@ import { CookieName } from 'src/enum';
 import { env } from 'src/env';
 import { ConnectionRepository } from 'src/repositories/connection.repository';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
+import { DiscordRepository } from 'src/repositories/discord.repository';
 import { OidcRepository } from 'src/repositories/oidc.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
 import { UserRepository } from 'src/repositories/user.repository';
@@ -30,6 +31,7 @@ export class AuthService {
     private readonly session: SessionRepository,
     private readonly wideContext: WideContextRepository,
     private readonly connection: ConnectionRepository,
+    private readonly discord: DiscordRepository,
   ) {}
 
   async authenticate(headers: IncomingHttpHeaders): Promise<AuthDto> {
@@ -85,6 +87,7 @@ export class AuthService {
       [CookieName.OidcState]: expectedState,
       [CookieName.OidcCodeVerifier]: codeVerifier,
       [CookieName.InviteCode]: inviteCode,
+      [CookieName.DiscordInvite]: discordInvite,
       [CookieName.RedirectPath]: redirectPath,
     } = cookies;
 
@@ -104,7 +107,7 @@ export class AuthService {
 
     this.wideContext.assignContext({ claims });
 
-    const user = await this.getOrCreateUser(claims, inviteCode);
+    const user = await this.getOrCreateUser(claims, inviteCode, discordInvite);
 
     this.wideContext.addContext('customerId', user.id);
 
@@ -122,7 +125,11 @@ export class AuthService {
     };
   }
 
-  async getOrCreateUser(claims: Pick<UserInfoResponse, 'sub' | 'name' | 'email'>, inviteCode?: string) {
+  async getOrCreateUser(
+    claims: Pick<UserInfoResponse, 'sub' | 'name' | 'email'>,
+    inviteCode?: string,
+    discordInvite?: string,
+  ) {
     if (typeof claims.name !== 'string') {
       throw new InternalServerErrorException('name is missing from claims');
     }
@@ -142,8 +149,16 @@ export class AuthService {
         name: claims.name,
         email: claims.email,
       });
-    } else {
-      await this.assertEmailAllowed(claims.email.toLowerCase(), inviteCode);
+    }
+
+    // Consumed before the user row exists: a concurrent redemption of the same
+    // single-use token loses here and falls through to the allowlist gate.
+    const invite = discordInvite ? await this.discord.consumeInviteRequest(discordInvite) : undefined;
+
+    if (!user) {
+      if (!invite) {
+        await this.assertEmailAllowed(claims.email.toLowerCase(), inviteCode);
+      }
 
       user = await this.user.create({
         sub: claims.sub,
@@ -152,6 +167,11 @@ export class AuthService {
       });
 
       await this.connection.getOrCreateDefault(user.id);
+    }
+
+    if (invite?.allowlistId) {
+      await this.discord.linkDirect(user.id, invite.discordUserId, invite.discordUsername);
+      await this.allowlist.markUsed(invite.allowlistId);
     }
 
     return user;

--- a/packages/yucca-api/src/services/discord.service.spec.ts
+++ b/packages/yucca-api/src/services/discord.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { AuthDto } from 'src/dto/auth.dto';
 import { DiscordService } from 'src/services/discord.service';
 import { Mocks, newMocks } from '../../test/mocks';
@@ -10,6 +10,7 @@ describe(DiscordService.name, () => {
   const request = {
     id: 'request-id',
     code: 'code',
+    allowlistId: null,
     discordUserId: '123456789',
     discordUsername: 'someone',
     expiresAt: new Date(Date.now() + 60_000),
@@ -114,6 +115,78 @@ describe(DiscordService.name, () => {
       mocks.discord.getLinkByDiscordUserId.mockResolvedValue(void 0);
 
       await expect(sut.getLink('123456789')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('createInvite', () => {
+    const entry = { id: 'entry' } as never;
+
+    it('mints a claim and a single-use token', async () => {
+      mocks.crypto.randomHex.mockReturnValueOnce('invite-code').mockReturnValueOnce('token');
+      mocks.discord.claimInvite.mockResolvedValue({ status: 'ok', entry, remaining: 2 });
+      mocks.discord.createRequest.mockResolvedValue({ ...request, code: 'token', allowlistId: 'entry' });
+
+      await expect(
+        sut.createInvite({ discordUserId: '123456789', discordUsername: 'someone', batchId: 'batch' }),
+      ).resolves.toEqual({ code: 'token', expiresAt: request.expiresAt, remaining: 2 });
+
+      expect(mocks.discord.claimInvite).toHaveBeenCalledWith('123456789', 'batch', 'invite-code');
+      expect(mocks.discord.createRequest).toHaveBeenCalledWith(expect.objectContaining({ allowlistId: 'entry' }));
+    });
+
+    it('re-issues a token for an existing unused claim without consuming a batch slot', async () => {
+      mocks.crypto.randomHex.mockReturnValueOnce('invite-code').mockReturnValueOnce('token');
+      mocks.discord.claimInvite.mockResolvedValue({ status: 'ok', entry, remaining: null });
+      mocks.discord.createRequest.mockResolvedValue({ ...request, code: 'token', allowlistId: 'entry' });
+
+      await expect(sut.createInvite({ discordUserId: '123456789', discordUsername: 'someone' })).resolves.toEqual(
+        expect.objectContaining({ remaining: null }),
+      );
+    });
+
+    it.each([
+      ['linked', 'ALREADY_LINKED'],
+      ['used', 'INVITE_USED'],
+      ['exhausted', 'BATCH_EXHAUSTED'],
+    ] as const)('rejects a %s claim with a conflict', async (status, message) => {
+      mocks.discord.claimInvite.mockResolvedValue({ status });
+
+      await expect(sut.createInvite({ discordUserId: '123456789', discordUsername: 'someone' })).rejects.toThrow(
+        new ConflictException(message),
+      );
+      expect(mocks.discord.createRequest).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown batch', async () => {
+      mocks.discord.claimInvite.mockResolvedValue({ status: 'unknownBatch' });
+
+      await expect(
+        sut.createInvite({ discordUserId: '123456789', discordUsername: 'someone', batchId: 'nope' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getInvite', () => {
+    it('returns the discord username for a valid invite token', async () => {
+      mocks.discord.getRequestByCode.mockResolvedValue({ ...request, allowlistId: 'entry' });
+
+      await expect(sut.getInvite('code')).resolves.toEqual({ discordUsername: 'someone' });
+    });
+
+    it('rejects a link-request token that is not an invite', async () => {
+      mocks.discord.getRequestByCode.mockResolvedValue({ ...request, allowlistId: null });
+
+      await expect(sut.getInvite('code')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('setInviteBatchMessage', () => {
+    it('rejects an unknown batch', async () => {
+      mocks.discord.setBatchMessage.mockResolvedValue(false);
+
+      await expect(sut.setInviteBatchMessage('nope', { messageId: 'message' })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
   });
 

--- a/packages/yucca-api/src/services/discord.service.ts
+++ b/packages/yucca-api/src/services/discord.service.ts
@@ -1,7 +1,13 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { Duration } from 'luxon';
 import { AuthDto } from 'src/dto/auth.dto';
 import {
+  DiscordInviteBatchCreateDto,
+  DiscordInviteBatchDto,
+  DiscordInviteBatchMessageDto,
+  DiscordInviteCreateDto,
+  DiscordInviteCreatedDto,
+  DiscordInviteResponseDto,
   DiscordLinkDto,
   DiscordLinkRequestCreateDto,
   DiscordLinkRequestCreatedDto,
@@ -65,6 +71,57 @@ export class DiscordService {
     if (!(await this.discord.updateUsername(discordUserId, dto.discordUsername))) {
       throw new NotFoundException(`No link for Discord user ${discordUserId}`);
     }
+  }
+
+  async createInviteBatch(dto: DiscordInviteBatchCreateDto): Promise<DiscordInviteBatchDto> {
+    const batch = await this.discord.createBatch({
+      guildId: dto.guildId,
+      channelId: dto.channelId,
+      maxClaims: dto.maxClaims,
+      createdByDiscordUserId: dto.createdByDiscordUserId,
+    });
+    return { id: batch.id, maxClaims: batch.maxClaims, claimed: 0 };
+  }
+
+  async setInviteBatchMessage(batchId: string, dto: DiscordInviteBatchMessageDto): Promise<void> {
+    if (!(await this.discord.setBatchMessage(batchId, dto.messageId))) {
+      throw new NotFoundException(`No invite batch with id ${batchId}`);
+    }
+  }
+
+  async createInvite(dto: DiscordInviteCreateDto): Promise<DiscordInviteCreatedDto> {
+    await this.discord.deleteExpiredRequests();
+    const claim = await this.discord.claimInvite(dto.discordUserId, dto.batchId ?? null, this.crypto.randomHex(16));
+    switch (claim.status) {
+      case 'linked': {
+        throw new ConflictException('ALREADY_LINKED');
+      }
+      case 'used': {
+        throw new ConflictException('INVITE_USED');
+      }
+      case 'exhausted': {
+        throw new ConflictException('BATCH_EXHAUSTED');
+      }
+      case 'unknownBatch': {
+        throw new NotFoundException(`No invite batch with id ${dto.batchId}`);
+      }
+    }
+    const request = await this.discord.createRequest({
+      code: this.crypto.randomHex(32),
+      discordUserId: dto.discordUserId,
+      discordUsername: dto.discordUsername,
+      allowlistId: claim.entry.id,
+      expiresAt: new Date(Date.now() + LINK_REQUEST_TTL.toMillis()),
+    });
+    return { code: request.code, expiresAt: request.expiresAt, remaining: claim.remaining };
+  }
+
+  async getInvite(code: string): Promise<DiscordInviteResponseDto> {
+    const request = await this.getValidRequest(code);
+    if (!request.allowlistId) {
+      throw new NotFoundException('Unknown or expired link code');
+    }
+    return { discordUsername: request.discordUsername };
   }
 
   async getUserSummary(userId: string): Promise<DiscordUserSummaryDto> {

--- a/packages/yucca-api/test/mocks.ts
+++ b/packages/yucca-api/test/mocks.ts
@@ -30,11 +30,16 @@ export const newDiscordRepositoryMock = (): jest.Mocked<RepositoryInterface<Disc
   return {
     createRequest: jest.fn(),
     getRequestByCode: jest.fn(),
+    consumeInviteRequest: jest.fn(),
     deleteExpiredRequests: jest.fn(),
     getLinkByDiscordUserId: jest.fn(),
     getLinkByUserId: jest.fn(),
     link: jest.fn(),
+    linkDirect: jest.fn(),
     updateUsername: jest.fn(),
+    createBatch: jest.fn(),
+    setBatchMessage: jest.fn(),
+    claimInvite: jest.fn(),
     getUserSummary: jest.fn(),
   };
 };


### PR DESCRIPTION
Mints email-less allowlist claims from Discord; redemption auto-links the claimer's account.

- `main` <!-- branch-stack -->
  - \#569 :point\_left:
    - \#570
      - \#571
