### PR TITLE
feat(yucca-api): discord ticket to freshdesk mapping table and internal endpoints

### DIFF
--- a/packages/yucca-api/src/controllers/discordInternal.controller.ts
+++ b/packages/yucca-api/src/controllers/discordInternal.controller.ts
@@ -21,6 +21,10 @@ import {
   DiscordLinkRequestCreateDto,
   DiscordLinkRequestCreatedDto,
   DiscordLinkUsernameUpdateDto,
+  DiscordTicketCreateDto,
+  DiscordTicketDto,
+  DiscordTicketListDto,
+  DiscordTicketUpdateDto,
   DiscordUserSummaryDto,
 } from 'src/dto/discord.dto';
 import { InternalGuard } from 'src/middleware/internal.guard';
@@ -73,5 +77,31 @@ export class DiscordInternalController {
   @Get('/users/:userId/summary')
   getUserSummary(@Param('userId', ParseUUIDPipe) userId: string): Promise<DiscordUserSummaryDto> {
     return this.discord.getUserSummary(userId);
+  }
+
+  @Post('/tickets')
+  createTicket(@Body() dto: DiscordTicketCreateDto): Promise<DiscordTicketDto> {
+    return this.discord.createTicket(dto);
+  }
+
+  @Get('/tickets/open')
+  listOpenTickets(): Promise<DiscordTicketListDto> {
+    return this.discord.listOpenTickets();
+  }
+
+  @Get('/tickets/by-thread/:threadId')
+  getTicketByThread(@Param('threadId') threadId: string): Promise<DiscordTicketDto> {
+    return this.discord.getTicketByThread(threadId);
+  }
+
+  @Get('/tickets/by-freshdesk/:freshdeskTicketId')
+  getTicketByFreshdeskId(@Param('freshdeskTicketId') freshdeskTicketId: string): Promise<DiscordTicketDto> {
+    return this.discord.getTicketByFreshdeskId(freshdeskTicketId);
+  }
+
+  @Patch('/tickets/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  updateTicket(@Param('id', ParseUUIDPipe) id: string, @Body() dto: DiscordTicketUpdateDto): Promise<void> {
+    return this.discord.updateTicket(id, dto);
   }
 }

--- a/packages/yucca-api/src/dto/discord.dto.ts
+++ b/packages/yucca-api/src/dto/discord.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsOptional, IsString, IsUUID, Max, MaxLength, Min } from 'class-validator';
+import { IsBoolean, IsInt, IsOptional, IsString, IsUUID, Max, MaxLength, Min } from 'class-validator';
 
 export class DiscordLinkRequestResponseDto {
   @ApiProperty()
@@ -88,6 +88,83 @@ export class DiscordInviteCreatedDto {
 export class DiscordInviteResponseDto {
   @ApiProperty()
   discordUsername!: string;
+}
+
+export class DiscordTicketCreateDto {
+  @IsString()
+  @MaxLength(64)
+  threadId!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  staffThreadId?: string;
+
+  @IsString()
+  @MaxLength(64)
+  freshdeskTicketId!: string;
+
+  @IsString()
+  @MaxLength(64)
+  discordUserId!: string;
+
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  lastMirroredMessageId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  lastStaffMirroredMessageId?: string;
+}
+
+export class DiscordTicketUpdateDto {
+  @IsOptional()
+  @IsBoolean()
+  emailSubscribed?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  lastMirroredMessageId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  lastStaffMirroredMessageId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  lastFreshdeskConversationId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  closed?: boolean;
+}
+
+export class DiscordTicketDto {
+  id!: string;
+  threadId!: string;
+  staffThreadId!: string | null;
+  freshdeskTicketId!: string;
+  discordUserId!: string;
+  userId!: string | null;
+  emailSubscribed!: boolean;
+  lastMirroredMessageId!: string | null;
+  lastStaffMirroredMessageId!: string | null;
+  lastFreshdeskConversationId!: string | null;
+  closedAt!: Date | null;
+  createdAt!: Date;
+}
+
+export class DiscordTicketListDto {
+  items!: DiscordTicketDto[];
 }
 
 export class DiscordUserSummaryDto {

--- a/packages/yucca-api/src/repositories/discord.repository.ts
+++ b/packages/yucca-api/src/repositories/discord.repository.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { Insertable, Kysely, Selectable, sql } from 'kysely';
+import { Insertable, Kysely, Selectable, Updateable, sql } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { DB } from 'src/schema';
 import { DiscordInviteBatchTable } from 'src/schema/tables/discordInviteBatch.table';
 import { DiscordLinkRequestTable } from 'src/schema/tables/discordLinkRequest.table';
+import { DiscordTicketTable } from 'src/schema/tables/discordTicket.table';
 import { UserAllowlistTable } from 'src/schema/tables/userAllowlist.table';
 
 export type InviteClaimResult =
@@ -169,6 +170,56 @@ export class DiscordRepository {
         .executeTakeFirstOrThrow();
       return { status: 'ok', entry, remaining };
     });
+  }
+
+  createTicket(ticket: Insertable<DiscordTicketTable>) {
+    return this.db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto('discordTickets')
+        .values(ticket)
+        .onConflict((oc) => oc.column('threadId').doNothing())
+        .execute();
+      return trx
+        .selectFrom('discordTickets')
+        .selectAll()
+        .where('threadId', '=', ticket.threadId)
+        .executeTakeFirstOrThrow();
+    });
+  }
+
+  getTicketByThread(threadId: string) {
+    return this.db
+      .selectFrom('discordTickets')
+      .selectAll()
+      .where((eb) => eb.or([eb('threadId', '=', threadId), eb('staffThreadId', '=', threadId)]))
+      .executeTakeFirst();
+  }
+
+  getTicketByFreshdeskId(freshdeskTicketId: string) {
+    return this.db
+      .selectFrom('discordTickets')
+      .selectAll()
+      .where('freshdeskTicketId', '=', freshdeskTicketId)
+      .executeTakeFirst();
+  }
+
+  listOpenTickets() {
+    return this.db
+      .selectFrom('discordTickets')
+      .selectAll()
+      .where('closedAt', 'is', null)
+      .orderBy('createdAt', 'asc')
+      .execute();
+  }
+
+  async updateTicket(id: string, updates: Updateable<DiscordTicketTable>): Promise<boolean> {
+    const updated = await this.db
+      .updateTable('discordTickets')
+      .set(updates)
+      .where('id', '=', sql<string>`${id}::uuid`)
+      .returning('id')
+      .executeTakeFirst();
+    return updated !== undefined;
   }
 
   getUserSummary(userId: string) {

--- a/packages/yucca-api/src/schema/index.ts
+++ b/packages/yucca-api/src/schema/index.ts
@@ -4,6 +4,7 @@ import { ConnectionMetricsTable } from './tables/connectionMetrics.table';
 import { DiscordInviteBatchTable } from './tables/discordInviteBatch.table';
 import { DiscordLinkTable } from './tables/discordLink.table';
 import { DiscordLinkRequestTable } from './tables/discordLinkRequest.table';
+import { DiscordTicketTable } from './tables/discordTicket.table';
 import { RepositoryTable } from './tables/repository.table';
 import { RepositoryMeterTable } from './tables/repositoryMeter.table';
 import { RepositoryMeterHistoryTable } from './tables/repositoryMeterHistory.table';
@@ -33,6 +34,7 @@ export class ImmichDatabase {
     DiscordLinkTable,
     DiscordLinkRequestTable,
     DiscordInviteBatchTable,
+    DiscordTicketTable,
   ];
 
   functions = [];
@@ -56,4 +58,5 @@ export interface DB {
   discordLinks: DiscordLinkTable;
   discordLinkRequests: DiscordLinkRequestTable;
   discordInviteBatches: DiscordInviteBatchTable;
+  discordTickets: DiscordTicketTable;
 }

--- a/packages/yucca-api/src/schema/migrations/20260828120000-AddDiscordTickets.ts
+++ b/packages/yucca-api/src/schema/migrations/20260828120000-AddDiscordTickets.ts
@@ -1,0 +1,26 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE TABLE "discordTickets" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "threadId" character varying NOT NULL,
+  "staffThreadId" character varying,
+  "freshdeskTicketId" character varying NOT NULL,
+  "discordUserId" character varying NOT NULL,
+  "userId" uuid,
+  "emailSubscribed" boolean NOT NULL DEFAULT false,
+  "lastMirroredMessageId" character varying,
+  "lastStaffMirroredMessageId" character varying,
+  "lastFreshdeskConversationId" character varying,
+  "closedAt" timestamp with time zone,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "discordTickets_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users" ("id") ON UPDATE CASCADE ON DELETE SET NULL,
+  CONSTRAINT "discordTickets_threadId_uq" UNIQUE ("threadId"),
+  CONSTRAINT "discordTickets_freshdeskTicketId_uq" UNIQUE ("freshdeskTicketId"),
+  CONSTRAINT "discordTickets_pkey" PRIMARY KEY ("id")
+);`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP TABLE "discordTickets";`.execute(db);
+}

--- a/packages/yucca-api/src/schema/tables/discordTicket.table.ts
+++ b/packages/yucca-api/src/schema/tables/discordTicket.table.ts
@@ -1,0 +1,41 @@
+import { Column, ForeignKeyColumn, type Generated, Table } from '@immich/sql-tools';
+import { UserTable } from './user.table';
+
+@Table({ name: 'discordTickets' })
+export class DiscordTicketTable {
+  @Column({ primary: true, type: 'uuid', default: () => 'gen_random_uuid()' })
+  id!: Generated<string>;
+
+  @Column({ unique: true })
+  threadId!: string;
+
+  @Column({ nullable: true })
+  staffThreadId!: string | null;
+
+  @Column({ unique: true })
+  freshdeskTicketId!: string;
+
+  @Column()
+  discordUserId!: string;
+
+  @ForeignKeyColumn(() => UserTable, { onUpdate: 'CASCADE', onDelete: 'SET NULL', nullable: true, index: false })
+  userId!: string | null;
+
+  @Column({ type: 'boolean', default: () => 'false' })
+  emailSubscribed!: Generated<boolean>;
+
+  @Column({ nullable: true })
+  lastMirroredMessageId!: string | null;
+
+  @Column({ nullable: true })
+  lastStaffMirroredMessageId!: string | null;
+
+  @Column({ nullable: true })
+  lastFreshdeskConversationId!: string | null;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  closedAt!: Date | null;
+
+  @Column({ type: 'timestamp with time zone', default: () => 'now()' })
+  createdAt!: Generated<Date>;
+}

--- a/packages/yucca-api/src/services/discord.service.spec.ts
+++ b/packages/yucca-api/src/services/discord.service.spec.ts
@@ -214,4 +214,72 @@ describe(DiscordService.name, () => {
       await expect(sut.getUserSummary('user-id')).rejects.toBeInstanceOf(NotFoundException);
     });
   });
+
+  describe('tickets', () => {
+    const ticket = {
+      id: 'ticket-id',
+      threadId: 'thread-1',
+      staffThreadId: 'staff-1',
+      freshdeskTicketId: '42',
+      discordUserId: '123456789',
+      userId: 'user-id',
+      emailSubscribed: false,
+      lastMirroredMessageId: null,
+      lastStaffMirroredMessageId: null,
+      lastFreshdeskConversationId: null,
+      closedAt: null,
+      createdAt: new Date(),
+    };
+
+    it('creates a mapping with defaulted nullables', async () => {
+      mocks.discord.createTicket.mockResolvedValue(ticket);
+
+      await expect(
+        sut.createTicket({ threadId: 'thread-1', freshdeskTicketId: '42', discordUserId: '123456789' }),
+      ).resolves.toEqual(ticket);
+
+      expect(mocks.discord.createTicket).toHaveBeenCalledWith({
+        threadId: 'thread-1',
+        staffThreadId: null,
+        freshdeskTicketId: '42',
+        discordUserId: '123456789',
+        userId: null,
+        lastMirroredMessageId: null,
+        lastStaffMirroredMessageId: null,
+      });
+    });
+
+    it('rejects an unknown thread', async () => {
+      mocks.discord.getTicketByThread.mockResolvedValue(void 0);
+
+      await expect(sut.getTicketByThread('nope')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects an unknown freshdesk ticket', async () => {
+      mocks.discord.getTicketByFreshdeskId.mockResolvedValue(void 0);
+
+      await expect(sut.getTicketByFreshdeskId('nope')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('translates closed into a closedAt timestamp', async () => {
+      await sut.updateTicket('ticket-id', { closed: true, lastFreshdeskConversationId: '7' });
+
+      expect(mocks.discord.updateTicket).toHaveBeenCalledWith('ticket-id', {
+        lastFreshdeskConversationId: '7',
+        closedAt: expect.any(Date),
+      });
+    });
+
+    it('leaves closedAt untouched when closed is not passed', async () => {
+      await sut.updateTicket('ticket-id', { emailSubscribed: true });
+
+      expect(mocks.discord.updateTicket).toHaveBeenCalledWith('ticket-id', { emailSubscribed: true });
+    });
+
+    it('rejects updates to an unknown ticket', async () => {
+      mocks.discord.updateTicket.mockResolvedValue(false);
+
+      await expect(sut.updateTicket('ticket-id', { closed: true })).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
 });

--- a/packages/yucca-api/src/services/discord.service.ts
+++ b/packages/yucca-api/src/services/discord.service.ts
@@ -13,6 +13,10 @@ import {
   DiscordLinkRequestCreatedDto,
   DiscordLinkRequestResponseDto,
   DiscordLinkUsernameUpdateDto,
+  DiscordTicketCreateDto,
+  DiscordTicketDto,
+  DiscordTicketListDto,
+  DiscordTicketUpdateDto,
   DiscordUserSummaryDto,
 } from 'src/dto/discord.dto';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
@@ -130,6 +134,49 @@ export class DiscordService {
       throw new NotFoundException('Unknown or expired link code');
     }
     return { discordUsername: request.discordUsername };
+  }
+
+  createTicket(dto: DiscordTicketCreateDto): Promise<DiscordTicketDto> {
+    return this.discord.createTicket({
+      threadId: dto.threadId,
+      staffThreadId: dto.staffThreadId ?? null,
+      freshdeskTicketId: dto.freshdeskTicketId,
+      discordUserId: dto.discordUserId,
+      userId: dto.userId ?? null,
+      lastMirroredMessageId: dto.lastMirroredMessageId ?? null,
+      lastStaffMirroredMessageId: dto.lastStaffMirroredMessageId ?? null,
+    });
+  }
+
+  async getTicketByThread(threadId: string): Promise<DiscordTicketDto> {
+    const ticket = await this.discord.getTicketByThread(threadId);
+    if (!ticket) {
+      throw new NotFoundException(`No ticket for thread ${threadId}`);
+    }
+    return ticket;
+  }
+
+  async getTicketByFreshdeskId(freshdeskTicketId: string): Promise<DiscordTicketDto> {
+    const ticket = await this.discord.getTicketByFreshdeskId(freshdeskTicketId);
+    if (!ticket) {
+      throw new NotFoundException(`No ticket for Freshdesk ticket ${freshdeskTicketId}`);
+    }
+    return ticket;
+  }
+
+  async listOpenTickets(): Promise<DiscordTicketListDto> {
+    return { items: await this.discord.listOpenTickets() };
+  }
+
+  async updateTicket(id: string, dto: DiscordTicketUpdateDto): Promise<void> {
+    const { closed, ...updates } = dto;
+    const updated = await this.discord.updateTicket(id, {
+      ...updates,
+      ...(closed === undefined ? {} : { closedAt: closed ? new Date() : null }),
+    });
+    if (!updated) {
+      throw new NotFoundException(`No ticket with id ${id}`);
+    }
   }
 
   async getUserSummary(userId: string): Promise<DiscordUserSummaryDto> {

--- a/packages/yucca-api/test/mocks.ts
+++ b/packages/yucca-api/test/mocks.ts
@@ -40,6 +40,11 @@ export const newDiscordRepositoryMock = (): jest.Mocked<RepositoryInterface<Disc
     createBatch: jest.fn(),
     setBatchMessage: jest.fn(),
     claimInvite: jest.fn(),
+    createTicket: jest.fn(),
+    getTicketByThread: jest.fn(),
+    getTicketByFreshdeskId: jest.fn(),
+    listOpenTickets: jest.fn().mockResolvedValue([]),
+    updateTicket: jest.fn().mockResolvedValue(true),
     getUserSummary: jest.fn(),
   };
 };


### PR DESCRIPTION
Adds the discordTickets mapping table + internal endpoints for the Freshdesk ticket sync.

- `main` <!-- branch-stack -->
  - \#576 :point\_left:
    - \#577
      - \#578
