### PR TITLE
feat(futo-backups-bot): bidirectional freshdesk sync for support tickets

### DIFF
--- a/packages/futo-backups-bot/src/app.module.ts
+++ b/packages/futo-backups-bot/src/app.module.ts
@@ -3,9 +3,12 @@ import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
 import { InternalController } from './controllers/internal.controller';
+import { WebhookController } from './controllers/webhook.controller';
 import { DiscordRepository } from './repositories/discord.repository';
+import { FreshdeskRepository } from './repositories/freshdesk.repository';
 import { TranscriptStorageRepository } from './repositories/transcriptStorage.repository';
 import { YuccaApiRepository } from './repositories/yuccaApi.repository';
+import { FreshdeskSyncService } from './services/freshdeskSync.service';
 import { InviteService } from './services/invite.service';
 import { SupportService } from './services/support.service';
 import { SweepService } from './services/sweep.service';
@@ -17,7 +20,9 @@ export const providers = [
   LoggerRepository,
   DiscordRepository,
   YuccaApiRepository,
+  FreshdeskRepository,
   TranscriptStorageRepository,
+  FreshdeskSyncService,
   InviteService,
   SupportService,
   SweepService,
@@ -26,7 +31,7 @@ export const providers = [
 
 @Module({
   imports: [OtelModule, ...imports],
-  controllers: [InternalController],
+  controllers: [InternalController, WebhookController],
   providers,
 })
 export class AppModule {}

--- a/packages/futo-backups-bot/src/controllers/webhook.controller.ts
+++ b/packages/futo-backups-bot/src/controllers/webhook.controller.ts
@@ -1,0 +1,32 @@
+import { LoggerRepository } from '@common/server/otel';
+import { BadRequestException, Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { FreshdeskWebhookGuard } from 'src/middleware/freshdeskWebhook.guard';
+import { FreshdeskSyncService } from 'src/services/freshdeskSync.service';
+import { z } from 'zod';
+
+const pingSchema = z.object({
+  ticket_id: z.coerce.number().int().positive(),
+});
+
+@Controller('/hooks/freshdesk')
+@UseGuards(FreshdeskWebhookGuard)
+export class WebhookController {
+  constructor(
+    private readonly sync: FreshdeskSyncService,
+    private readonly logger: LoggerRepository,
+  ) {}
+
+  // The payload is only a hint: the sync re-reads everything from the
+  // Freshdesk API, so a forged ticket_id can at most trigger a no-op sync.
+  @Post()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  notify(@Body() body: unknown): void {
+    const parsed = pingSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.message);
+    }
+    void this.sync
+      .onFreshdeskPing(String(parsed.data.ticket_id))
+      .catch((error: unknown) => this.logger.error(error, 'freshdesk webhook processing failed'));
+  }
+}

--- a/packages/futo-backups-bot/src/env.ts
+++ b/packages/futo-backups-bot/src/env.ts
@@ -25,6 +25,15 @@ const schema = z.object({
   TICKET_USER_LIMIT: z.coerce.number().int().positive().default(3),
   CLAIM_PROMPT_MIN_MESSAGES: z.coerce.number().int().positive().default(25),
 
+  FRESHDESK_URL: z.string().default(''),
+  FRESHDESK_API_KEY: z.string().default(''),
+  FRESHDESK_WEBHOOK_SECRET: z.string().default(''),
+  FRESHDESK_TAGS: z.string().default(''),
+  FRESHDESK_GROUP_ID: z.string().default(''),
+  FRESHDESK_DUMMY_EMAIL_DOMAIN: z.string().default('no.futo.org'),
+  TICKET_MIRROR_DEBOUNCE_SECONDS: z.coerce.number().int().positive().default(120),
+  TICKET_MIRROR_MAX_WAIT_SECONDS: z.coerce.number().int().positive().default(600),
+
   TRANSCRIPT_S3_ENDPOINT: z.string().default(''),
   TRANSCRIPT_S3_BUCKET: z.string().default(''),
   TRANSCRIPT_S3_ACCESS_KEY_ID: z.string().default(''),

--- a/packages/futo-backups-bot/src/messages.ts
+++ b/packages/futo-backups-bot/src/messages.ts
@@ -65,4 +65,25 @@ export const Messages = {
   claimExhausted: 'All invites have been claimed, keep an eye out for the next drop.',
   claimDropEnded: 'This drop has ended, keep an eye out for the next one.',
   inviteDropEndedButton: 'Drop ended',
+
+  emailUpdatesNotAvailable: 'Email updates are not available.',
+  emailUpdatesNotATicket: 'Run this inside your ticket thread.',
+  emailUpdatesOwnerOnly: 'Only the ticket owner can change email updates.',
+  emailUpdatesNoAccount: 'This ticket has no linked FUTO Backups account, so there is no email to send updates to.',
+  emailUpdatesClosed: 'This ticket is closed.',
+  emailUpdatesOn: (email: string) => `Email updates are on, staff replies will also be sent to ${email}.`,
+  emailUpdatesOff: 'Email updates are off, this ticket stays on Discord only.',
+  ticketResolvedByAgent: 'This ticket was resolved by our support staff.',
+  staffOnlyHandoff: 'Only staff can hand a ticket off.',
+  handoffNotATicket: 'Run this inside a ticket thread.',
+  handoffClosed: 'This ticket is already closed.',
+  handoffNoAccount: 'This ticket has no linked FUTO Backups account, so there is no email address to hand off to.',
+  handoffAnnouncement: (userId: string) =>
+    `<@${userId}>, we're moving this ticket to email. Our support team will follow up at the email address on your FUTO Backups account.`,
+  handoffDone: 'Handed off. The Freshdesk ticket stays open and agent replies now go to the customer by email.',
+  handoffNote: (staffUsername: string) =>
+    `Handed off from Discord by ${staffUsername}. The Discord thread is closed — continue with the customer by email.`,
+  supportAuthor: (name: string) => `${name} (FUTO support)`,
+  viaEmailAuthor: 'Customer (via email)',
+  attachmentTooLarge: (name: string, url: string) => `Attachment (too large to re-upload): [${name}](${url})`,
 };

--- a/packages/futo-backups-bot/src/middleware/freshdeskWebhook.guard.ts
+++ b/packages/futo-backups-bot/src/middleware/freshdeskWebhook.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { env } from 'src/env';
+
+export const FRESHDESK_SECRET_HEADER = 'x-freshdesk-secret';
+
+const digest = (value: string) => createHash('sha256').update(value).digest();
+
+@Injectable()
+export class FreshdeskWebhookGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ headers: Record<string, string | string[] | undefined> }>();
+    const secret = request.headers[FRESHDESK_SECRET_HEADER];
+    if (
+      !env.FRESHDESK_WEBHOOK_SECRET ||
+      typeof secret !== 'string' ||
+      !timingSafeEqual(digest(secret), digest(env.FRESHDESK_WEBHOOK_SECRET))
+    ) {
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
+}

--- a/packages/futo-backups-bot/src/repositories/discord.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/discord.repository.ts
@@ -31,7 +31,10 @@ export class DiscordRepository {
     return Boolean(env.DISCORD_BOT_TOKEN);
   }
 
-  async start(onInteraction: (interaction: Interaction) => Promise<void>): Promise<void> {
+  async start(
+    onInteraction: (interaction: Interaction) => Promise<void>,
+    onMessage?: (message: Message) => Promise<void>,
+  ): Promise<void> {
     if (!env.DISCORD_BOT_TOKEN) {
       this.logger.info('DISCORD_BOT_TOKEN is not set — the bot stays idle');
       return;
@@ -41,6 +44,9 @@ export class DiscordRepository {
       intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
     });
     client.on('interactionCreate', (interaction) => void onInteraction(interaction));
+    if (onMessage) {
+      client.on('messageCreate', (message) => void onMessage(message));
+    }
     client.on('error', (error) => this.logger.error(error, 'discord client error'));
     await client.login(env.DISCORD_BOT_TOKEN);
     this.client = client;
@@ -63,6 +69,14 @@ export class DiscordRepository {
       new SlashCommandBuilder()
         .setName('claim-backups-role')
         .setDescription('Claim the FUTO Backups customer role for your linked account')
+        .toJSON(),
+      new SlashCommandBuilder()
+        .setName('email-updates')
+        .setDescription('Toggle email copies of staff replies for this ticket')
+        .toJSON(),
+      new SlashCommandBuilder()
+        .setName('handoff')
+        .setDescription('Close this ticket on Discord and hand it to email support (staff only)')
         .toJSON(),
       new SlashCommandBuilder()
         .setName('beta-invite')
@@ -169,7 +183,7 @@ export class DiscordRepository {
     return thread;
   }
 
-  async createStaffThread(name: string, content: string): Promise<void> {
+  async createStaffThread(name: string, content: string): Promise<{ thread: ThreadChannel; seed: Message }> {
     const channel = await this.supportChannel();
     const thread = await channel.threads.create({
       name,
@@ -177,7 +191,40 @@ export class DiscordRepository {
       invitable: false,
       autoArchiveDuration: THREAD_AUTO_ARCHIVE_MINUTES,
     });
-    await thread.send(content);
+    const seed = await thread.send(content);
+    return { thread, seed };
+  }
+
+  async getThreadById(threadId: string): Promise<AnyThreadChannel> {
+    const guild = await this.guild();
+    const channel = await guild.channels.fetch(threadId);
+    if (!channel?.isThread()) {
+      throw new TypeError(`Channel ${threadId} is not a thread`);
+    }
+    return channel;
+  }
+
+  async sendToThread(threadId: string, message: MessageCreateOptions): Promise<void> {
+    const thread = await this.getThreadById(threadId);
+    await thread.send(message);
+  }
+
+  async fetchMessagesAfter(threadId: string, afterId: string | null): Promise<Message[]> {
+    const thread = await this.getThreadById(threadId);
+    const all: Message[] = [];
+    let after = afterId ?? '0';
+    for (;;) {
+      const batch = await thread.messages.fetch({ limit: 100, after });
+      if (batch.size === 0) {
+        return all;
+      }
+      const ascending = [...batch.values()].toSorted((a, b) => a.createdTimestamp - b.createdTimestamp);
+      all.push(...ascending);
+      after = ascending.at(-1)!.id;
+      if (batch.size < 100) {
+        return all;
+      }
+    }
   }
 
   async listOpenTicketThreads(discordUserId: string): Promise<ThreadChannel[]> {

--- a/packages/futo-backups-bot/src/repositories/freshdesk.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/freshdesk.repository.ts
@@ -1,0 +1,232 @@
+import { LoggerRepository } from '@common/server/otel';
+import { Injectable } from '@nestjs/common';
+import { env } from 'src/env';
+import { escapeHtml } from 'src/utils/mirror';
+import { z } from 'zod';
+
+export const TICKET_STATUS_OPEN = 2;
+export const TICKET_STATUS_RESOLVED = 4;
+
+const MAX_ATTACHMENT_BYTES = 18 * 1024 * 1024;
+
+const ticketCreatedSchema = z.object({
+  id: z.number(),
+});
+
+const ticketSchema = z.object({
+  id: z.number(),
+  status: z.number(),
+});
+
+const conversationSchema = z.object({
+  id: z.number(),
+  body_text: z.string().nullish(),
+  user_id: z.number(),
+  private: z.boolean(),
+  incoming: z.boolean(),
+  attachments: z.array(z.object({ name: z.string(), attachment_url: z.string() })).default([]),
+});
+
+const agentSchema = z.object({
+  id: z.number(),
+  contact: z.object({ name: z.string() }),
+});
+
+const updatedTicketsSchema = z.array(z.object({ id: z.number() }));
+
+export type FreshdeskConversation = z.infer<typeof conversationSchema>;
+export type OutboundAttachment = { name: string; url: string };
+
+@Injectable()
+export class FreshdeskRepository {
+  private agentNames = new Map<number, string>();
+  private ownAgentId: number | null = null;
+
+  constructor(private readonly logger: LoggerRepository) {}
+
+  get enabled(): boolean {
+    return Boolean(env.FRESHDESK_URL && env.FRESHDESK_API_KEY);
+  }
+
+  async createTicket(input: { email: string; name: string; subject: string; description: string }): Promise<string> {
+    const response = await this.request('POST', '/api/v2/tickets', {
+      email: input.email,
+      name: input.name,
+      subject: input.subject,
+      description: input.description,
+      status: TICKET_STATUS_OPEN,
+      priority: 1,
+      tags: this.tags(),
+      ...(env.FRESHDESK_GROUP_ID ? { group_id: Number(env.FRESHDESK_GROUP_ID) } : {}),
+    });
+    return String(ticketCreatedSchema.parse(await response.json()).id);
+  }
+
+  async getTicketStatus(ticketId: string): Promise<number> {
+    const response = await this.request('GET', `/api/v2/tickets/${encodeURIComponent(ticketId)}`);
+    return ticketSchema.parse(await response.json()).status;
+  }
+
+  async resolveTicket(ticketId: string): Promise<void> {
+    await this.request('PUT', `/api/v2/tickets/${encodeURIComponent(ticketId)}`, { status: TICKET_STATUS_RESOLVED });
+  }
+
+  async setRequester(ticketId: string, email: string, name: string): Promise<void> {
+    await this.request('PUT', `/api/v2/tickets/${encodeURIComponent(ticketId)}`, { email, name });
+  }
+
+  async createNote(
+    ticketId: string,
+    body: string,
+    options: { private: boolean; incoming?: boolean },
+    attachments: OutboundAttachment[] = [],
+  ): Promise<void> {
+    await this.createConversation(`/api/v2/tickets/${encodeURIComponent(ticketId)}/notes`, body, attachments, {
+      private: options.private,
+      incoming: options.incoming ?? false,
+    });
+  }
+
+  async createReply(ticketId: string, body: string, attachments: OutboundAttachment[] = []): Promise<void> {
+    await this.createConversation(`/api/v2/tickets/${encodeURIComponent(ticketId)}/reply`, body, attachments, {});
+  }
+
+  async listConversationsAfter(ticketId: string, afterId: string | null): Promise<FreshdeskConversation[]> {
+    const since = afterId === null ? null : Number(afterId);
+    const all: FreshdeskConversation[] = [];
+    for (let page = 1; page <= 20; page++) {
+      const response = await this.request(
+        'GET',
+        `/api/v2/tickets/${encodeURIComponent(ticketId)}/conversations?per_page=100&page=${page}`,
+      );
+      const batch = z.array(conversationSchema).parse(await response.json());
+      all.push(...batch.filter((conversation) => since === null || conversation.id > since));
+      if (batch.length < 100) {
+        break;
+      }
+    }
+    return all.toSorted((a, b) => a.id - b.id);
+  }
+
+  // null = more than five full pages changed inside the lookback — the
+  // listing is incomplete and the caller must treat every ticket as updated.
+  async listUpdatedTicketIds(since: Date): Promise<string[] | null> {
+    const ids: string[] = [];
+    for (let page = 1; page <= 5; page++) {
+      const response = await this.request(
+        'GET',
+        `/api/v2/tickets?updated_since=${encodeURIComponent(since.toISOString())}&order_by=updated_at&per_page=100&page=${page}`,
+      );
+      const batch = updatedTicketsSchema.parse(await response.json());
+      ids.push(...batch.map((ticket) => String(ticket.id)));
+      if (batch.length < 100) {
+        return ids;
+      }
+    }
+    return null;
+  }
+
+  async getOwnAgentId(): Promise<number> {
+    if (this.ownAgentId === null) {
+      const response = await this.request('GET', '/api/v2/agents/me');
+      this.ownAgentId = agentSchema.parse(await response.json()).id;
+    }
+    return this.ownAgentId;
+  }
+
+  async getAgentName(agentId: number): Promise<string> {
+    const cached = this.agentNames.get(agentId);
+    if (cached) {
+      return cached;
+    }
+    const response = await this.request('GET', `/api/v2/agents/${agentId}`, undefined, [404]);
+    const name = response.status === 404 ? 'Support' : agentSchema.parse(await response.json()).contact.name;
+    this.agentNames.set(agentId, name);
+    return name;
+  }
+
+  private tags(): string[] {
+    const extra = env.FRESHDESK_TAGS.split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    return ['discord', ...extra];
+  }
+
+  private async createConversation(
+    path: string,
+    body: string,
+    attachments: OutboundAttachment[],
+    fields: Record<string, boolean>,
+  ): Promise<void> {
+    const { files, omitted } = await this.download(attachments);
+    const fullBody = [
+      body,
+      ...omitted.map((name) => `<i>Attachment omitted (too large): ${escapeHtml(name)}</i>`),
+    ].join('<br>');
+
+    if (files.length === 0) {
+      await this.request('POST', path, { body: fullBody, ...fields });
+      return;
+    }
+
+    const form = new FormData();
+    form.append('body', fullBody);
+    for (const [key, value] of Object.entries(fields)) {
+      form.append(key, String(value));
+    }
+    for (const file of files) {
+      form.append('attachments[]', file.blob, file.name);
+    }
+    await this.request('POST', path, form);
+  }
+
+  private async download(
+    attachments: OutboundAttachment[],
+  ): Promise<{ files: { name: string; blob: Blob }[]; omitted: string[] }> {
+    const files: { name: string; blob: Blob }[] = [];
+    const omitted: string[] = [];
+    let total = 0;
+    for (const attachment of attachments) {
+      try {
+        const response = await fetch(attachment.url);
+        if (!response.ok) {
+          throw new Error(`${response.status} ${response.statusText}`);
+        }
+        const blob = await response.blob();
+        if (blob.size > MAX_ATTACHMENT_BYTES || total + blob.size > MAX_ATTACHMENT_BYTES) {
+          omitted.push(attachment.name);
+          continue;
+        }
+        total += blob.size;
+        files.push({ name: attachment.name, blob });
+      } catch (error) {
+        this.logger.warn(error, `failed to download attachment ${attachment.name}`);
+        omitted.push(attachment.name);
+      }
+    }
+    return { files, omitted };
+  }
+
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+    allowedStatuses: number[] = [],
+  ): Promise<Response> {
+    const isForm = body instanceof FormData;
+    const response = await fetch(new URL(path, env.FRESHDESK_URL), {
+      method,
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${env.FRESHDESK_API_KEY}:X`).toString('base64')}`,
+        ...(body === undefined || isForm ? {} : { 'Content-Type': 'application/json' }),
+      },
+      ...(body === undefined ? {} : { body: isForm ? body : JSON.stringify(body) }),
+    });
+    if (!response.ok && !allowedStatuses.includes(response.status)) {
+      throw new Error(
+        `freshdesk ${method} ${path} failed: ${response.status} ${response.statusText} — ${await response.text()}`,
+      );
+    }
+    return response;
+  }
+}

--- a/packages/futo-backups-bot/src/repositories/yuccaApi.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/yuccaApi.repository.ts
@@ -37,9 +37,34 @@ const userSummarySchema = z.object({
   lastSeenAt: z.coerce.date().nullable(),
 });
 
+const ticketMappingSchema = z.object({
+  id: z.string(),
+  threadId: z.string(),
+  staffThreadId: z.string().nullable(),
+  freshdeskTicketId: z.string(),
+  discordUserId: z.string(),
+  userId: z.string().nullable(),
+  emailSubscribed: z.boolean(),
+  lastMirroredMessageId: z.string().nullable(),
+  lastStaffMirroredMessageId: z.string().nullable(),
+  lastFreshdeskConversationId: z.string().nullable(),
+  closedAt: z.coerce.date().nullable(),
+});
+
+const ticketMappingListSchema = z.object({
+  items: z.array(ticketMappingSchema),
+});
+
 export type DiscordLink = z.infer<typeof linkSchema>;
 export type UserSummary = z.infer<typeof userSummarySchema>;
 export type LinkRequestCreated = z.infer<typeof linkRequestCreatedSchema>;
+export type TicketMapping = z.infer<typeof ticketMappingSchema>;
+export type TicketMappingUpdate = Partial<
+  Pick<
+    TicketMapping,
+    'emailSubscribed' | 'lastMirroredMessageId' | 'lastStaffMirroredMessageId' | 'lastFreshdeskConversationId'
+  > & { closed: boolean }
+>;
 export type InviteResult =
   | ({ status: 'ok' } & z.infer<typeof inviteCreatedSchema>)
   | { status: 'already-linked' | 'invite-used' | 'exhausted' | 'cancelled' };
@@ -128,6 +153,54 @@ export class YuccaApiRepository {
   async getUserSummary(userId: string): Promise<UserSummary> {
     const response = await this.request('GET', `/api/internal/discord/users/${encodeURIComponent(userId)}/summary`);
     return userSummarySchema.parse(await response.json());
+  }
+
+  async createTicketMapping(mapping: {
+    threadId: string;
+    staffThreadId?: string;
+    freshdeskTicketId: string;
+    discordUserId: string;
+    userId?: string;
+    lastMirroredMessageId?: string;
+    lastStaffMirroredMessageId?: string;
+  }): Promise<TicketMapping> {
+    const response = await this.request('POST', '/api/internal/discord/tickets', mapping);
+    return ticketMappingSchema.parse(await response.json());
+  }
+
+  async getTicketByThread(threadId: string): Promise<TicketMapping | null> {
+    const response = await this.request(
+      'GET',
+      `/api/internal/discord/tickets/by-thread/${encodeURIComponent(threadId)}`,
+      undefined,
+      [404],
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    return ticketMappingSchema.parse(await response.json());
+  }
+
+  async getTicketByFreshdeskId(freshdeskTicketId: string): Promise<TicketMapping | null> {
+    const response = await this.request(
+      'GET',
+      `/api/internal/discord/tickets/by-freshdesk/${encodeURIComponent(freshdeskTicketId)}`,
+      undefined,
+      [404],
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    return ticketMappingSchema.parse(await response.json());
+  }
+
+  async listOpenTickets(): Promise<TicketMapping[]> {
+    const response = await this.request('GET', '/api/internal/discord/tickets/open');
+    return ticketMappingListSchema.parse(await response.json()).items;
+  }
+
+  async updateTicket(id: string, updates: TicketMappingUpdate): Promise<void> {
+    await this.request('PATCH', `/api/internal/discord/tickets/${encodeURIComponent(id)}`, updates);
   }
 
   private async request(

--- a/packages/futo-backups-bot/src/services/freshdeskSync.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/freshdeskSync.service.spec.ts
@@ -1,0 +1,430 @@
+import { FreshdeskSyncService } from 'src/services/freshdeskSync.service';
+import { Mocks, newMocks } from '../../test/mocks';
+
+const mapping = {
+  id: 'map-1',
+  threadId: 'thread-1',
+  staffThreadId: 'staff-1',
+  freshdeskTicketId: '42',
+  discordUserId: 'cust',
+  userId: 'user-1',
+  emailSubscribed: false,
+  lastMirroredMessageId: 'seed',
+  lastStaffMirroredMessageId: 'staff-seed',
+  lastFreshdeskConversationId: null,
+  closedAt: null,
+};
+
+const summary = {
+  id: 'user-1',
+  name: 'Someone',
+  email: 'someone@example.test',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  connectionCount: 1,
+  repositoryCount: 2,
+  lastSeenAt: null,
+};
+
+const msg = (id: string, authorId: string, overrides: object = {}) =>
+  ({
+    id,
+    author: { id: authorId, bot: false, username: `user-${authorId}` },
+    content: `message ${id}`,
+    attachments: new Map(),
+    ...overrides,
+  }) as never;
+
+const inThread = (message: object, channelId: string) =>
+  ({
+    ...message,
+    channel: { isThread: () => true, parentId: 'support-channel', id: channelId },
+  }) as never;
+
+const conversation = (id: number, overrides: object = {}) => ({
+  id,
+  body_text: `conversation ${id}`,
+  user_id: 9,
+  private: false,
+  incoming: false,
+  attachments: [],
+  ...overrides,
+});
+
+const newInteraction = (overrides: object = {}) =>
+  ({
+    channelId: 'thread-1',
+    user: { id: 'cust', username: 'someone' },
+    reply: jest.fn(),
+    deferReply: jest.fn(),
+    editReply: jest.fn(),
+    ...overrides,
+  }) as never;
+
+const staffInteraction = (overrides: object = {}) =>
+  newInteraction({ user: { id: 'staff', username: 'staffer' }, member: { roles: ['staff-role'] }, ...overrides });
+
+describe(FreshdeskSyncService.name, () => {
+  let sut: FreshdeskSyncService;
+  let mocks: Mocks;
+
+  beforeEach(() => {
+    mocks = newMocks();
+    sut = new FreshdeskSyncService(
+      mocks.logger as never,
+      mocks.discord as never,
+      mocks.freshdesk as never,
+      mocks.api as never,
+    );
+  });
+
+  describe('onTicketOpened', () => {
+    it('creates the freshdesk ticket with a dummy requester and registers the mapping', async () => {
+      mocks.freshdesk.createTicket.mockResolvedValue('42');
+      mocks.api.createTicketMapping.mockResolvedValue(mapping);
+
+      await sut.onTicketOpened({
+        threadId: 'thread-1',
+        seedMessageId: 'seed',
+        staffThreadId: 'staff-1',
+        staffSeedMessageId: 'staff-seed',
+        discordUserId: 'cust',
+        username: 'someone',
+        userId: 'user-1',
+        description: 'backups fail\nwith an error',
+        staffNote: 'account context',
+      });
+
+      expect(mocks.freshdesk.createTicket).toHaveBeenCalledWith({
+        email: 'cust@no.futo.org',
+        name: 'someone',
+        subject: '[Discord] someone: backups fail',
+        description: 'backups fail<br>with an error',
+      });
+      expect(mocks.api.createTicketMapping).toHaveBeenCalledWith({
+        threadId: 'thread-1',
+        staffThreadId: 'staff-1',
+        freshdeskTicketId: '42',
+        discordUserId: 'cust',
+        userId: 'user-1',
+        lastMirroredMessageId: 'seed',
+        lastStaffMirroredMessageId: 'staff-seed',
+      });
+      expect(mocks.freshdesk.createNote).toHaveBeenCalledWith('42', expect.stringContaining('account context'), {
+        private: true,
+      });
+    });
+  });
+
+  describe('handleMessage', () => {
+    it('mirrors buffered staff messages and the customer message in order', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.discord.fetchMessagesAfter.mockResolvedValue([msg('m1', 'staff'), msg('m2', 'cust')]);
+
+      await sut.handleMessage(inThread(msg('m2', 'cust'), 'thread-1'));
+
+      expect(mocks.freshdesk.createReply).toHaveBeenCalledWith('42', expect.stringContaining('user-staff'), []);
+      expect(mocks.freshdesk.createNote).toHaveBeenCalledWith(
+        '42',
+        expect.stringContaining('user-cust'),
+        { private: false, incoming: true },
+        [],
+      );
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { lastMirroredMessageId: 'm1' });
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { lastMirroredMessageId: 'm2' });
+    });
+
+    it('holds back a trailing staff group until the debounce fires', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.discord.fetchMessagesAfter.mockResolvedValue([msg('m1', 'cust'), msg('m2', 'staff')]);
+
+      await sut.handleMessage(inThread(msg('m1', 'cust'), 'thread-1'));
+
+      expect(mocks.freshdesk.createNote).toHaveBeenCalledTimes(1);
+      expect(mocks.freshdesk.createReply).not.toHaveBeenCalled();
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { lastMirroredMessageId: 'm1' });
+      expect(mocks.api.updateTicket).not.toHaveBeenCalledWith('map-1', { lastMirroredMessageId: 'm2' });
+    });
+
+    it('debounces staff messages into one combined reply', async () => {
+      jest.useFakeTimers();
+      try {
+        mocks.api.getTicketByThread.mockResolvedValue(mapping);
+        mocks.discord.fetchMessagesAfter.mockResolvedValue([msg('m1', 'staff-a'), msg('m2', 'staff-b')]);
+
+        await sut.handleMessage(inThread(msg('m1', 'staff-a'), 'thread-1'));
+        await sut.handleMessage(inThread(msg('m2', 'staff-b'), 'thread-1'));
+        expect(mocks.freshdesk.createReply).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(120_000);
+
+        expect(mocks.freshdesk.createReply).toHaveBeenCalledTimes(1);
+        expect(mocks.freshdesk.createReply).toHaveBeenCalledWith('42', expect.stringContaining('user-staff-a'), []);
+        expect(mocks.freshdesk.createReply).toHaveBeenCalledWith('42', expect.stringContaining('user-staff-b'), []);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('mirrors staff-thread messages as private notes', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.discord.fetchMessagesAfter.mockResolvedValue([msg('s1', 'staff')]);
+
+      await sut.handleMessage(inThread(msg('s1', 'staff'), 'staff-1'));
+
+      expect(mocks.discord.fetchMessagesAfter).toHaveBeenCalledWith('staff-1', 'staff-seed');
+      expect(mocks.freshdesk.createNote).toHaveBeenCalledWith(
+        '42',
+        expect.stringContaining('staff notes'),
+        { private: true },
+        [],
+      );
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { lastStaffMirroredMessageId: 's1' });
+    });
+
+    it('ignores threads without a mapping', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(null);
+
+      await sut.handleMessage(inThread(msg('m1', 'cust'), 'thread-9'));
+
+      expect(mocks.freshdesk.createNote).not.toHaveBeenCalled();
+      expect(mocks.freshdesk.createReply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onFreshdeskPing', () => {
+    it('posts agent replies and skips private and own conversations', async () => {
+      mocks.api.getTicketByFreshdeskId.mockResolvedValue(mapping);
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.freshdesk.listConversationsAfter.mockResolvedValue([
+        conversation(5),
+        conversation(6, { user_id: 1 }),
+        conversation(7, { private: true }),
+      ] as never);
+
+      await sut.onFreshdeskPing('42');
+
+      expect(mocks.discord.sendToThread).toHaveBeenCalledTimes(1);
+      expect(mocks.discord.sendToThread).toHaveBeenCalledWith('thread-1', expect.objectContaining({ files: [] }));
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { lastFreshdeskConversationId: '5' });
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { lastFreshdeskConversationId: '7' });
+    });
+
+    it('closes the discord side and swaps the requester when the ticket is resolved', async () => {
+      mocks.api.getTicketByFreshdeskId.mockResolvedValue(mapping);
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.freshdesk.getTicketStatus.mockResolvedValue(4);
+      mocks.api.getUserSummary.mockResolvedValue(summary);
+      mocks.discord.getThreadById.mockResolvedValue({} as never);
+
+      await sut.onFreshdeskPing('42');
+
+      expect(mocks.discord.sendToThread).toHaveBeenCalledWith(
+        'thread-1',
+        expect.objectContaining({ content: expect.stringContaining('resolved') }),
+      );
+      expect(mocks.discord.closeThread).toHaveBeenCalledTimes(2);
+      expect(mocks.freshdesk.resolveTicket).not.toHaveBeenCalled();
+      expect(mocks.freshdesk.setRequester).toHaveBeenCalledWith('42', 'someone@example.test', 'Someone');
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { closed: true });
+    });
+
+    it('ignores unmapped tickets', async () => {
+      mocks.api.getTicketByFreshdeskId.mockResolvedValue(null);
+
+      await sut.onFreshdeskPing('9999');
+
+      expect(mocks.freshdesk.listConversationsAfter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onTicketClosed', () => {
+    it('resolves the freshdesk ticket and swaps the requester to the real email', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.api.getUserSummary.mockResolvedValue(summary);
+
+      await sut.onTicketClosed('thread-1');
+
+      expect(mocks.freshdesk.resolveTicket).toHaveBeenCalledWith('42');
+      expect(mocks.freshdesk.setRequester).toHaveBeenCalledWith('42', 'someone@example.test', 'Someone');
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { closed: true });
+    });
+
+    it('keeps the requester when email updates are already on', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue({ ...mapping, emailSubscribed: true });
+
+      await sut.onTicketClosed('thread-1');
+
+      expect(mocks.freshdesk.resolveTicket).toHaveBeenCalledWith('42');
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+    });
+
+    it('skips a ticket without a linked account', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue({ ...mapping, userId: null });
+
+      await sut.onTicketClosed('thread-1');
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { closed: true });
+    });
+  });
+
+  describe('onEmailUpdatesCommand', () => {
+    it('subscribes by swapping the requester to the real email', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.api.getUserSummary.mockResolvedValue(summary);
+      const interaction = newInteraction();
+
+      await sut.onEmailUpdatesCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).toHaveBeenCalledWith('42', 'someone@example.test', 'Someone');
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { emailSubscribed: true });
+      expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('someone@example.test') }),
+      );
+    });
+
+    it('unsubscribes by swapping back to the dummy address', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue({ ...mapping, emailSubscribed: true });
+      const interaction = newInteraction();
+
+      await sut.onEmailUpdatesCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).toHaveBeenCalledWith('42', 'cust@no.futo.org', 'someone');
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { emailSubscribed: false });
+    });
+
+    it('refuses anyone but the ticket owner', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      const interaction = newInteraction({ user: { id: 'staff', username: 'staffer' } });
+
+      await sut.onEmailUpdatesCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('owner') }),
+      );
+    });
+
+    it('refuses the staff-notes thread', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      const interaction = newInteraction({ channelId: 'staff-1' });
+
+      await sut.onEmailUpdatesCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('ticket thread') }),
+      );
+    });
+
+    it('refuses a ticket without a linked account', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue({ ...mapping, userId: null });
+      const interaction = newInteraction();
+
+      await sut.onEmailUpdatesCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('no linked') }),
+      );
+    });
+  });
+
+  describe('onHandoffCommand', () => {
+    it('closes the discord side, swaps the requester and leaves the freshdesk ticket open', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.api.getUserSummary.mockResolvedValue(summary);
+      mocks.discord.getThreadById.mockResolvedValue({} as never);
+      const interaction = staffInteraction();
+
+      await sut.onHandoffCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).toHaveBeenCalledWith('42', 'someone@example.test', 'Someone');
+      expect(mocks.freshdesk.resolveTicket).not.toHaveBeenCalled();
+      expect(mocks.freshdesk.createNote).toHaveBeenCalledWith('42', expect.stringContaining('staffer'), {
+        private: true,
+      });
+      expect(mocks.discord.sendToThread).toHaveBeenCalledWith(
+        'thread-1',
+        expect.objectContaining({ content: expect.stringContaining('<@cust>') }),
+      );
+      expect(mocks.discord.closeThread).toHaveBeenCalledTimes(2);
+      expect(mocks.api.updateTicket).toHaveBeenCalledWith('map-1', { closed: true });
+      expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Handed off') }),
+      );
+    });
+
+    it('refuses non-staff', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      const interaction = newInteraction({ member: { roles: [] as string[] } });
+
+      await sut.onHandoffCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('staff') }),
+      );
+    });
+
+    it('refuses a ticket without a linked account', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue({ ...mapping, userId: null });
+      const interaction = staffInteraction();
+
+      await sut.onHandoffCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect(mocks.discord.closeThread).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('no linked') }),
+      );
+    });
+
+    it('refuses an already-closed ticket', async () => {
+      mocks.api.getTicketByThread.mockResolvedValue({ ...mapping, closedAt: new Date() });
+      const interaction = staffInteraction();
+
+      await sut.onHandoffCommand(interaction);
+
+      expect(mocks.freshdesk.setRequester).not.toHaveBeenCalled();
+      expect((interaction as { reply: jest.Mock }).reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('already closed') }),
+      );
+    });
+  });
+
+  describe('poll', () => {
+    it('force-mirrors open tickets and ingests only updated ones', async () => {
+      mocks.api.listOpenTickets.mockResolvedValue([mapping]);
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.freshdesk.listUpdatedTicketIds.mockResolvedValue(['42']);
+      mocks.discord.fetchMessagesAfter.mockResolvedValue([msg('m1', 'staff')]);
+      mocks.freshdesk.listConversationsAfter.mockResolvedValue([conversation(5)] as never);
+
+      await sut.poll();
+
+      expect(mocks.freshdesk.createReply).toHaveBeenCalled();
+      expect(mocks.discord.sendToThread).toHaveBeenCalledWith('thread-1', expect.anything());
+    });
+
+    it('skips ingest for tickets that did not change', async () => {
+      mocks.api.listOpenTickets.mockResolvedValue([mapping]);
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.freshdesk.listUpdatedTicketIds.mockResolvedValue([]);
+
+      await sut.poll();
+
+      expect(mocks.freshdesk.listConversationsAfter).not.toHaveBeenCalled();
+    });
+
+    it('ingests every open ticket when the updated listing overflows', async () => {
+      mocks.api.listOpenTickets.mockResolvedValue([mapping]);
+      mocks.api.getTicketByThread.mockResolvedValue(mapping);
+      mocks.freshdesk.listUpdatedTicketIds.mockResolvedValue(null);
+
+      await sut.poll();
+
+      expect(mocks.freshdesk.listConversationsAfter).toHaveBeenCalledWith('42', null);
+    });
+  });
+});

--- a/packages/futo-backups-bot/src/services/freshdeskSync.service.ts
+++ b/packages/futo-backups-bot/src/services/freshdeskSync.service.ts
@@ -1,0 +1,465 @@
+import { LoggerRepository } from '@common/server/otel';
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { AttachmentBuilder, ChatInputCommandInteraction, EmbedBuilder, Message, MessageFlags } from 'discord.js';
+import { env } from 'src/env';
+import { Messages } from 'src/messages';
+import { DiscordRepository } from 'src/repositories/discord.repository';
+import {
+  FreshdeskConversation,
+  FreshdeskRepository,
+  TICKET_STATUS_RESOLVED,
+} from 'src/repositories/freshdesk.repository';
+import { TicketMapping, YuccaApiRepository } from 'src/repositories/yuccaApi.repository';
+import { MirrorMessage, escapeHtml, groupForMirror, toHtmlBody } from 'src/utils/mirror';
+import { isStaff } from 'src/utils/staff';
+
+const POLL_LOOKBACK_MS = 15 * 60_000;
+const MAPPING_CACHE_TTL_MS = 60_000;
+const MAX_DISCORD_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+const MAX_EMBED_DESCRIPTION = 4000;
+const SUBJECT_MAX_LENGTH = 80;
+
+export type TicketOpened = {
+  threadId: string;
+  seedMessageId: string;
+  staffThreadId: string;
+  staffSeedMessageId: string;
+  discordUserId: string;
+  username: string;
+  userId: string | null;
+  description: string;
+  staffNote: string;
+};
+
+@Injectable()
+export class FreshdeskSyncService {
+  private readonly mappingCache = new Map<string, { mapping: TicketMapping | null; at: number }>();
+  private readonly pendingFlush = new Map<string, { timer: NodeJS.Timeout; firstAt: number }>();
+  private readonly locks = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly logger: LoggerRepository,
+    private readonly discord: DiscordRepository,
+    private readonly freshdesk: FreshdeskRepository,
+    private readonly api: YuccaApiRepository,
+  ) {}
+
+  get enabled(): boolean {
+    return this.freshdesk.enabled;
+  }
+
+  async onTicketOpened(input: TicketOpened): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    const firstLine = input.description.split('\n')[0].slice(0, SUBJECT_MAX_LENGTH);
+    const freshdeskTicketId = await this.freshdesk.createTicket({
+      email: this.dummyEmail(input.discordUserId),
+      name: input.username,
+      subject: `[Discord] ${input.username}: ${firstLine}`,
+      description: toHtmlBody(input.description),
+    });
+    const mapping = await this.api.createTicketMapping({
+      threadId: input.threadId,
+      staffThreadId: input.staffThreadId,
+      freshdeskTicketId,
+      discordUserId: input.discordUserId,
+      ...(input.userId ? { userId: input.userId } : {}),
+      lastMirroredMessageId: input.seedMessageId,
+      lastStaffMirroredMessageId: input.staffSeedMessageId,
+    });
+    this.mappingCache.set(mapping.threadId, { mapping, at: Date.now() });
+    const threadLink = `https://discord.com/channels/${env.DISCORD_GUILD_ID}/${input.threadId}`;
+    await this.freshdesk.createNote(
+      freshdeskTicketId,
+      `${toHtmlBody(input.staffNote)}<br><br>Discord thread: <a href="${threadLink}">${threadLink}</a>`,
+      { private: true },
+    );
+  }
+
+  async handleMessage(message: Message): Promise<void> {
+    try {
+      if (!this.enabled || message.author.bot) {
+        return;
+      }
+      const channel = message.channel;
+      if (!channel.isThread() || channel.parentId !== env.DISCORD_SUPPORT_CHANNEL_ID) {
+        return;
+      }
+      const mapping = await this.getMapping(channel.id);
+      if (!mapping || mapping.closedAt) {
+        return;
+      }
+      if (channel.id === mapping.staffThreadId) {
+        await this.withLock(mapping.threadId, () => this.mirrorStaff(mapping.threadId));
+        return;
+      }
+      if (message.author.id === mapping.discordUserId) {
+        await this.withLock(mapping.threadId, () => this.mirrorTicket(mapping.threadId, false));
+        return;
+      }
+      this.scheduleFlush(mapping.threadId);
+    } catch (error) {
+      this.logger.error(error, 'failed to mirror a discord message to freshdesk');
+    }
+  }
+
+  async onTicketClosed(threadId: string): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    await this.withLock(threadId, async () => {
+      const mapping = await this.api.getTicketByThread(threadId);
+      if (!mapping || mapping.closedAt) {
+        return;
+      }
+      await this.mirrorTicket(threadId, true);
+      await this.mirrorStaff(threadId);
+      await this.freshdesk.resolveTicket(mapping.freshdeskTicketId);
+      await this.finalizeRequester(mapping);
+      await this.api.updateTicket(mapping.id, { closed: true });
+      this.forgetMapping(mapping);
+    });
+  }
+
+  async onFreshdeskPing(freshdeskTicketId: string): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    const mapping = await this.api.getTicketByFreshdeskId(freshdeskTicketId);
+    if (!mapping || mapping.closedAt) {
+      return;
+    }
+    await this.withLock(mapping.threadId, () => this.ingest(mapping.threadId));
+  }
+
+  async onEmailUpdatesCommand(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!this.enabled) {
+      await interaction.reply({ content: Messages.emailUpdatesNotAvailable, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    const mapping = interaction.channelId ? await this.api.getTicketByThread(interaction.channelId) : null;
+    if (!mapping || mapping.threadId !== interaction.channelId) {
+      await interaction.reply({ content: Messages.emailUpdatesNotATicket, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    if (mapping.closedAt) {
+      await interaction.reply({ content: Messages.emailUpdatesClosed, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    if (interaction.user.id !== mapping.discordUserId) {
+      await interaction.reply({ content: Messages.emailUpdatesOwnerOnly, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    if (!mapping.userId) {
+      await interaction.reply({ content: Messages.emailUpdatesNoAccount, flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    if (mapping.emailSubscribed) {
+      await this.freshdesk.setRequester(
+        mapping.freshdeskTicketId,
+        this.dummyEmail(mapping.discordUserId),
+        interaction.user.username,
+      );
+      await this.api.updateTicket(mapping.id, { emailSubscribed: false });
+      this.mappingCache.delete(mapping.threadId);
+      await interaction.editReply({ content: Messages.emailUpdatesOff });
+      return;
+    }
+    const summary = await this.api.getUserSummary(mapping.userId);
+    await this.freshdesk.setRequester(mapping.freshdeskTicketId, summary.email, summary.name);
+    await this.api.updateTicket(mapping.id, { emailSubscribed: true });
+    this.mappingCache.delete(mapping.threadId);
+    await interaction.editReply({ content: Messages.emailUpdatesOn(summary.email) });
+  }
+
+  async onHandoffCommand(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!this.enabled) {
+      await interaction.reply({ content: Messages.emailUpdatesNotAvailable, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    if (!isStaff(interaction)) {
+      await interaction.reply({ content: Messages.staffOnlyHandoff, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    const mapping = interaction.channelId ? await this.api.getTicketByThread(interaction.channelId) : null;
+    if (!mapping || mapping.threadId !== interaction.channelId) {
+      await interaction.reply({ content: Messages.handoffNotATicket, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    if (mapping.closedAt) {
+      await interaction.reply({ content: Messages.handoffClosed, flags: MessageFlags.Ephemeral });
+      return;
+    }
+    if (!mapping.userId) {
+      await interaction.reply({ content: Messages.handoffNoAccount, flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    await this.withLock(mapping.threadId, async () => {
+      const fresh = await this.api.getTicketByThread(mapping.threadId);
+      if (!fresh?.userId || fresh.closedAt) {
+        return;
+      }
+      await this.mirrorTicket(fresh.threadId, true);
+      await this.mirrorStaff(fresh.threadId);
+      // The Freshdesk ticket deliberately stays open — the handoff moves the
+      // conversation to email, it does not resolve it.
+      const summary = await this.api.getUserSummary(fresh.userId);
+      await this.freshdesk.setRequester(fresh.freshdeskTicketId, summary.email, summary.name);
+      await this.freshdesk.createNote(fresh.freshdeskTicketId, Messages.handoffNote(interaction.user.username), {
+        private: true,
+      });
+      await this.discord.sendToThread(fresh.threadId, { content: Messages.handoffAnnouncement(fresh.discordUserId) });
+      if (fresh.staffThreadId) {
+        await this.discord.closeThread(await this.discord.getThreadById(fresh.staffThreadId));
+      }
+      await this.discord.closeThread(await this.discord.getThreadById(fresh.threadId));
+      await this.api.updateTicket(fresh.id, { closed: true });
+      this.forgetMapping(fresh);
+    });
+    await interaction.editReply({ content: Messages.handoffDone });
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async poll(): Promise<void> {
+    if (!this.discord.enabled || !this.enabled) {
+      return;
+    }
+    let updated: Set<string> | null;
+    try {
+      const ids = await this.freshdesk.listUpdatedTicketIds(new Date(Date.now() - POLL_LOOKBACK_MS));
+      updated = ids === null ? null : new Set(ids);
+    } catch (error) {
+      this.logger.warn(error, 'could not list updated freshdesk tickets — ingesting every open ticket');
+      updated = null;
+    }
+    for (const { threadId, freshdeskTicketId } of await this.api.listOpenTickets()) {
+      try {
+        await this.withLock(threadId, async () => {
+          if (!this.pendingFlush.has(threadId)) {
+            await this.mirrorTicket(threadId, true);
+          }
+          await this.mirrorStaff(threadId);
+          if (updated === null || updated.has(freshdeskTicketId)) {
+            await this.ingest(threadId);
+          }
+        });
+      } catch (error) {
+        this.logger.error(error, `freshdesk sync failed for thread ${threadId}`);
+      }
+    }
+  }
+
+  private async mirrorTicket(threadId: string, force: boolean): Promise<void> {
+    const mapping = await this.api.getTicketByThread(threadId);
+    if (!mapping || mapping.closedAt) {
+      return;
+    }
+    const messages = await this.discord.fetchMessagesAfter(mapping.threadId, mapping.lastMirroredMessageId);
+    const batches = groupForMirror(
+      messages.map((message) => this.toMirror(message)),
+      mapping.discordUserId,
+    );
+    if (!force && batches.at(-1)?.kind === 'staff') {
+      batches.pop();
+    }
+    for (const batch of batches) {
+      await (batch.kind === 'customer'
+        ? this.freshdesk.createNote(
+            mapping.freshdeskTicketId,
+            `<b>${escapeHtml(batch.message.authorName)}</b> (Discord):<br>${this.bodyOf(batch.message)}`,
+            { private: false, incoming: true },
+            batch.message.attachments,
+          )
+        : this.freshdesk.createReply(
+            mapping.freshdeskTicketId,
+            batch.messages
+              .map((message) => `<b>${escapeHtml(message.authorName)}</b>:<br>${this.bodyOf(message)}`)
+              .join('<br><br>'),
+            batch.messages.flatMap((message) => message.attachments),
+          ));
+      await this.api.updateTicket(mapping.id, { lastMirroredMessageId: batch.lastMessageId });
+    }
+  }
+
+  private async mirrorStaff(threadId: string): Promise<void> {
+    const mapping = await this.api.getTicketByThread(threadId);
+    if (!mapping?.staffThreadId || mapping.closedAt) {
+      return;
+    }
+    const messages = await this.discord.fetchMessagesAfter(mapping.staffThreadId, mapping.lastStaffMirroredMessageId);
+    let patched = mapping.lastStaffMirroredMessageId;
+    for (const message of messages) {
+      if (!message.author.bot) {
+        const mirror = this.toMirror(message);
+        await this.freshdesk.createNote(
+          mapping.freshdeskTicketId,
+          `<b>${escapeHtml(mirror.authorName)}</b> (staff notes):<br>${this.bodyOf(mirror)}`,
+          { private: true },
+          mirror.attachments,
+        );
+        await this.api.updateTicket(mapping.id, { lastStaffMirroredMessageId: message.id });
+        patched = message.id;
+      }
+    }
+    const last = messages.at(-1);
+    if (last && last.id !== patched) {
+      await this.api.updateTicket(mapping.id, { lastStaffMirroredMessageId: last.id });
+    }
+  }
+
+  private async ingest(threadId: string): Promise<void> {
+    const mapping = await this.api.getTicketByThread(threadId);
+    if (!mapping || mapping.closedAt) {
+      return;
+    }
+    const ownAgentId = await this.freshdesk.getOwnAgentId();
+    const conversations = await this.freshdesk.listConversationsAfter(
+      mapping.freshdeskTicketId,
+      mapping.lastFreshdeskConversationId,
+    );
+    let patched = mapping.lastFreshdeskConversationId;
+    for (const conversation of conversations) {
+      if (!conversation.private && conversation.user_id !== ownAgentId) {
+        await this.postToDiscord(mapping, conversation);
+        await this.api.updateTicket(mapping.id, { lastFreshdeskConversationId: String(conversation.id) });
+        patched = String(conversation.id);
+      }
+    }
+    const last = conversations.at(-1);
+    if (last && String(last.id) !== patched) {
+      await this.api.updateTicket(mapping.id, { lastFreshdeskConversationId: String(last.id) });
+    }
+    if ((await this.freshdesk.getTicketStatus(mapping.freshdeskTicketId)) >= TICKET_STATUS_RESOLVED) {
+      await this.closeFromFreshdesk(mapping);
+    }
+  }
+
+  private async closeFromFreshdesk(mapping: TicketMapping): Promise<void> {
+    await this.mirrorTicket(mapping.threadId, true);
+    await this.mirrorStaff(mapping.threadId);
+    await this.discord.sendToThread(mapping.threadId, { content: Messages.ticketResolvedByAgent });
+    if (mapping.staffThreadId) {
+      await this.discord.closeThread(await this.discord.getThreadById(mapping.staffThreadId));
+    }
+    await this.discord.closeThread(await this.discord.getThreadById(mapping.threadId));
+    await this.finalizeRequester(mapping);
+    await this.api.updateTicket(mapping.id, { closed: true });
+    this.forgetMapping(mapping);
+  }
+
+  private async postToDiscord(mapping: TicketMapping, conversation: FreshdeskConversation): Promise<void> {
+    const author = conversation.incoming
+      ? Messages.viaEmailAuthor
+      : Messages.supportAuthor(await this.freshdesk.getAgentName(conversation.user_id));
+    const files: AttachmentBuilder[] = [];
+    const links: string[] = [];
+    for (const attachment of conversation.attachments) {
+      try {
+        const response = await fetch(attachment.attachment_url);
+        if (!response.ok) {
+          throw new Error(`${response.status} ${response.statusText}`);
+        }
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (buffer.byteLength > MAX_DISCORD_ATTACHMENT_BYTES) {
+          links.push(Messages.attachmentTooLarge(attachment.name, attachment.attachment_url));
+          continue;
+        }
+        files.push(new AttachmentBuilder(buffer, { name: attachment.name }));
+      } catch (error) {
+        this.logger.warn(error, `failed to fetch freshdesk attachment ${attachment.name}`);
+        links.push(Messages.attachmentTooLarge(attachment.name, attachment.attachment_url));
+      }
+    }
+    const body = (conversation.body_text ?? '').trim() || '(attachment)';
+    const description = [body, ...links].join('\n').slice(0, MAX_EMBED_DESCRIPTION);
+    await this.discord.sendToThread(mapping.threadId, {
+      embeds: [new EmbedBuilder().setAuthor({ name: author }).setDescription(description)],
+      files,
+    });
+  }
+
+  private async finalizeRequester(mapping: TicketMapping): Promise<void> {
+    if (mapping.emailSubscribed || !mapping.userId) {
+      return;
+    }
+    const summary = await this.api.getUserSummary(mapping.userId);
+    await this.freshdesk.setRequester(mapping.freshdeskTicketId, summary.email, summary.name);
+  }
+
+  private scheduleFlush(threadId: string): void {
+    const existing = this.pendingFlush.get(threadId);
+    const firstAt = existing?.firstAt ?? Date.now();
+    if (existing) {
+      clearTimeout(existing.timer);
+    }
+    const debounceMs = env.TICKET_MIRROR_DEBOUNCE_SECONDS * 1000;
+    const maxWaitMs = env.TICKET_MIRROR_MAX_WAIT_SECONDS * 1000;
+    const wait = Math.min(debounceMs, Math.max(0, firstAt + maxWaitMs - Date.now()));
+    const timer = setTimeout(() => {
+      this.pendingFlush.delete(threadId);
+      void this.withLock(threadId, () => this.mirrorTicket(threadId, true)).catch((error: unknown) =>
+        this.logger.error(error, `debounced mirror failed for thread ${threadId}`),
+      );
+    }, wait);
+    timer.unref();
+    this.pendingFlush.set(threadId, { timer, firstAt });
+  }
+
+  private withLock<T>(threadId: string, run: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(threadId) ?? Promise.resolve();
+    const next = previous.then(run, run);
+    this.locks.set(
+      threadId,
+      next.then(
+        () => {},
+        () => {},
+      ),
+    );
+    return next;
+  }
+
+  private async getMapping(threadId: string): Promise<TicketMapping | null> {
+    const cached = this.mappingCache.get(threadId);
+    if (cached && Date.now() - cached.at < MAPPING_CACHE_TTL_MS) {
+      return cached.mapping;
+    }
+    const mapping = await this.api.getTicketByThread(threadId);
+    this.mappingCache.set(threadId, { mapping, at: Date.now() });
+    return mapping;
+  }
+
+  private forgetMapping(mapping: TicketMapping): void {
+    this.mappingCache.delete(mapping.threadId);
+    if (mapping.staffThreadId) {
+      this.mappingCache.delete(mapping.staffThreadId);
+    }
+  }
+
+  private toMirror(message: Message): MirrorMessage {
+    return {
+      id: message.id,
+      authorId: message.author.id,
+      authorName: message.author.username,
+      fromBot: message.author.bot,
+      content: message.content,
+      attachments: [...message.attachments.values()].map((attachment) => ({
+        name: attachment.name,
+        url: attachment.url,
+      })),
+    };
+  }
+
+  private bodyOf(message: MirrorMessage): string {
+    return toHtmlBody(message.content) || '<i>(attachment)</i>';
+  }
+
+  private dummyEmail(discordUserId: string): string {
+    return `${discordUserId}@${env.FRESHDESK_DUMMY_EMAIL_DOMAIN}`;
+  }
+}

--- a/packages/futo-backups-bot/src/services/support.service.spec.ts
+++ b/packages/futo-backups-bot/src/services/support.service.spec.ts
@@ -90,6 +90,7 @@ describe(SupportService.name, () => {
       mocks.discord as never,
       mocks.api as never,
       new InviteService(mocks.logger as never, mocks.discord as never, mocks.api as never),
+      mocks.freshdeskSync as never,
     );
   });
 
@@ -161,7 +162,7 @@ describe(SupportService.name, () => {
     it('creates the ticket thread with a staff thread and replies with a pointer', async () => {
       mocks.api.getLink.mockResolvedValue(link);
       mocks.api.getUserSummary.mockResolvedValue(summary);
-      const send = jest.fn();
+      const send = jest.fn().mockResolvedValue({ id: 'seed-1' });
       mocks.discord.createTicketThread.mockResolvedValue(asThread({ id: 'thread-1', send }));
       const interaction = newModalInteraction('My backups are failing.');
 
@@ -184,6 +185,16 @@ describe(SupportService.name, () => {
       expect((interaction as { editReply: jest.Mock }).editReply).toHaveBeenCalledWith(
         expect.objectContaining({ content: expect.stringContaining('thread-1') }),
       );
+      expect(mocks.freshdeskSync.onTicketOpened).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: 'thread-1',
+          seedMessageId: 'seed-1',
+          staffThreadId: 'staff-thread-1',
+          staffSeedMessageId: 'staff-seed-1',
+          userId: 'user-1',
+          description: 'My backups are failing.',
+        }),
+      );
     });
   });
 
@@ -201,7 +212,7 @@ describe(SupportService.name, () => {
 
     it('opens a ticket for an unlinked user without requiring a link', async () => {
       mocks.api.getLink.mockResolvedValue(null);
-      const send = jest.fn();
+      const send = jest.fn().mockResolvedValue({ id: 'seed-9' });
       mocks.discord.createTicketThread.mockResolvedValue(asThread({ id: 'thread-9', send }));
       const interaction = newCommandInteraction(
         { id: '555000', username: 'Guest' },

--- a/packages/futo-backups-bot/src/services/support.service.ts
+++ b/packages/futo-backups-bot/src/services/support.service.ts
@@ -23,6 +23,7 @@ import { env } from 'src/env';
 import { Messages } from 'src/messages';
 import { DiscordRepository } from 'src/repositories/discord.repository';
 import { DiscordLink, UserSummary, YuccaApiRepository } from 'src/repositories/yuccaApi.repository';
+import { FreshdeskSyncService } from 'src/services/freshdeskSync.service';
 import { InviteService } from 'src/services/invite.service';
 import { isStaff } from 'src/utils/staff';
 
@@ -55,13 +56,17 @@ export class SupportService implements OnApplicationBootstrap {
     private readonly discord: DiscordRepository,
     private readonly api: YuccaApiRepository,
     private readonly invite: InviteService,
+    private readonly freshdeskSync: FreshdeskSyncService,
   ) {}
 
   async onApplicationBootstrap() {
     if (!this.discord.enabled) {
       return;
     }
-    await this.discord.start((interaction) => this.handleInteraction(interaction));
+    await this.discord.start(
+      (interaction) => this.handleInteraction(interaction),
+      (message) => this.freshdeskSync.handleMessage(message),
+    );
     try {
       await this.discord.registerCommands();
     } catch (error) {
@@ -107,6 +112,12 @@ export class SupportService implements OnApplicationBootstrap {
       }
       if (interaction.isChatInputCommand() && interaction.commandName === 'claim-backups-role') {
         return await this.onClaimRequested(interaction);
+      }
+      if (interaction.isChatInputCommand() && interaction.commandName === 'email-updates') {
+        return await this.freshdeskSync.onEmailUpdatesCommand(interaction);
+      }
+      if (interaction.isChatInputCommand() && interaction.commandName === 'handoff') {
+        return await this.freshdeskSync.onHandoffCommand(interaction);
       }
       if (interaction.isChatInputCommand() && interaction.commandName === 'beta-invite') {
         return await this.invite.onInviteCommand(interaction);
@@ -334,7 +345,7 @@ export class SupportService implements OnApplicationBootstrap {
     const suffix = this.ticketSuffix(user.username, user.id);
     const thread = await this.discord.createTicketThread(`ticket-${suffix}`, user.id);
 
-    await thread.send({
+    const seed = await thread.send({
       content: `<@${user.id}> <@&${env.DISCORD_STAFF_ROLE_ID}>`,
       embeds: [new EmbedBuilder().setTitle(Messages.ticketEmbedTitle).setDescription(description)],
       components: [this.buttonRow(ComponentId.CloseTicket, Messages.closeTicketButton, ButtonStyle.Danger)],
@@ -353,10 +364,22 @@ export class SupportService implements OnApplicationBootstrap {
           return null;
         })
       : null;
-    await this.discord.createStaffThread(
-      `staff-${suffix}`,
-      `<@&${env.DISCORD_STAFF_ROLE_ID}>\n${this.staffNote(link, summary)}`,
-    );
+    const note = this.staffNote(link, summary);
+    const staff = await this.discord.createStaffThread(`staff-${suffix}`, `<@&${env.DISCORD_STAFF_ROLE_ID}>\n${note}`);
+
+    void this.freshdeskSync
+      .onTicketOpened({
+        threadId: thread.id,
+        seedMessageId: seed.id,
+        staffThreadId: staff.thread.id,
+        staffSeedMessageId: staff.seed.id,
+        discordUserId: user.id,
+        username: user.username,
+        userId: link?.userId ?? null,
+        description,
+        staffNote: note,
+      })
+      .catch((error: unknown) => this.logger.error(error, 'failed to open the freshdesk ticket'));
 
     return thread;
   }
@@ -408,6 +431,10 @@ export class SupportService implements OnApplicationBootstrap {
       await this.discord.closeThread(staffThread);
     }
     await this.discord.closeThread(thread);
+
+    void this.freshdeskSync
+      .onTicketClosed(thread.id)
+      .catch((error: unknown) => this.logger.error(error, 'failed to resolve the freshdesk ticket'));
   }
 
   private syncUsername(link: DiscordLink, user: User) {

--- a/packages/futo-backups-bot/src/utils/mirror.spec.ts
+++ b/packages/futo-backups-bot/src/utils/mirror.spec.ts
@@ -1,0 +1,66 @@
+import { MirrorMessage, escapeHtml, groupForMirror, toHtmlBody } from 'src/utils/mirror';
+
+const message = (id: string, authorId: string, overrides: Partial<MirrorMessage> = {}): MirrorMessage => ({
+  id,
+  authorId,
+  authorName: `user-${authorId}`,
+  fromBot: false,
+  content: `message ${id}`,
+  attachments: [],
+  ...overrides,
+});
+
+describe('groupForMirror', () => {
+  it('emits each customer message as its own batch', () => {
+    const batches = groupForMirror([message('1', 'customer'), message('2', 'customer')], 'customer');
+
+    expect(batches).toEqual([
+      expect.objectContaining({ kind: 'customer', lastMessageId: '1' }),
+      expect.objectContaining({ kind: 'customer', lastMessageId: '2' }),
+    ]);
+  });
+
+  it('groups consecutive staff messages into one batch', () => {
+    const batches = groupForMirror(
+      [message('1', 'staff-a'), message('2', 'staff-b'), message('3', 'staff-a')],
+      'customer',
+    );
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(
+      expect.objectContaining({ kind: 'staff', lastMessageId: '3', messages: expect.arrayContaining([]) }),
+    );
+  });
+
+  it('splits staff groups on customer messages', () => {
+    const batches = groupForMirror(
+      [message('1', 'staff-a'), message('2', 'customer'), message('3', 'staff-a'), message('4', 'staff-b')],
+      'customer',
+    );
+
+    expect(batches.map((batch) => batch.kind)).toEqual(['staff', 'customer', 'staff']);
+    expect(batches.map((batch) => batch.lastMessageId)).toEqual(['1', '2', '4']);
+  });
+
+  it('skips bot messages without breaking staff grouping', () => {
+    const batches = groupForMirror(
+      [message('1', 'staff-a'), message('2', 'bot', { fromBot: true }), message('3', 'staff-b')],
+      'customer',
+    );
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(expect.objectContaining({ kind: 'staff', lastMessageId: '3' }));
+  });
+});
+
+describe('toHtmlBody', () => {
+  it('escapes html and converts newlines', () => {
+    expect(toHtmlBody('a <b>\nc & d')).toBe('a &lt;b&gt;<br>c &amp; d');
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes quotes', () => {
+    expect(escapeHtml('"name"')).toBe('&quot;name&quot;');
+  });
+});

--- a/packages/futo-backups-bot/src/utils/mirror.ts
+++ b/packages/futo-backups-bot/src/utils/mirror.ts
@@ -1,0 +1,38 @@
+export type MirrorMessage = {
+  id: string;
+  authorId: string;
+  authorName: string;
+  fromBot: boolean;
+  content: string;
+  attachments: { name: string; url: string }[];
+};
+
+export type MirrorBatch =
+  | { kind: 'customer'; lastMessageId: string; message: MirrorMessage }
+  | { kind: 'staff'; lastMessageId: string; messages: MirrorMessage[] };
+
+export const groupForMirror = (messages: MirrorMessage[], customerId: string): MirrorBatch[] => {
+  const batches: MirrorBatch[] = [];
+  for (const message of messages) {
+    if (message.fromBot) {
+      continue;
+    }
+    if (message.authorId === customerId) {
+      batches.push({ kind: 'customer', lastMessageId: message.id, message });
+      continue;
+    }
+    const last = batches.at(-1);
+    if (last?.kind === 'staff') {
+      last.messages.push(message);
+      last.lastMessageId = message.id;
+    } else {
+      batches.push({ kind: 'staff', lastMessageId: message.id, messages: [message] });
+    }
+  }
+  return batches;
+};
+
+export const escapeHtml = (value: string): string =>
+  value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+
+export const toHtmlBody = (value: string): string => escapeHtml(value).replaceAll('\n', '<br>');

--- a/packages/futo-backups-bot/test/mocks.ts
+++ b/packages/futo-backups-bot/test/mocks.ts
@@ -1,7 +1,9 @@
 import type { LoggerRepository } from '@common/server/otel';
 import type { DiscordRepository } from 'src/repositories/discord.repository';
+import type { FreshdeskRepository } from 'src/repositories/freshdesk.repository';
 import type { TranscriptStorageRepository } from 'src/repositories/transcriptStorage.repository';
 import type { YuccaApiRepository } from 'src/repositories/yuccaApi.repository';
+import type { FreshdeskSyncService } from 'src/services/freshdeskSync.service';
 
 export type RepositoryInterface<T extends object> = Pick<T, keyof T>;
 
@@ -26,13 +28,45 @@ export const newDiscordRepositoryMock = (): jest.Mocked<RepositoryInterface<Disc
     sendDirectMessage: jest.fn().mockResolvedValue(true),
     editMessage: jest.fn().mockResolvedValue(void 0),
     createTicketThread: jest.fn(),
-    createStaffThread: jest.fn(),
+    createStaffThread: jest.fn().mockResolvedValue({ thread: { id: 'staff-thread-1' }, seed: { id: 'staff-seed-1' } }),
+    getThreadById: jest.fn(),
+    sendToThread: jest.fn().mockResolvedValue(void 0),
+    fetchMessagesAfter: jest.fn().mockResolvedValue([]),
     listOpenTicketThreads: jest.fn().mockResolvedValue([]),
     findSupportThreadByName: jest.fn(),
     closeThread: jest.fn(),
     listClosedTicketThreads: jest.fn().mockResolvedValue([]),
     fetchAllMessages: jest.fn(),
     deleteThread: jest.fn(),
+  };
+};
+
+export const newFreshdeskRepositoryMock = (): jest.Mocked<RepositoryInterface<FreshdeskRepository>> => {
+  return {
+    enabled: true,
+    createTicket: jest.fn().mockResolvedValue('42'),
+    getTicketStatus: jest.fn().mockResolvedValue(2),
+    resolveTicket: jest.fn().mockResolvedValue(void 0),
+    setRequester: jest.fn().mockResolvedValue(void 0),
+    createNote: jest.fn().mockResolvedValue(void 0),
+    createReply: jest.fn().mockResolvedValue(void 0),
+    listConversationsAfter: jest.fn().mockResolvedValue([]),
+    listUpdatedTicketIds: jest.fn().mockResolvedValue([]),
+    getOwnAgentId: jest.fn().mockResolvedValue(1),
+    getAgentName: jest.fn().mockResolvedValue('Agent Smith'),
+  };
+};
+
+export const newFreshdeskSyncServiceMock = (): jest.Mocked<RepositoryInterface<FreshdeskSyncService>> => {
+  return {
+    enabled: false,
+    onTicketOpened: jest.fn().mockResolvedValue(void 0),
+    onTicketClosed: jest.fn().mockResolvedValue(void 0),
+    onFreshdeskPing: jest.fn().mockResolvedValue(void 0),
+    onEmailUpdatesCommand: jest.fn().mockResolvedValue(void 0),
+    onHandoffCommand: jest.fn().mockResolvedValue(void 0),
+    handleMessage: jest.fn().mockResolvedValue(void 0),
+    poll: jest.fn().mockResolvedValue(void 0),
   };
 };
 
@@ -45,6 +79,11 @@ export const newYuccaApiRepositoryMock = (): jest.Mocked<RepositoryInterface<Yuc
     setInviteBatchMessage: jest.fn().mockResolvedValue(void 0),
     createInvite: jest.fn(),
     getUserSummary: jest.fn(),
+    createTicketMapping: jest.fn(),
+    getTicketByThread: jest.fn().mockResolvedValue(null),
+    getTicketByFreshdeskId: jest.fn().mockResolvedValue(null),
+    listOpenTickets: jest.fn().mockResolvedValue([]),
+    updateTicket: jest.fn().mockResolvedValue(void 0),
   };
 };
 
@@ -61,6 +100,8 @@ export const newMocks = () => {
     discord: newDiscordRepositoryMock(),
     api: newYuccaApiRepositoryMock(),
     storage: newTranscriptStorageRepositoryMock(),
+    freshdesk: newFreshdeskRepositoryMock(),
+    freshdeskSync: newFreshdeskSyncServiceMock(),
   };
 };
 

--- a/packages/futo-backups-bot/test/setup.ts
+++ b/packages/futo-backups-bot/test/setup.ts
@@ -5,3 +5,6 @@ process.env.DISCORD_SUPPORT_CHANNEL_ID ??= 'support-channel';
 process.env.DISCORD_GENERAL_CHANNEL_ID ??= 'general-channel';
 process.env.DISCORD_CHAT_CHANNEL_ID ??= 'chat-channel';
 process.env.DISCORD_CUSTOMER_ROLE_ID ??= 'customer-role';
+process.env.FRESHDESK_URL ??= 'https://example.freshdesk.test';
+process.env.FRESHDESK_API_KEY ??= 'test-key';
+process.env.FRESHDESK_WEBHOOK_SECRET ??= 'test-webhook-secret';


### PR DESCRIPTION
Live-mirrors ticket threads into Freshdesk and agent replies back, with debounced staff coalescing and /email-updates.

- `main` <!-- branch-stack -->
  - \#576
    - \#577 :point\_left:
      - \#578
