### PR TITLE
fix(futo-backups-bot): mention the everyone role as a literal @everyone

### DIFF
--- a/packages/futo-backups-bot/src/services/invite.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/invite.service.spec.ts
@@ -150,6 +150,19 @@ describe(InviteService.name, () => {
       });
     });
 
+    it('mentions the everyone role as a literal @everyone', async () => {
+      mocks.api.createInviteBatch.mockResolvedValue('batch-1');
+      mocks.discord.sendMessage.mockResolvedValue({ id: 'message-1' } as never);
+      const interaction = newCommandInteraction({ channel: { id: 'c1' }, limit: 2, mention: { id: 'guild-1' } });
+
+      await sut.onInviteCommand(interaction);
+
+      expect(mocks.discord.sendMessage).toHaveBeenCalledWith(
+        'c1',
+        expect.objectContaining({ content: expect.stringMatching(/^@everyone We're opening 2 spots/) }),
+      );
+    });
+
     it('mentions the requested role in the channel post', async () => {
       mocks.api.createInviteBatch.mockResolvedValue('batch-1');
       mocks.discord.sendMessage.mockResolvedValue({ id: 'message-1' } as never);

--- a/packages/futo-backups-bot/src/services/invite.service.ts
+++ b/packages/futo-backups-bot/src/services/invite.service.ts
@@ -47,8 +47,18 @@ export class InviteService {
       interaction,
       channel!.id,
       interaction.options.getInteger('limit'),
-      interaction.options.getRole('mention')?.id ?? null,
+      this.roleMention(interaction),
     );
+  }
+
+  private roleMention(interaction: ChatInputCommandInteraction): string | null {
+    const role = interaction.options.getRole('mention');
+    if (!role) {
+      return null;
+    }
+    // The everyone role's id is the guild id; <@&guildId> renders as a broken
+    // "@@everyone" and pings nobody.
+    return role.id === interaction.guildId ? '@everyone' : `<@&${role.id}>`;
   }
 
   private async inviteUser(interaction: ChatInputCommandInteraction, target: User): Promise<void> {
@@ -78,7 +88,7 @@ export class InviteService {
     interaction: ChatInputCommandInteraction,
     channelId: string,
     limit: number | null,
-    mentionRoleId: string | null,
+    mention: string | null,
   ): Promise<void> {
     if (!limit) {
       await interaction.editReply({ content: 'Set a limit when posting invites to a channel.' });
@@ -92,7 +102,7 @@ export class InviteService {
       interaction.user.id,
     );
     const message = await this.discord.sendMessage(channelId, {
-      content: `${mentionRoleId ? `<@&${mentionRoleId}> ` : ''}We're opening ${limit} spot${limit === 1 ? '' : 's'} in the FUTO Backups closed beta — first come, first served.`,
+      content: `${mention ? `${mention} ` : ''}We're opening ${limit} spot${limit === 1 ? '' : 's'} in the FUTO Backups closed beta — first come, first served.`,
       components: [this.claimRow(batchId, 'Claim your invite')],
     });
     // The message id is audit-only (disabling edits interaction.message), so a


### PR DESCRIPTION
The everyone role's id is the guild id; <@\&guildId> renders as a broken @@everyone.

- `main` <!-- branch-stack -->
  - \#573 :point\_left:
