### PR TITLE
feat(web): discord beta-invite redemption on the invite page

### DIFF
--- a/packages/web/src/locales/en.po
+++ b/packages/web/src/locales/en.po
@@ -25,6 +25,10 @@ msgstr "{0} repositories"
 #~ msgid "{num, plural, one {# item} other {# items}}"
 #~ msgstr "{num, plural, one {# item} other {# items}}"
 
+#: src/routes/login/invite/+page.svelte
+msgid "@{0}, you're invited to the FUTO Backups beta. Sign in to join."
+msgstr "@{0}, you're invited to the FUTO Backups beta. Sign in to join."
+
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "1 year"
 #~ msgstr "1 year"
@@ -218,6 +222,10 @@ msgstr "Enter an invite code to continue."
 msgid "Invite code"
 msgstr "Invite code"
 
+#: src/routes/login/invite/+page.svelte
+msgid "Join the beta"
+msgstr "Join the beta"
+
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "Key label"
 #~ msgstr "Key label"
@@ -329,6 +337,10 @@ msgstr "Logout"
 #: src/lib/components/connections/NewConnectionModal.svelte
 #~ msgid "This connection type can't be added from here — see the note above."
 #~ msgstr "This connection type can't be added from here — see the note above."
+
+#: src/routes/login/invite/+page.svelte
+msgid "This invite link has expired. Go back to Discord and claim it again to get a fresh one."
+msgstr "This invite link has expired. Go back to Discord and claim it again to get a fresh one."
 
 #: src/routes/link/discord/+page.svelte
 msgid "This link is invalid or has expired. Click the support button in Discord to get a new one."

--- a/packages/web/src/locales/ja.po
+++ b/packages/web/src/locales/ja.po
@@ -25,6 +25,10 @@ msgstr ""
 #~ msgid "{num, plural, one {# item} other {# items}}"
 #~ msgstr "{num, plural, one {# hello} other {# hellos}}"
 
+#: src/routes/login/invite/+page.svelte
+msgid "@{0}, you're invited to the FUTO Backups beta. Sign in to join."
+msgstr ""
+
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "1 year"
 #~ msgstr ""
@@ -218,6 +222,10 @@ msgstr ""
 msgid "Invite code"
 msgstr ""
 
+#: src/routes/login/invite/+page.svelte
+msgid "Join the beta"
+msgstr ""
+
 #: src/lib/components/connections/CreateResticModal.svelte
 #~ msgid "Key label"
 #~ msgstr ""
@@ -329,6 +337,10 @@ msgstr ""
 #: src/lib/components/connections/NewConnectionModal.svelte
 #~ msgid "This connection type can't be added from here — see the note above."
 #~ msgstr ""
+
+#: src/routes/login/invite/+page.svelte
+msgid "This invite link has expired. Go back to Discord and claim it again to get a fresh one."
+msgstr ""
 
 #: src/routes/link/discord/+page.svelte
 msgid "This link is invalid or has expired. Click the support button in Discord to get a new one."

--- a/packages/web/src/routes/login/invite/+page.svelte
+++ b/packages/web/src/routes/login/invite/+page.svelte
@@ -12,6 +12,8 @@
   } from "@immich/ui";
   import { t } from "svelte-i18n-lingui";
 
+  let { data } = $props();
+
   let inviteCode = $state("");
 
   const notAllowed = page.url.searchParams.get("error") === "not_allowed";
@@ -26,6 +28,13 @@
       defaults.baseUrl +
       "api/auth/oidc/login?invite_code=" +
       encodeURIComponent(code);
+  };
+
+  const join = () => {
+    location.href =
+      defaults.baseUrl +
+      "api/auth/oidc/login?discord_invite=" +
+      encodeURIComponent(data.token);
   };
 </script>
 
@@ -43,17 +52,29 @@
               >{$t`Your email isn't part of the beta yet.`}</Alert
             >
           {/if}
-          <p>{$t`Enter an invite code to continue.`}</p>
-          <form onsubmit={submit}>
-            <VStack>
-              <Input
-                bind:value={inviteCode}
-                placeholder={$t`Invite code`}
-                aria-label={$t`Invite code`}
-              />
-              <Button type="submit">{$t`Continue`}</Button>
-            </VStack>
-          </form>
+          {#if data.invite}
+            <p>
+              {$t`@${data.invite.discordUsername}, you're invited to the FUTO Backups beta. Sign in to join.`}
+            </p>
+            <Button onclick={join}>{$t`Join the beta`}</Button>
+          {:else}
+            {#if data.token}
+              <Alert color="warning"
+                >{$t`This invite link has expired. Go back to Discord and claim it again to get a fresh one.`}</Alert
+              >
+            {/if}
+            <p>{$t`Enter an invite code to continue.`}</p>
+            <form onsubmit={submit}>
+              <VStack>
+                <Input
+                  bind:value={inviteCode}
+                  placeholder={$t`Invite code`}
+                  aria-label={$t`Invite code`}
+                />
+                <Button type="submit">{$t`Continue`}</Button>
+              </VStack>
+            </form>
+          {/if}
         </VStack>
       </CardBody>
     </Card>

--- a/packages/web/src/routes/login/invite/+page.ts
+++ b/packages/web/src/routes/login/invite/+page.ts
@@ -1,0 +1,22 @@
+import type { PageLoad } from './$types';
+import {
+  getDiscordInvite,
+  type DiscordInviteResponseDto,
+} from '@futo-org/backups-api-client';
+
+export const load: PageLoad = async ({ url, fetch }) => {
+  const token = url.searchParams.get('token') ?? '';
+
+  let invite: DiscordInviteResponseDto | null = null;
+  if (token) {
+    try {
+      invite = await getDiscordInvite(token, { fetch });
+    } catch (error) {
+      if ((error as { status?: number }).status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  return { token, invite };
+};


### PR DESCRIPTION
Adds the token flow to /login/invite.

- `main` <!-- branch-stack -->
  - \#569
    - \#570 :point\_left:
      - \#571
