### PR TITLE
refactor(futo-backups-bot): centralize user-facing copy in messages.ts

### DIFF
--- a/packages/futo-backups-bot/src/messages.ts
+++ b/packages/futo-backups-bot/src/messages.ts
@@ -25,7 +25,7 @@ export const Messages = {
   staffOnlyClose: 'Only staff can close tickets.',
   staffNotesLink: (threadId: string) => `Staff notes: <#${threadId}>`,
   staffNotesMissing: 'No staff-notes thread found for this ticket.',
-  staffNoteHeader: 'Staff notes — not visible to the user.',
+  staffNoteHeader: 'Staff notes, not visible to the user.',
   staffNoteNoLink: 'No linked FUTO Backups account.',
 
   linkIntro: 'First, link your Discord account to your FUTO Backups account. The link is valid for 10 minutes.',
@@ -37,8 +37,8 @@ export const Messages = {
 
   claimNotAvailable: 'Role claiming is not available yet.',
   claimUnavailable: 'Role claiming is temporarily unavailable, please try again.',
-  roleClaimed: (chatMention: string) => `Role claimed — welcome!${chatMention}`,
-  linkedAndClaimed: (chatMention: string) => `Account linked and role claimed — welcome!${chatMention}`,
+  roleClaimed: (chatMention: string) => `Role claimed, welcome!${chatMention}`,
+  linkedAndClaimed: (chatMention: string) => `Account linked and role claimed, welcome!${chatMention}`,
   chatMention: (chatChannelId: string) => (chatChannelId ? ` Say hi in <#${chatChannelId}>.` : ''),
   claimPrompt: (chatChannelId: string) =>
     `FUTO Backups customer? Claim your role to unlock${chatChannelId ? ` <#${chatChannelId}>` : ' the customer chat'}.`,
@@ -52,15 +52,15 @@ export const Messages = {
   inviteSent: (userId: string) => `Invite sent to <@${userId}>.`,
   inviteDmsClosed: (userId: string, url: string) =>
     `<@${userId}> has DMs closed — pass this personal link along: ${url}`,
-  inviteAlreadyLinked: (userId: string) => `<@${userId}> already has a FUTO Backups account — no invite needed.`,
+  inviteAlreadyLinked: (userId: string) => `<@${userId}> already has a FUTO Backups account, no invite needed.`,
   inviteUsed: (userId: string) => `<@${userId}> already used their beta invite.`,
   inviteDrop: (limit: number, mention: string | null, creatorId: string) =>
-    `${mention ? `${mention}, ` : ''}<@${creatorId}> has opened up ${limit} spot${limit === 1 ? '' : 's'} in the FUTO Backups closed beta — first come, first served.`,
+    `${mention ? `${mention}, ` : ''}<@${creatorId}> has opened up ${limit} spot${limit === 1 ? '' : 's'} in the FUTO Backups closed beta, first come, first served.\nFUTO Backups is **FREE** while in the closed beta.`,
   inviteDropButton: 'Claim your invite',
   inviteDropClaimedButton: 'All invites claimed',
   inviteDropPosted: (limit: number, channelId: string) => `Posted ${limit} invites in <#${channelId}>.`,
-  claimSuccess: "You're in! This personal link is valid for 10 minutes — claim again if it expires.",
-  claimAlreadyLinked: 'You already have a FUTO Backups account — no invite needed.',
+  claimSuccess: "You're in! This personal link is valid for 10 minutes, claim again if it expires.",
+  claimAlreadyLinked: 'You already have a FUTO Backups account, no invite needed.',
   claimInviteUsed: 'You already used your beta invite.',
-  claimExhausted: 'All invites have been claimed — keep an eye out for the next drop.',
+  claimExhausted: 'All invites have been claimed, keep an eye out for the next drop.',
 };

--- a/packages/futo-backups-bot/src/messages.ts
+++ b/packages/futo-backups-bot/src/messages.ts
@@ -1,0 +1,66 @@
+export const Messages = {
+  somethingWentWrong: 'Something went wrong, please try again.',
+
+  supportSticky: 'Need help with FUTO Backups? Click below to open a private ticket with our staff.',
+  supportStickyButton: 'Get support',
+  supportUnavailable: 'Support is temporarily unavailable, please try again.',
+
+  ticketModalTitle: 'Get support',
+  ticketModalLabel: 'Describe your issue',
+  ticketEmbedTitle: 'Support ticket',
+  ticketOpenedByStaff: (staffId: string) => `Opened by staff (<@${staffId}>).`,
+  ticketReady: (threadId: string) => `Your ticket is ready: <#${threadId}>`,
+  ticketReadyStaff: (threadId: string) => `Ticket ready: <#${threadId}>`,
+  ticketAlreadyCreating: 'Your ticket is already being created.',
+  ticketAlreadyCreatingStaff: 'A ticket for that user is already being created.',
+  ticketLimit: (count: number, threadMentions: string) =>
+    `You already have ${count} open tickets: ${threadMentions}. Close one before opening another.`,
+  ticketLimitStaff: (userId: string, count: number, threadMentions: string) =>
+    `<@${userId}> already has ${count} open tickets: ${threadMentions}.`,
+  ticketClosedBy: (userId: string) => `Ticket closed by <@${userId}>.`,
+  closeTicketButton: 'Close ticket',
+  notATicket: 'This channel is not a ticket.',
+  staffOnlyTickets: 'Only staff can open tickets for users.',
+  staffOnlyNotes: 'Only staff can view staff notes.',
+  staffOnlyClose: 'Only staff can close tickets.',
+  staffNotesLink: (threadId: string) => `Staff notes: <#${threadId}>`,
+  staffNotesMissing: 'No staff-notes thread found for this ticket.',
+  staffNoteHeader: 'Staff notes — not visible to the user.',
+  staffNoteNoLink: 'No linked FUTO Backups account.',
+
+  linkIntro: 'First, link your Discord account to your FUTO Backups account. The link is valid for 10 minutes.',
+  linkButton: 'Link account',
+  linkedOpenTicket: 'Account linked! Now open your ticket.',
+  openTicketButton: 'Open ticket',
+  linkExpired: 'The link expired. Click the support button again to get a new one.',
+  linkGone: 'Your Discord account is no longer linked. Click the support button to link it again.',
+
+  claimNotAvailable: 'Role claiming is not available yet.',
+  claimUnavailable: 'Role claiming is temporarily unavailable, please try again.',
+  roleClaimed: (chatMention: string) => `Role claimed — welcome!${chatMention}`,
+  linkedAndClaimed: (chatMention: string) => `Account linked and role claimed — welcome!${chatMention}`,
+  chatMention: (chatChannelId: string) => (chatChannelId ? ` Say hi in <#${chatChannelId}>.` : ''),
+  claimPrompt: (chatChannelId: string) =>
+    `FUTO Backups customer? Claim your role to unlock${chatChannelId ? ` <#${chatChannelId}>` : ' the customer chat'}.`,
+  claimPromptButton: 'Claim your role',
+
+  inviteStaffOnly: 'Only staff can send beta invites.',
+  invitePickOne: 'Pick either a user to DM or a channel to post in.',
+  inviteLimitRequired: 'Set a limit when posting invites to a channel.',
+  inviteDm: "You're invited to the FUTO Backups closed beta! This personal link is valid for 10 minutes.",
+  inviteLinkButton: 'Join the beta',
+  inviteSent: (userId: string) => `Invite sent to <@${userId}>.`,
+  inviteDmsClosed: (userId: string, url: string) =>
+    `<@${userId}> has DMs closed — pass this personal link along: ${url}`,
+  inviteAlreadyLinked: (userId: string) => `<@${userId}> already has a FUTO Backups account — no invite needed.`,
+  inviteUsed: (userId: string) => `<@${userId}> already used their beta invite.`,
+  inviteDrop: (limit: number, mention: string | null, creatorId: string) =>
+    `${mention ? `${mention}, ` : ''}<@${creatorId}> has opened up ${limit} spot${limit === 1 ? '' : 's'} in the FUTO Backups closed beta — first come, first served.`,
+  inviteDropButton: 'Claim your invite',
+  inviteDropClaimedButton: 'All invites claimed',
+  inviteDropPosted: (limit: number, channelId: string) => `Posted ${limit} invites in <#${channelId}>.`,
+  claimSuccess: "You're in! This personal link is valid for 10 minutes — claim again if it expires.",
+  claimAlreadyLinked: 'You already have a FUTO Backups account — no invite needed.',
+  claimInviteUsed: 'You already used your beta invite.',
+  claimExhausted: 'All invites have been claimed — keep an eye out for the next drop.',
+};

--- a/packages/futo-backups-bot/src/services/invite.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/invite.service.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentId } from 'src/enum';
 import { env } from 'src/env';
+import { Messages } from 'src/messages';
 import { InviteService } from 'src/services/invite.service';
 import { Mocks, newMocks } from '../../test/mocks';
 
@@ -61,7 +62,7 @@ describe(InviteService.name, () => {
       await sut.onInviteCommand(interaction);
 
       expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: 'Only staff can send beta invites.' }),
+        expect.objectContaining({ content: Messages.inviteStaffOnly }),
       );
       expect(mocks.api.createInvite).not.toHaveBeenCalled();
     });
@@ -75,7 +76,7 @@ describe(InviteService.name, () => {
 
       for (const interaction of [both, neither]) {
         expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
-          expect.objectContaining({ content: 'Pick either a user to DM or a channel to post in.' }),
+          expect.objectContaining({ content: Messages.invitePickOne }),
         );
       }
       expect(mocks.api.createInvite).not.toHaveBeenCalled();
@@ -90,10 +91,10 @@ describe(InviteService.name, () => {
       expect(mocks.api.createInvite).toHaveBeenCalledWith('u1', 'target');
       expect(mocks.discord.sendDirectMessage).toHaveBeenCalledWith(
         'u1',
-        expect.objectContaining({ content: expect.stringContaining('closed beta') }),
+        expect.objectContaining({ content: Messages.inviteDm }),
       );
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: 'Invite sent to <@u1>.',
+        content: Messages.inviteSent('u1'),
       });
     });
 
@@ -117,7 +118,7 @@ describe(InviteService.name, () => {
 
       expect(mocks.discord.sendDirectMessage).not.toHaveBeenCalled();
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: '<@u1> already has a FUTO Backups account — no invite needed.',
+        content: Messages.inviteAlreadyLinked('u1'),
       });
     });
 
@@ -127,7 +128,7 @@ describe(InviteService.name, () => {
       await sut.onInviteCommand(interaction);
 
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: 'Set a limit when posting invites to a channel.',
+        content: Messages.inviteLimitRequired,
       });
       expect(mocks.api.createInviteBatch).not.toHaveBeenCalled();
     });
@@ -142,11 +143,11 @@ describe(InviteService.name, () => {
       expect(mocks.api.createInviteBatch).toHaveBeenCalledWith('guild-1', 'c1', 10, 'staff-1');
       expect(mocks.discord.sendMessage).toHaveBeenCalledWith(
         'c1',
-        expect.objectContaining({ content: expect.stringContaining('10 spots') }),
+        expect.objectContaining({ content: Messages.inviteDrop(10, null, 'staff-1') }),
       );
       expect(mocks.api.setInviteBatchMessage).toHaveBeenCalledWith('batch-1', 'message-1');
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: 'Posted 10 invites in <#c1>.',
+        content: Messages.inviteDropPosted(10, 'c1'),
       });
     });
 
@@ -159,7 +160,7 @@ describe(InviteService.name, () => {
 
       expect(mocks.discord.sendMessage).toHaveBeenCalledWith(
         'c1',
-        expect.objectContaining({ content: expect.stringMatching(/^@everyone We're opening 2 spots/) }),
+        expect.objectContaining({ content: Messages.inviteDrop(2, '@everyone', 'staff-1') }),
       );
     });
 
@@ -172,7 +173,7 @@ describe(InviteService.name, () => {
 
       expect(mocks.discord.sendMessage).toHaveBeenCalledWith(
         'c1',
-        expect.objectContaining({ content: expect.stringMatching(/^<@&role-1> We're opening 5 spots/) }),
+        expect.objectContaining({ content: Messages.inviteDrop(5, '<@&role-1>', 'staff-1') }),
       );
     });
   });
@@ -186,7 +187,7 @@ describe(InviteService.name, () => {
 
       expect(mocks.api.createInvite).toHaveBeenCalledWith('123456789', 'Someone', 'batch-1');
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining("You're in!") }),
+        expect.objectContaining({ content: Messages.claimSuccess }),
       );
       expect((interaction as { message: { edit: jest.Mock } }).message.edit).not.toHaveBeenCalled();
     });
@@ -208,7 +209,7 @@ describe(InviteService.name, () => {
 
       expect((interaction as { message: { edit: jest.Mock } }).message.edit).toHaveBeenCalled();
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: 'All invites have been claimed — keep an eye out for the next drop.',
+        content: Messages.claimExhausted,
       });
     });
 
@@ -219,7 +220,7 @@ describe(InviteService.name, () => {
       await sut.onClaimInvite(interaction);
 
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: 'You already have a FUTO Backups account — no invite needed.',
+        content: Messages.claimAlreadyLinked,
       });
     });
 
@@ -230,7 +231,7 @@ describe(InviteService.name, () => {
       await sut.onClaimInvite(interaction);
 
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith({
-        content: 'You already used your beta invite.',
+        content: Messages.claimInviteUsed,
       });
     });
   });

--- a/packages/futo-backups-bot/src/services/invite.service.ts
+++ b/packages/futo-backups-bot/src/services/invite.service.ts
@@ -11,6 +11,7 @@ import {
 } from 'discord.js';
 import { ComponentId } from 'src/enum';
 import { env } from 'src/env';
+import { Messages } from 'src/messages';
 import { DiscordRepository } from 'src/repositories/discord.repository';
 import { YuccaApiRepository } from 'src/repositories/yuccaApi.repository';
 import { isStaff } from 'src/utils/staff';
@@ -25,7 +26,7 @@ export class InviteService {
 
   async onInviteCommand(interaction: ChatInputCommandInteraction): Promise<void> {
     if (!isStaff(interaction)) {
-      await interaction.reply({ content: 'Only staff can send beta invites.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.inviteStaffOnly, flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -33,7 +34,7 @@ export class InviteService {
     const channel = interaction.options.getChannel('channel');
     if (Boolean(target) === Boolean(channel)) {
       await interaction.reply({
-        content: 'Pick either a user to DM or a channel to post in.',
+        content: Messages.invitePickOne,
         flags: MessageFlags.Ephemeral,
       });
       return;
@@ -65,22 +66,18 @@ export class InviteService {
     const result = await this.api.createInvite(target.id, target.username);
     if (result.status !== 'ok') {
       const content =
-        result.status === 'invite-used'
-          ? `<@${target.id}> already used their beta invite.`
-          : `<@${target.id}> already has a FUTO Backups account — no invite needed.`;
+        result.status === 'invite-used' ? Messages.inviteUsed(target.id) : Messages.inviteAlreadyLinked(target.id);
       await interaction.editReply({ content });
       return;
     }
 
     const url = this.inviteUrl(result.code);
     const delivered = await this.discord.sendDirectMessage(target.id, {
-      content: "You're invited to the FUTO Backups closed beta! This personal link is valid for 10 minutes.",
+      content: Messages.inviteDm,
       components: [this.linkRow(url)],
     });
     await interaction.editReply({
-      content: delivered
-        ? `Invite sent to <@${target.id}>.`
-        : `<@${target.id}> has DMs closed — pass this personal link along: ${url}`,
+      content: delivered ? Messages.inviteSent(target.id) : Messages.inviteDmsClosed(target.id, url),
     });
   }
 
@@ -91,7 +88,7 @@ export class InviteService {
     mention: string | null,
   ): Promise<void> {
     if (!limit) {
-      await interaction.editReply({ content: 'Set a limit when posting invites to a channel.' });
+      await interaction.editReply({ content: Messages.inviteLimitRequired });
       return;
     }
 
@@ -102,15 +99,15 @@ export class InviteService {
       interaction.user.id,
     );
     const message = await this.discord.sendMessage(channelId, {
-      content: `${mention ? `${mention} ` : ''}We're opening ${limit} spot${limit === 1 ? '' : 's'} in the FUTO Backups closed beta — first come, first served.`,
-      components: [this.claimRow(batchId, 'Claim your invite')],
+      content: Messages.inviteDrop(limit, mention, interaction.user.id),
+      components: [this.claimRow(batchId, Messages.inviteDropButton)],
     });
     // The message id is audit-only (disabling edits interaction.message), so a
     // failure here must not report a live drop as failed and invite a repost.
     await this.api
       .setInviteBatchMessage(batchId, message.id)
       .catch((error: unknown) => this.logger.warn(error, 'could not record the invite drop message id'));
-    await interaction.editReply({ content: `Posted ${limit} invites in <#${channelId}>.` });
+    await interaction.editReply({ content: Messages.inviteDropPosted(limit, channelId) });
   }
 
   async onClaimInvite(interaction: ButtonInteraction): Promise<void> {
@@ -120,24 +117,24 @@ export class InviteService {
     const result = await this.api.createInvite(interaction.user.id, interaction.user.username, batchId);
     switch (result.status) {
       case 'already-linked': {
-        await interaction.editReply({ content: 'You already have a FUTO Backups account — no invite needed.' });
+        await interaction.editReply({ content: Messages.claimAlreadyLinked });
         return;
       }
       case 'invite-used': {
-        await interaction.editReply({ content: 'You already used your beta invite.' });
+        await interaction.editReply({ content: Messages.claimInviteUsed });
         return;
       }
       case 'exhausted': {
         await this.disableClaimButton(interaction, batchId);
         await interaction.editReply({
-          content: 'All invites have been claimed — keep an eye out for the next drop.',
+          content: Messages.claimExhausted,
         });
         return;
       }
     }
 
     await interaction.editReply({
-      content: "You're in! This personal link is valid for 10 minutes — claim again if it expires.",
+      content: Messages.claimSuccess,
       components: [this.linkRow(this.inviteUrl(result.code))],
     });
     if (result.remaining === 0) {
@@ -147,7 +144,7 @@ export class InviteService {
 
   private async disableClaimButton(interaction: ButtonInteraction, batchId: string): Promise<void> {
     await interaction.message
-      .edit({ components: [this.claimRow(batchId, 'All invites claimed', true)] })
+      .edit({ components: [this.claimRow(batchId, Messages.inviteDropClaimedButton, true)] })
       .catch((error: unknown) => this.logger.warn(error, 'could not disable the claim button'));
   }
 
@@ -157,7 +154,7 @@ export class InviteService {
 
   private linkRow(url: string) {
     return new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder().setStyle(ButtonStyle.Link).setLabel('Join the beta').setURL(url),
+      new ButtonBuilder().setStyle(ButtonStyle.Link).setLabel(Messages.inviteLinkButton).setURL(url),
     );
   }
 

--- a/packages/futo-backups-bot/src/services/support.service.ts
+++ b/packages/futo-backups-bot/src/services/support.service.ts
@@ -20,6 +20,7 @@ import {
 } from 'discord.js';
 import { ComponentId } from 'src/enum';
 import { env } from 'src/env';
+import { Messages } from 'src/messages';
 import { DiscordRepository } from 'src/repositories/discord.repository';
 import { DiscordLink, UserSummary, YuccaApiRepository } from 'src/repositories/yuccaApi.repository';
 import { InviteService } from 'src/services/invite.service';
@@ -69,8 +70,8 @@ export class SupportService implements OnApplicationBootstrap {
     await this.discord.ensurePinnedMessage(
       env.DISCORD_SUPPORT_CHANNEL_ID,
       {
-        content: 'Need help with FUTO Backups? Click below to open a private ticket with our staff.',
-        components: [this.buttonRow(ComponentId.OpenTicket, 'Get support')],
+        content: Messages.supportSticky,
+        components: [this.buttonRow(ComponentId.OpenTicket, Messages.supportStickyButton)],
       },
       ComponentId.OpenTicket,
     );
@@ -115,7 +116,7 @@ export class SupportService implements OnApplicationBootstrap {
       if (!interaction.isButton() && !interaction.isModalSubmit() && !interaction.isChatInputCommand()) {
         return;
       }
-      const content = 'Something went wrong, please try again.';
+      const content = Messages.somethingWentWrong;
       if (interaction.deferred) {
         await interaction.editReply({ content }).catch(() => {});
       } else if (!interaction.replied) {
@@ -131,7 +132,7 @@ export class SupportService implements OnApplicationBootstrap {
     } catch (error) {
       this.logger.error(error, 'link lookup failed');
       await interaction.reply({
-        content: 'Support is temporarily unavailable, please try again.',
+        content: Messages.supportUnavailable,
         flags: MessageFlags.Ephemeral,
       });
       return;
@@ -145,12 +146,12 @@ export class SupportService implements OnApplicationBootstrap {
     await interaction.showModal(
       new ModalBuilder()
         .setCustomId(ComponentId.TicketModal)
-        .setTitle('Get support')
+        .setTitle(Messages.ticketModalTitle)
         .addComponents(
           new ActionRowBuilder<TextInputBuilder>().addComponents(
             new TextInputBuilder()
               .setCustomId(ComponentId.TicketDescription)
-              .setLabel('Describe your issue')
+              .setLabel(Messages.ticketModalLabel)
               .setStyle(TextInputStyle.Paragraph)
               .setRequired(true)
               .setMinLength(10)
@@ -162,7 +163,7 @@ export class SupportService implements OnApplicationBootstrap {
 
   private async onClaimRequested(interaction: ButtonInteraction | ChatInputCommandInteraction) {
     if (!env.DISCORD_CUSTOMER_ROLE_ID) {
-      await interaction.reply({ content: 'Role claiming is not available yet.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.claimNotAvailable, flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -172,7 +173,7 @@ export class SupportService implements OnApplicationBootstrap {
     } catch (error) {
       this.logger.error(error, 'link lookup failed');
       await interaction.reply({
-        content: 'Role claiming is temporarily unavailable, please try again.',
+        content: Messages.claimUnavailable,
         flags: MessageFlags.Ephemeral,
       });
       return;
@@ -182,12 +183,12 @@ export class SupportService implements OnApplicationBootstrap {
     if (!link) {
       return this.startLinkFlow(interaction, async () => {
         await this.discord.addRoleToMember(interaction.user.id, env.DISCORD_CUSTOMER_ROLE_ID);
-        return { content: `Account linked and role claimed — welcome!${this.chatMention()}` };
+        return { content: Messages.linkedAndClaimed(Messages.chatMention(env.DISCORD_CHAT_CHANNEL_ID)) };
       });
     }
 
     await this.discord.addRoleToMember(interaction.user.id, env.DISCORD_CUSTOMER_ROLE_ID);
-    await interaction.editReply({ content: `Role claimed — welcome!${this.chatMention()}` });
+    await interaction.editReply({ content: Messages.roleClaimed(Messages.chatMention(env.DISCORD_CHAT_CHANNEL_ID)) });
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_NOON)
@@ -220,8 +221,8 @@ export class SupportService implements OnApplicationBootstrap {
         .catch((error: unknown) => this.logger.warn(error, 'could not delete the previous claim prompt'));
     }
     await this.discord.sendMessage(env.DISCORD_GENERAL_CHANNEL_ID, {
-      content: `FUTO Backups customer? Claim your role to unlock${env.DISCORD_CHAT_CHANNEL_ID ? ` <#${env.DISCORD_CHAT_CHANNEL_ID}>` : ' the customer chat'}.`,
-      components: [this.buttonRow(ComponentId.ClaimRole, 'Claim your role')],
+      content: Messages.claimPrompt(env.DISCORD_CHAT_CHANNEL_ID),
+      components: [this.buttonRow(ComponentId.ClaimRole, Messages.claimPromptButton)],
     });
   }
 
@@ -237,10 +238,10 @@ export class SupportService implements OnApplicationBootstrap {
     const url = `${env.WEB_URL}/link/discord?code=${code}`;
 
     await interaction.editReply({
-      content: 'First, link your Discord account to your FUTO Backups account. The link is valid for 10 minutes.',
+      content: Messages.linkIntro,
       components: [
         new ActionRowBuilder<ButtonBuilder>().addComponents(
-          new ButtonBuilder().setStyle(ButtonStyle.Link).setLabel('Link account').setURL(url),
+          new ButtonBuilder().setStyle(ButtonStyle.Link).setLabel(Messages.linkButton).setURL(url),
         ),
       ],
     });
@@ -251,8 +252,8 @@ export class SupportService implements OnApplicationBootstrap {
         const success = onLinked
           ? await onLinked()
           : {
-              content: 'Account linked! Now open your ticket.',
-              components: [this.buttonRow(ComponentId.CreateTicket, 'Open ticket')],
+              content: Messages.linkedOpenTicket,
+              components: [this.buttonRow(ComponentId.CreateTicket, Messages.openTicketButton)],
             };
         await interaction.editReply({ components: [], ...success });
         return;
@@ -261,7 +262,7 @@ export class SupportService implements OnApplicationBootstrap {
     }
 
     await interaction.editReply({
-      content: 'The link expired. Click the support button again to get a new one.',
+      content: Messages.linkExpired,
       components: [],
     });
   }
@@ -272,13 +273,13 @@ export class SupportService implements OnApplicationBootstrap {
     const link = await this.api.getLink(interaction.user.id);
     if (!link) {
       await interaction.editReply({
-        content: 'Your Discord account is no longer linked. Click the support button to link it again.',
+        content: Messages.linkGone,
       });
       return;
     }
 
     if (this.creating.has(interaction.user.id)) {
-      await interaction.editReply({ content: 'Your ticket is already being created.' });
+      await interaction.editReply({ content: Messages.ticketAlreadyCreating });
       return;
     }
     this.creating.add(interaction.user.id);
@@ -286,14 +287,14 @@ export class SupportService implements OnApplicationBootstrap {
       const open = await this.discord.listOpenTicketThreads(interaction.user.id);
       if (open.length >= env.TICKET_USER_LIMIT) {
         await interaction.editReply({
-          content: `You already have ${open.length} open tickets: ${open.map((thread) => `<#${thread.id}>`).join(' ')}. Close one before opening another.`,
+          content: Messages.ticketLimit(open.length, open.map((thread) => `<#${thread.id}>`).join(' ')),
         });
         return;
       }
 
       const description = interaction.fields.getTextInputValue(ComponentId.TicketDescription);
       const thread = await this.openTicket(interaction.user, description);
-      await interaction.editReply({ content: `Your ticket is ready: <#${thread.id}>` });
+      await interaction.editReply({ content: Messages.ticketReady(thread.id) });
     } finally {
       this.creating.delete(interaction.user.id);
     }
@@ -301,7 +302,7 @@ export class SupportService implements OnApplicationBootstrap {
 
   private async onStaffTicket(interaction: ChatInputCommandInteraction) {
     if (!isStaff(interaction)) {
-      await interaction.reply({ content: 'Only staff can open tickets for users.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.staffOnlyTickets, flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -309,7 +310,7 @@ export class SupportService implements OnApplicationBootstrap {
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     if (this.creating.has(target.id)) {
-      await interaction.editReply({ content: 'A ticket for that user is already being created.' });
+      await interaction.editReply({ content: Messages.ticketAlreadyCreatingStaff });
       return;
     }
     this.creating.add(target.id);
@@ -317,13 +318,13 @@ export class SupportService implements OnApplicationBootstrap {
       const open = await this.discord.listOpenTicketThreads(target.id);
       if (open.length >= env.TICKET_USER_LIMIT) {
         await interaction.editReply({
-          content: `<@${target.id}> already has ${open.length} open tickets: ${open.map((thread) => `<#${thread.id}>`).join(' ')}.`,
+          content: Messages.ticketLimitStaff(target.id, open.length, open.map((thread) => `<#${thread.id}>`).join(' ')),
         });
         return;
       }
 
-      const thread = await this.openTicket(target, `Opened by staff (<@${interaction.user.id}>).`);
-      await interaction.editReply({ content: `Ticket ready: <#${thread.id}>` });
+      const thread = await this.openTicket(target, Messages.ticketOpenedByStaff(interaction.user.id));
+      await interaction.editReply({ content: Messages.ticketReadyStaff(thread.id) });
     } finally {
       this.creating.delete(target.id);
     }
@@ -335,8 +336,8 @@ export class SupportService implements OnApplicationBootstrap {
 
     await thread.send({
       content: `<@${user.id}> <@&${env.DISCORD_STAFF_ROLE_ID}>`,
-      embeds: [new EmbedBuilder().setTitle('Support ticket').setDescription(description)],
-      components: [this.buttonRow(ComponentId.CloseTicket, 'Close ticket', ButtonStyle.Danger)],
+      embeds: [new EmbedBuilder().setTitle(Messages.ticketEmbedTitle).setDescription(description)],
+      components: [this.buttonRow(ComponentId.CloseTicket, Messages.closeTicketButton, ButtonStyle.Danger)],
     });
 
     const link = await this.api.getLink(user.id).catch((error: unknown) => {
@@ -362,7 +363,7 @@ export class SupportService implements OnApplicationBootstrap {
 
   private async onStaffNotesRequested(interaction: ChatInputCommandInteraction) {
     if (!isStaff(interaction)) {
-      await interaction.reply({ content: 'Only staff can view staff notes.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.staffOnlyNotes, flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -372,20 +373,20 @@ export class SupportService implements OnApplicationBootstrap {
       thread.parentId !== env.DISCORD_SUPPORT_CHANNEL_ID ||
       !thread.name.startsWith('ticket-')
     ) {
-      await interaction.reply({ content: 'This channel is not a ticket.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.notATicket, flags: MessageFlags.Ephemeral });
       return;
     }
 
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
     const staffThread = await this.discord.findSupportThreadByName(thread.name.replace(/^ticket-/, 'staff-'), true);
     await interaction.editReply({
-      content: staffThread ? `Staff notes: <#${staffThread.id}>` : 'No staff-notes thread found for this ticket.',
+      content: staffThread ? Messages.staffNotesLink(staffThread.id) : Messages.staffNotesMissing,
     });
   }
 
   private async onCloseRequested(interaction: ButtonInteraction) {
     if (!isStaff(interaction)) {
-      await interaction.reply({ content: 'Only staff can close tickets.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.staffOnlyClose, flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -395,12 +396,12 @@ export class SupportService implements OnApplicationBootstrap {
       thread.parentId !== env.DISCORD_SUPPORT_CHANNEL_ID ||
       !thread.name.startsWith('ticket-')
     ) {
-      await interaction.reply({ content: 'This channel is not a ticket.', flags: MessageFlags.Ephemeral });
+      await interaction.reply({ content: Messages.notATicket, flags: MessageFlags.Ephemeral });
       return;
     }
 
     await interaction.deferReply();
-    await interaction.editReply({ content: `Ticket closed by <@${interaction.user.id}>.` });
+    await interaction.editReply({ content: Messages.ticketClosedBy(interaction.user.id) });
 
     const staffThread = await this.discord.findSupportThreadByName(thread.name.replace(/^ticket-/, 'staff-'));
     if (staffThread) {
@@ -423,9 +424,9 @@ export class SupportService implements OnApplicationBootstrap {
   }
 
   private staffNote(link: DiscordLink | null, summary: UserSummary | null): string {
-    const lines = ['Staff notes — not visible to the user.'];
+    const lines = [Messages.staffNoteHeader];
     if (!link) {
-      lines.push('No linked FUTO Backups account.');
+      lines.push(Messages.staffNoteNoLink);
       return lines.join('\n');
     }
     const grafanaBase = env.GRAFANA_URL.replace(/\/+$/, '');


### PR DESCRIPTION
All bot copy now lives in one file for easy editing.

- `main` <!-- branch-stack -->
  - \#574 :point\_left:
