### PR TITLE
feat(infra): wire the freshdesk webhook route, network policy and secrets

### DIFF
--- a/charts/apps/futo-backups-bot/templates/service.yaml
+++ b/charts/apps/futo-backups-bot/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "yucca-common.service" . }}

--- a/charts/apps/futo-backups-bot/values.yaml
+++ b/charts/apps/futo-backups-bot/values.yaml
@@ -18,6 +18,9 @@ ports:
   - name: http
     containerPort: 3050
 
+service:
+  type: ClusterIP
+
 # Empty token on purpose: the bot idles without one, so dev without a Discord
 # guild stays green. Real dev values arrive via the yucca-dev-env extraEnvFrom
 # layer (last envFrom wins), prod's via the TF-provisioned Secret of the same

--- a/docs/discord-support.md
+++ b/docs/discord-support.md
@@ -109,10 +109,11 @@ only claim and ties the new account to their Discord identity.
 
 ## Tickets: Discord is the source of truth
 
-No ticket table. A ticket is a **private thread** under the support channel;
-closed = **locked + archived** (locked distinguishes a real close from
-Discord's auto-archive on idle), and Discord's own `archiveTimestamp` drives
-retention. yucca-api's scope stays pure account-linking.
+A ticket is a **private thread** under the support channel; closed =
+**locked + archived** (locked distinguishes a real close from Discord's
+auto-archive on idle), and Discord's own `archiveTimestamp` drives retention.
+The only ticket state in postgres is the Freshdesk mapping row
+(`discordTickets`, below) — the conversation itself lives in Discord.
 
 - **Open**: the button (always, when linked) opens a **modal with a required
   description field**; the thread is only created on submit. The bot creates
@@ -136,6 +137,67 @@ retention. yucca-api's scope stays pure account-linking.
   (`TRANSCRIPT_S3_*`, Ceph RGW in prod), then deleted. History survives as
   the transcript; threads never touch the guild's channel cap.
 
+## Freshdesk sync
+
+Every ticket thread is mirrored **live and bidirectionally** into a Freshdesk
+ticket, so agents can work from either side. The mapping (thread id ↔ FD
+ticket id, plus the mirror cursors) is the `discordTickets` table in yucca-api
+(`/internal/discord/tickets*`); the bot holds no state across restarts and
+self-heals by re-reading messages after the stored cursors. Dormant unless
+`FRESHDESK_URL` + `FRESHDESK_API_KEY` are set.
+
+- **Open**: the bot creates the FD ticket (tags `discord` + `FRESHDESK_TAGS`,
+  e.g. `staging`; assigned to the per-env TF-managed group when
+  `FRESHDESK_GROUP_ID` is set) with the requester set to a **non-deliverable dummy**
+  `<discordUserId>@no.futo.org` — nothing emails the user while the
+  conversation lives in Discord. The staff-thread context (Grafana link,
+  account summary) lands as a private note with a link back to the thread.
+- **Discord → FD**: customer messages mirror immediately as incoming public
+  notes; staff messages are **debounced** (`TICKET_MIRROR_DEBOUNCE_SECONDS`,
+  quiet-period, capped by `TICKET_MIRROR_MAX_WAIT_SECONDS`) and coalesce into
+  one public reply per burst — one burst = at most one email to a subscribed
+  requester. Staff-thread messages mirror as private notes. Attachments are
+  re-uploaded (Discord CDN URLs expire); oversized ones degrade to an
+  omission note.
+- **FD → Discord**: automation rules POST `{"ticket_id": {{ticket.id}}}` to
+  the capability URL `https://<web>/hooks/<YUCCA_FRESHDESK_WEBHOOK_PATH>`
+  (a TF-generated path segment, substituted into the HTTPRoute from the
+  cluster-secrets Secret and rewritten to the bot's fixed `/hooks/freshdesk`
+  mount — read it from 1P, it is never in git) with the `x-freshdesk-secret`
+  header; the
+  bot treats the payload as a hint and re-reads the conversation via the API
+  (so forged payloads are inert), posting agent replies into the thread as
+  embeds. A 5-minute `updated_since` poll catches anything the hand-configured
+  rules miss and doubles as the crash-recovery sweep.
+- **`/email-updates`** (ticket owner, per ticket): swaps the FD requester to
+  the account's real email so native agent replies email them too; running it
+  again swaps back. FD-native reply emails are 1:1 per deliberate agent reply.
+- **Close**: either side wins. The Discord Close button resolves the FD
+  ticket; resolving/closing in FD posts a closing note and locks + archives
+  the threads. Both paths then swap the requester to the real email
+  (resolve-first ordering, so no close-time email goes out) — purely so the
+  closed ticket sits on the real customer's FD contact for cross-channel
+  history. The retention sweep is unchanged: by deletion time FD already
+  holds the full conversation.
+- **`/handoff`** (staff, in a ticket thread): moves the ticket to email
+  support. The Discord side closes (with a "we'll follow up by email" note to
+  the user) but the FD ticket **stays open** with the requester swapped to
+  the real email and a private note naming the handing-off staffer — a
+  Freshdesk agent takes it from there. Requires a linked account (no email,
+  no handoff).
+
+**Freshdesk-side setup**: the ticket-update **automation rule** (reply /
+public note / status change, performed by agent → webhook to the capability
+URL with the `x-freshdesk-secret` header) and the per-env **agent group** are
+**TF-managed** (`freshdesk.tf` in each talos stack, `slop-place/freshdesk`
+provider); the rule's events/actions JSON is validated by Freshdesk itself on
+first apply. What stays
+manual, once per account: create a dedicated **bot agent** and put its API
+key in the `YUCCA_FRESHDESK_API_KEY` item (with `YUCCA_FRESHDESK_URL` beside
+it), and put an **admin** agent's key in `YUCCA_FRESHDESK_ADMIN_API_KEY` —
+used only by TF for rule/group CRUD, never shipped to the cluster. Staging
+shares the account; its tickets carry the `staging` tag and its own group.
+
 ## Configuration
 
 The Discord surface itself is Terraform in **core-infra-tf** (community
@@ -153,6 +215,12 @@ uses the dev guild through `.env`.
 | `INTERNAL_SECRET` | Secret ← TF-generated (`random_password`, shared with yucca-api) |
 | `TRANSCRIPT_S3_ACCESS_KEY_ID` / `..._SECRET_ACCESS_KEY` | Secret ← ceph-stack-minted `*_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_*` |
 | `TRANSCRIPT_S3_ENDPOINT`, `TRANSCRIPT_S3_BUCKET` | cluster-settings |
+| `FRESHDESK_URL`, `FRESHDESK_API_KEY` | Secret ← `YUCCA_FRESHDESK_{URL,API_KEY}` (manual items) |
+| `FRESHDESK_GROUP_ID` | Secret ← TF (restapi-created per-env group) |
+| `FRESHDESK_WEBHOOK_SECRET` | Secret ← TF-generated (mirrored to 1P) |
+| webhook URL path segment | TF-generated → flux-system `cluster-secrets` Secret → HTTPRoute (`YUCCA_FRESHDESK_WEBHOOK_PATH` in 1P; never in git) |
+| `FRESHDESK_TAGS` | Secret (TF literal; `staging` on luke, empty on prod) |
+| `TICKET_MIRROR_DEBOUNCE_SECONDS` / `TICKET_MIRROR_MAX_WAIT_SECONDS` | staff-mirror coalescing window (120 / 600) |
 | `GRAFANA_URL` | defaults to grafana.futostatus.com; cluster-settings override |
 | `YUCCA_API_URL`, `WEB_URL` | HelmRelease env |
 | `TICKET_RETENTION_DAYS` | archive retention before transcript + delete (14) |
@@ -161,8 +229,8 @@ uses the dev guild through `.env`.
 
 | Concern | Location |
 |---|---|
-| Bot (gateway client, tickets, sweep) | `packages/futo-backups-bot/` |
-| Schema (`discordLinks`, `discordLinkRequests`) | `packages/yucca-api/src/schema/` |
+| Bot (gateway client, tickets, sweep, freshdesk sync) | `packages/futo-backups-bot/` |
+| Schema (`discordLinks`, `discordLinkRequests`, `discordTickets`) | `packages/yucca-api/src/schema/` |
 | Link endpoints (internal + public) | `packages/yucca-api/src/{controllers,services}/` |
 | Confirm page | `packages/web/src/routes/link/discord/` |
 | Chart / Flux wiring | `charts/apps/futo-backups-bot/`, `kubernetes/apps/`, `kubernetes/components/apps/` |

--- a/kubernetes/apps/base/futo-backups-bot/helmrelease.yaml
+++ b/kubernetes/apps/base/futo-backups-bot/helmrelease.yaml
@@ -29,11 +29,12 @@ spec:
       tag: ${YUCCA_IMAGE_TAG:=}
     # Drop the chart's dev-fixture Secret — the real DISCORD_BOT_TOKEN,
     # INTERNAL_SECRET, DISCORD_* ids (from the YUCCA_DISCORD_SUPPORT_IDS item
-    # core-infra-tf's discord apply writes), and TRANSCRIPT_S3_* credentials
-    # all arrive via the TF-provisioned futo-backups-bot Secret
-    # (tf .../secrets.tf). Until they land there the bot boots idle instead of
-    # crashing. NB: the ids must NOT appear under env: — explicit env beats
-    # envFrom, so an empty value here would shadow the Secret.
+    # core-infra-tf's discord apply writes), TRANSCRIPT_S3_* credentials, and
+    # FRESHDESK_* sync config all arrive via the TF-provisioned
+    # futo-backups-bot Secret (tf .../secrets.tf). Until they land there the
+    # bot boots idle instead of crashing. NB: the ids must NOT appear under
+    # env: — explicit env beats envFrom, so an empty value here would shadow
+    # the Secret.
     secretData: null
     env:
       - name: NODE_ENV

--- a/kubernetes/apps/base/httproutes/web.yaml
+++ b/kubernetes/apps/base/httproutes/web.yaml
@@ -35,6 +35,25 @@ spec:
       backendRefs:
         - name: yucca-api
           port: 3020
+    # Freshdesk automation webhooks (docs/discord-support.md). Capability URL:
+    # the path segment is a TF-generated secret arriving via the optional
+    # cluster-secrets Secret (never in git or CI; the default keeps secret-less
+    # renders working, and dev). The rewrite pins the bot's fixed mount, so the
+    # secret never reaches the pod; the x-freshdesk-secret header is the second
+    # wall, and the payload is an untrusted hint either way.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /hooks/${FRESHDESK_WEBHOOK_PATH:=freshdesk}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /hooks/freshdesk
+      backendRefs:
+        - name: futo-backups-bot
+          port: 3050
     - backendRefs:
         - name: yucca-web
           port: 5173

--- a/kubernetes/clusters/prod/htz-fsn1/apps.yaml
+++ b/kubernetes/clusters/prod/htz-fsn1/apps.yaml
@@ -11,7 +11,10 @@
 #
 # Substitution precedence (last wins): cluster-settings-generated (TF) ->
 # cluster-settings (human) -> image-versions (release-please-stamped prod
-# image pin; see image-versions.yaml); keys are disjoint by design. Injected
+# image pin; see image-versions.yaml), then cluster-secrets (TF-provisioned
+# Secret, optional: values like the Freshdesk webhook path that must never
+# appear in git or CI — defaults in the manifests keep secret-less renders
+# working); keys are disjoint by design. Injected
 # into the NESTED Kustomizations via the patches block (both layers' direct
 # objects use no ${vars} themselves).
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -44,6 +47,9 @@ spec:
         name: cluster-settings
       - kind: ConfigMap
         name: image-versions
+      - kind: Secret
+        name: cluster-secrets
+        optional: true
   patches:
     - target:
         group: kustomize.toolkit.fluxcd.io
@@ -62,6 +68,9 @@ spec:
                 name: cluster-settings
               - kind: ConfigMap
                 name: image-versions
+              - kind: Secret
+                name: cluster-secrets
+                optional: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -92,6 +101,9 @@ spec:
         name: cluster-settings
       - kind: ConfigMap
         name: image-versions
+      - kind: Secret
+        name: cluster-secrets
+        optional: true
   patches:
     - target:
         group: kustomize.toolkit.fluxcd.io
@@ -110,3 +122,6 @@ spec:
                 name: cluster-settings
               - kind: ConfigMap
                 name: image-versions
+              - kind: Secret
+                name: cluster-secrets
+                optional: true

--- a/kubernetes/clusters/staging/austin/apps.yaml
+++ b/kubernetes/clusters/staging/austin/apps.yaml
@@ -13,7 +13,9 @@
 #
 # Substitution precedence (last wins): cluster-settings-generated (TF) ->
 # cluster-settings (human) -> image-versions (CI-rewritten in-cluster, see the
-# flux-system ResourceSet); keys are disjoint by design. Injected into the
+# flux-system ResourceSet), then cluster-secrets (TF-provisioned Secret,
+# optional: values like the Freshdesk webhook path that must never appear in
+# git or CI — defaults in the manifests keep secret-less renders working). Keys are disjoint by design. Injected into the
 # NESTED Kustomizations via the patches block (both layers' direct objects use
 # no ${vars} themselves).
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -42,6 +44,9 @@ spec:
         name: cluster-settings
       - kind: ConfigMap
         name: image-versions
+      - kind: Secret
+        name: cluster-secrets
+        optional: true
   patches:
     - target:
         group: kustomize.toolkit.fluxcd.io
@@ -60,6 +65,9 @@ spec:
                 name: cluster-settings
               - kind: ConfigMap
                 name: image-versions
+              - kind: Secret
+                name: cluster-secrets
+                optional: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -86,6 +94,9 @@ spec:
         name: cluster-settings
       - kind: ConfigMap
         name: image-versions
+      - kind: Secret
+        name: cluster-secrets
+        optional: true
   patches:
     - target:
         group: kustomize.toolkit.fluxcd.io
@@ -104,3 +115,6 @@ spec:
                 name: cluster-settings
               - kind: ConfigMap
                 name: image-versions
+              - kind: Secret
+                name: cluster-secrets
+                optional: true

--- a/kubernetes/components/apps/networkpolicies.yaml
+++ b/kubernetes/components/apps/networkpolicies.yaml
@@ -5,7 +5,7 @@
 # NOT restricted in this pass (external RGW/OIDC/Polar egress needs FQDN rules
 # — a CiliumNetworkPolicy follow-up). Flow inventory:
 #   envoy (envoy-system)      → yucca-api:3020, web:5173, michael:3010,
-#                               meta:8080 (HTTPRoutes)
+#                               meta:8080, futo-backups-bot:3050 (HTTPRoutes)
 #   yucca-api → michael       = hairpin via the ingress VIP, so it ARRIVES as
 #                               envoy traffic — no direct pod-to-pod allow needed
 #   web (SSR)                 → yucca-api:3020
@@ -143,6 +143,17 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: yucca-admin-api
+      ports:
+        - { port: 3050, protocol: TCP }
+    # Freshdesk automation webhooks via the public gateway (/hooks/freshdesk
+    # HTTPRoute; x-freshdesk-secret guarded).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: envoy-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
       ports:
         - { port: 3050, protocol: TCP }
 ---

--- a/tf/.env
+++ b/tf/.env
@@ -99,3 +99,9 @@ export TF_VAR_yucca_discord_chat_channel_id="op://yucca_tf_staging/YUCCA_DISCORD
 export TF_VAR_yucca_discord_customer_role_id="op://yucca_tf_staging/YUCCA_DISCORD_SUPPORT_IDS/discord/customer_role_id"
 export TF_VAR_sietch_transcripts_access_key="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_ACCESS_KEY/password"
 export TF_VAR_sietch_transcripts_secret_key="op://yucca_tf_staging/SIETCH_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_SECRET_KEY/password"
+# Freshdesk ticket sync (docs/discord-support.md): the manual YUCCA_FRESHDESK_URL /
+# YUCCA_FRESHDESK_API_KEY items (core-infra-tf yucca-manual-secrets). The
+# webhook header secret and URL path segment are TF-generated (secrets.tf).
+export TF_VAR_yucca_freshdesk_url="op://yucca_tf_staging/YUCCA_FRESHDESK_URL/password"
+export TF_VAR_yucca_freshdesk_api_key="op://yucca_tf_staging/YUCCA_FRESHDESK_API_KEY/password"
+export TF_VAR_yucca_freshdesk_admin_api_key="op://yucca_tf_staging/YUCCA_FRESHDESK_ADMIN_API_KEY/password"

--- a/tf/.env.prod
+++ b/tf/.env.prod
@@ -99,3 +99,9 @@ export TF_VAR_vmauth_remote_write_password="op://shared_tf_prod/O11Y_VICTORIAMET
 # export TF_VAR_yucca_discord_customer_role_id="op://yucca_tf_prod/YUCCA_DISCORD_SUPPORT_IDS/discord/customer_role_id"
 # export TF_VAR_spice_transcripts_access_key="op://yucca_tf_prod/SPICE_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_ACCESS_KEY/password"
 # export TF_VAR_spice_transcripts_secret_key="op://yucca_tf_prod/SPICE_CEPH_S3_SVC_YUCCA_TRANSCRIPTS_SECRET_KEY/password"
+# Freshdesk ticket sync (docs/discord-support.md): the manual YUCCA_FRESHDESK_URL /
+# YUCCA_FRESHDESK_API_KEY items (core-infra-tf yucca-manual-secrets). The
+# webhook header secret and URL path segment are TF-generated (secrets.tf).
+export TF_VAR_yucca_freshdesk_url="op://yucca_tf_prod/YUCCA_FRESHDESK_URL/password"
+export TF_VAR_yucca_freshdesk_api_key="op://yucca_tf_prod/YUCCA_FRESHDESK_API_KEY/password"
+export TF_VAR_yucca_freshdesk_admin_api_key="op://yucca_tf_prod/YUCCA_FRESHDESK_ADMIN_API_KEY/password"

--- a/tf/deployment/prod/htz-fsn1/talos/.terraform.lock.hcl
+++ b/tf/deployment/prod/htz-fsn1/talos/.terraform.lock.hcl
@@ -131,3 +131,24 @@ provider "registry.opentofu.org/siderolabs/talos" {
     "zh:d218bab0f67a2a8b15add9b51df3d30f514b57e9a7c1d733ebe97966ea132acb",
   ]
 }
+
+provider "registry.terraform.io/slop-place/freshdesk" {
+  version     = "0.1.1"
+  constraints = "~> 0.1"
+  hashes = [
+    "h1:VyOKR4IfX4LWwW1Gv6rAa5A5x/h0IEDqKHL4hjliao8=",
+    "zh:19326bde07045235a0b41a1e0936a0929ee5b8a63d1856199dde34c1e2a2f641",
+    "zh:2221a63af314b9fae115bd455564e80105ead873856ebff4a9ae967fa91b9408",
+    "zh:239a2dc1433199705b587470fc86fc5d75761e2b6b2d640a112d416966676479",
+    "zh:4b7678d13a51cf6525ea7aec5788e2fcb96c8ef6b9f853937d224946f928ddb4",
+    "zh:74e33bffa31c664a3ae1cb20d098c804ff92c83fc042ec7d24b68f0ebd8f027f",
+    "zh:7943bf339e8f825b56c109ad92702102cdf4d07d577c48e45228e2f0d7889eaf",
+    "zh:7d4958ed366239294b085542859d5cc135b8041e1c5c5ab2a0b8c278c45df665",
+    "zh:91b8bcc4e58ba08f4e3380d07d6df32719d8464607cc1a0c56f75978cccd0cc9",
+    "zh:9deb669d3cd5dd598f83d51112987540c71c46f49b6d7841fd72a88fcb84f3f0",
+    "zh:ae3a04d72429f1b45db0cb1b1741ff007fc558c864c3b64652a48f1ab636f102",
+    "zh:d477d2919ff96f3d58be4df678f8eca52fb24254d53590fddca6b34d49d48215",
+    "zh:dd743e45b051dcff9b4f88bd99a6c5c24be9a614ee750625f900b4d0022634e8",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/tf/deployment/prod/htz-fsn1/talos/freshdesk.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/freshdesk.tf
@@ -1,0 +1,46 @@
+# Freshdesk-side webhook wiring, TF-owned end to end (slop-place/freshdesk
+# provider): the ticket-update automation rule and the per-env agent group.
+# The rule's two secret ingredients — the capability-URL path segment and the
+# x-freshdesk-secret header — are the random_password resources in
+# secrets.tf, so no human ever handles the values and CI plans mask them.
+# performer/events/actions are raw Automations-API JSON (the provider passes
+# them through); Freshdesk 400s with field-level errors if the shape drifts.
+# Scoping to discord tickets happens bot-side, so the rule has no conditions.
+
+locals {
+  # yucca-manual-secrets placeholders read back literally as REPLACE_ME —
+  # never let that masquerade as config.
+  freshdesk_url           = var.yucca_freshdesk_url == "REPLACE_ME" ? "" : var.yucca_freshdesk_url
+  freshdesk_api_key       = var.yucca_freshdesk_api_key == "REPLACE_ME" ? "" : var.yucca_freshdesk_api_key
+  freshdesk_admin_api_key = var.yucca_freshdesk_admin_api_key == "REPLACE_ME" ? "" : var.yucca_freshdesk_admin_api_key
+  freshdesk_rules_enabled = local.freshdesk_url != "" && local.freshdesk_admin_api_key != ""
+}
+
+# Bot-created tickets land here (FRESHDESK_GROUP_ID in the bot Secret).
+resource "freshdesk_group" "discord" {
+  count       = local.freshdesk_rules_enabled ? 1 : 0
+  name        = "FUTO Cloud"
+  description = "FUTO Backups Discord tickets, managed by yucca tf"
+}
+
+# rule_type 4 = observer (ticket updates); performer type 1 = agent.
+resource "freshdesk_automation_rule" "discord_webhook" {
+  count     = local.freshdesk_rules_enabled ? 1 : 0
+  name      = "yucca prod discord ticket sync"
+  rule_type = 4
+  active    = true
+  performer = jsonencode({ type = 1 })
+  events = jsonencode([
+    { field_name = "reply_sent" },
+    { field_name = "note_type", value = "public" },
+    { field_name = "status", from = "--", to = "--" },
+  ])
+  actions = jsonencode([{
+    field_name     = "trigger_webhook"
+    request_type   = "POST"
+    url            = "https://${var.yucca_app_domain}/hooks/${random_password.yucca_freshdesk_webhook_path.result}"
+    content_layout = 2
+    content        = "{\"ticket_id\": {{ticket.id}}}"
+    custom_headers = { "x-freshdesk-secret" = random_password.yucca_freshdesk_webhook_secret.result }
+  }])
+}

--- a/tf/deployment/prod/htz-fsn1/talos/providers.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/providers.tf
@@ -22,3 +22,11 @@ provider "kubernetes" {
 # 1Password — persists the kube/talosconfig into yucca_tf_prod (secrets.tf). Auth
 # via OP_SERVICE_ACCOUNT_TOKEN (op run).
 provider "onepassword" {}
+
+# Freshdesk automation rule + group (freshdesk.tf). Fallbacks keep the
+# provider configurable while the manual items are unfilled — never contacted,
+# every freshdesk resource is count-gated on the real config.
+provider "freshdesk" {
+  domain  = coalesce(local.freshdesk_url, "https://freshdesk.invalid")
+  api_key = coalesce(local.freshdesk_admin_api_key, "unset")
+}

--- a/tf/deployment/prod/htz-fsn1/talos/secrets.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/secrets.tf
@@ -240,11 +240,54 @@ resource "onepassword_item" "yucca_internal_secret" {
   password = random_password.yucca_internal_secret.result
 }
 
+# Freshdesk webhook credentials, both TF-generated and mirrored into 1P: the
+# header secret rides the bot Secret; the capability-URL path segment reaches
+# the HTTPRoute via cluster-secrets (below) so it never appears in git or CI.
+resource "random_password" "yucca_freshdesk_webhook_secret" {
+  length  = 48
+  special = false
+}
+
+resource "onepassword_item" "yucca_freshdesk_webhook_secret" {
+  vault    = data.onepassword_vault.prod.uuid
+  title    = "YUCCA_FRESHDESK_WEBHOOK_SECRET"
+  category = "password"
+
+  password = random_password.yucca_freshdesk_webhook_secret.result
+}
+
+resource "random_password" "yucca_freshdesk_webhook_path" {
+  length  = 32
+  special = false
+}
+
+resource "onepassword_item" "yucca_freshdesk_webhook_path" {
+  vault    = data.onepassword_vault.prod.uuid
+  title    = "YUCCA_FRESHDESK_WEBHOOK_PATH"
+  category = "password"
+
+  password = random_password.yucca_freshdesk_webhook_path.result
+}
+
+# Substituted into the Flux tree (apps.yaml postBuild, optional Secret source):
+# the one config channel that bypasses the git-committed cluster-settings.
+resource "kubernetes_secret_v1" "cluster_secrets" {
+  metadata {
+    name      = "cluster-secrets"
+    namespace = "flux-system"
+  }
+  data = {
+    FRESHDESK_WEBHOOK_PATH = random_password.yucca_freshdesk_webhook_path.result
+  }
+  depends_on = [helm_release.flux_operator]
+}
+
 # futo-backups-bot: Discord gateway token + the shared internal-API secret
-# + spice RGW keys for ticket transcripts. Deliberately no precondition: the
-# token and S3 keys default empty so this Secret can land before their 1P
-# items exist — the bot idles without a token and skips the archive sweep
-# without S3 keys.
+# + spice RGW keys for ticket transcripts + Freshdesk sync credentials.
+# Deliberately no precondition: the token, S3 keys and Freshdesk creds default
+# empty so this Secret can land before their 1P items exist — the bot idles
+# without a token, skips the archive sweep without S3 keys and leaves the
+# Freshdesk sync dormant without creds.
 resource "kubernetes_secret_v1" "futo_backups_bot" {
   metadata {
     name      = "futo-backups-bot"
@@ -261,6 +304,12 @@ resource "kubernetes_secret_v1" "futo_backups_bot" {
     DISCORD_CUSTOMER_ROLE_ID        = var.yucca_discord_customer_role_id
     TRANSCRIPT_S3_ACCESS_KEY_ID     = var.spice_transcripts_access_key
     TRANSCRIPT_S3_SECRET_ACCESS_KEY = var.spice_transcripts_secret_key
+    # REPLACE_ME-guarded locals (freshdesk.tf) — an unfilled placeholder
+    # keeps the sync dormant.
+    FRESHDESK_URL            = local.freshdesk_url
+    FRESHDESK_API_KEY        = local.freshdesk_api_key
+    FRESHDESK_GROUP_ID       = try(tostring(freshdesk_group.discord[0].id), "")
+    FRESHDESK_WEBHOOK_SECRET = random_password.yucca_freshdesk_webhook_secret.result
   }
 }
 

--- a/tf/deployment/prod/htz-fsn1/talos/variables.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/variables.tf
@@ -268,6 +268,32 @@ variable "spice_transcripts_secret_key" {
   default     = ""
 }
 
+variable "yucca_freshdesk_url" {
+  description = "Freshdesk base URL for the futo-backups-bot ticket sync (manual YUCCA_FRESHDESK_URL item). Empty = the sync stays dormant (placeholder items until filled)."
+  type        = string
+  default     = ""
+}
+
+variable "yucca_freshdesk_api_key" {
+  description = "Freshdesk API key of the dedicated bot agent (manual YUCCA_FRESHDESK_API_KEY item)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "yucca_freshdesk_admin_api_key" {
+  description = "Freshdesk API key of an ADMIN agent, used only by the freshdesk provider to manage the automation rule and group (manual YUCCA_FRESHDESK_ADMIN_API_KEY item; never lands in the cluster). Empty = the rules are unmanaged."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "yucca_app_domain" {
+  description = "Public app domain the Freshdesk webhook rule targets. Must match APP_DOMAIN in the cluster-settings.generated.yaml of this cluster."
+  type        = string
+  default     = "backups.futo.cloud"
+}
+
 variable "yucca_discord_guild_id" {
   description = "Discord server id for futo-backups-bot (YUCCA_DISCORD_SUPPORT_IDS, written by core-infra-tf's discord apply). Empty = the bot idles."
   type        = string

--- a/tf/deployment/prod/htz-fsn1/talos/versions.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/versions.tf
@@ -32,5 +32,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    # Freshdesk automation rule + agent group (freshdesk.tf).
+    freshdesk = {
+      source  = "registry.terraform.io/slop-place/freshdesk"
+      version = "~> 0.1"
+    }
   }
 }

--- a/tf/deployment/staging/austin/talos/.terraform.lock.hcl
+++ b/tf/deployment/staging/austin/talos/.terraform.lock.hcl
@@ -131,3 +131,24 @@ provider "registry.opentofu.org/siderolabs/talos" {
     "zh:d218bab0f67a2a8b15add9b51df3d30f514b57e9a7c1d733ebe97966ea132acb",
   ]
 }
+
+provider "registry.terraform.io/slop-place/freshdesk" {
+  version     = "0.1.1"
+  constraints = "~> 0.1"
+  hashes = [
+    "h1:VyOKR4IfX4LWwW1Gv6rAa5A5x/h0IEDqKHL4hjliao8=",
+    "zh:19326bde07045235a0b41a1e0936a0929ee5b8a63d1856199dde34c1e2a2f641",
+    "zh:2221a63af314b9fae115bd455564e80105ead873856ebff4a9ae967fa91b9408",
+    "zh:239a2dc1433199705b587470fc86fc5d75761e2b6b2d640a112d416966676479",
+    "zh:4b7678d13a51cf6525ea7aec5788e2fcb96c8ef6b9f853937d224946f928ddb4",
+    "zh:74e33bffa31c664a3ae1cb20d098c804ff92c83fc042ec7d24b68f0ebd8f027f",
+    "zh:7943bf339e8f825b56c109ad92702102cdf4d07d577c48e45228e2f0d7889eaf",
+    "zh:7d4958ed366239294b085542859d5cc135b8041e1c5c5ab2a0b8c278c45df665",
+    "zh:91b8bcc4e58ba08f4e3380d07d6df32719d8464607cc1a0c56f75978cccd0cc9",
+    "zh:9deb669d3cd5dd598f83d51112987540c71c46f49b6d7841fd72a88fcb84f3f0",
+    "zh:ae3a04d72429f1b45db0cb1b1741ff007fc558c864c3b64652a48f1ab636f102",
+    "zh:d477d2919ff96f3d58be4df678f8eca52fb24254d53590fddca6b34d49d48215",
+    "zh:dd743e45b051dcff9b4f88bd99a6c5c24be9a614ee750625f900b4d0022634e8",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/tf/deployment/staging/austin/talos/freshdesk.tf
+++ b/tf/deployment/staging/austin/talos/freshdesk.tf
@@ -1,0 +1,46 @@
+# Freshdesk-side webhook wiring, TF-owned end to end (slop-place/freshdesk
+# provider): the ticket-update automation rule and the per-env agent group.
+# The rule's two secret ingredients — the capability-URL path segment and the
+# x-freshdesk-secret header — are the random_password resources in
+# secrets.tf, so no human ever handles the values and CI plans mask them.
+# performer/events/actions are raw Automations-API JSON (the provider passes
+# them through); Freshdesk 400s with field-level errors if the shape drifts.
+# Scoping to discord tickets happens bot-side, so the rule has no conditions.
+
+locals {
+  # yucca-manual-secrets placeholders read back literally as REPLACE_ME —
+  # never let that masquerade as config.
+  freshdesk_url           = var.yucca_freshdesk_url == "REPLACE_ME" ? "" : var.yucca_freshdesk_url
+  freshdesk_api_key       = var.yucca_freshdesk_api_key == "REPLACE_ME" ? "" : var.yucca_freshdesk_api_key
+  freshdesk_admin_api_key = var.yucca_freshdesk_admin_api_key == "REPLACE_ME" ? "" : var.yucca_freshdesk_admin_api_key
+  freshdesk_rules_enabled = local.freshdesk_url != "" && local.freshdesk_admin_api_key != ""
+}
+
+# Bot-created tickets land here (FRESHDESK_GROUP_ID in the bot Secret).
+resource "freshdesk_group" "discord" {
+  count       = local.freshdesk_rules_enabled ? 1 : 0
+  name        = "FUTO Cloud (Staging)"
+  description = "FUTO Backups Discord tickets from staging, managed by yucca tf"
+}
+
+# rule_type 4 = observer (ticket updates); performer type 1 = agent.
+resource "freshdesk_automation_rule" "discord_webhook" {
+  count     = local.freshdesk_rules_enabled ? 1 : 0
+  name      = "yucca staging discord ticket sync"
+  rule_type = 4
+  active    = true
+  performer = jsonencode({ type = 1 })
+  events = jsonencode([
+    { field_name = "reply_sent" },
+    { field_name = "note_type", value = "public" },
+    { field_name = "status", from = "--", to = "--" },
+  ])
+  actions = jsonencode([{
+    field_name     = "trigger_webhook"
+    request_type   = "POST"
+    url            = "https://${var.yucca_app_domain}/hooks/${random_password.yucca_freshdesk_webhook_path[0].result}"
+    content_layout = 2
+    content        = "{\"ticket_id\": {{ticket.id}}}"
+    custom_headers = { "x-freshdesk-secret" = random_password.yucca_freshdesk_webhook_secret[0].result }
+  }])
+}

--- a/tf/deployment/staging/austin/talos/providers.tf
+++ b/tf/deployment/staging/austin/talos/providers.tf
@@ -34,3 +34,11 @@ provider "kubernetes" {
 # service-account token in OP_SERVICE_ACCOUNT_TOKEN (injected by `op run`, the
 # same token the rest of the stack uses); no Connect host needed.
 provider "onepassword" {}
+
+# Freshdesk automation rule + group (freshdesk.tf). Fallbacks keep the
+# provider configurable while the manual items are unfilled — never contacted,
+# every freshdesk resource is count-gated on the real config.
+provider "freshdesk" {
+  domain  = coalesce(local.freshdesk_url, "https://freshdesk.invalid")
+  api_key = coalesce(local.freshdesk_admin_api_key, "unset")
+}

--- a/tf/deployment/staging/austin/talos/secrets.tf
+++ b/tf/deployment/staging/austin/talos/secrets.tf
@@ -237,6 +237,53 @@ resource "onepassword_item" "yucca_internal_secret" {
   password = random_password.yucca_internal_secret[0].result
 }
 
+# Freshdesk webhook credentials, both TF-generated and mirrored into 1P: the
+# header secret rides the bot Secret; the capability-URL path segment reaches
+# the HTTPRoute via cluster-secrets (below) so it never appears in git or CI.
+resource "random_password" "yucca_freshdesk_webhook_secret" {
+  count   = local.provision_secrets ? 1 : 0
+  length  = 48
+  special = false
+}
+
+resource "onepassword_item" "yucca_freshdesk_webhook_secret" {
+  count    = local.provision_secrets ? 1 : 0
+  vault    = data.onepassword_vault.staging[0].uuid
+  title    = "YUCCA_FRESHDESK_WEBHOOK_SECRET"
+  category = "password"
+
+  password = random_password.yucca_freshdesk_webhook_secret[0].result
+}
+
+resource "random_password" "yucca_freshdesk_webhook_path" {
+  count   = local.provision_secrets ? 1 : 0
+  length  = 32
+  special = false
+}
+
+resource "onepassword_item" "yucca_freshdesk_webhook_path" {
+  count    = local.provision_secrets ? 1 : 0
+  vault    = data.onepassword_vault.staging[0].uuid
+  title    = "YUCCA_FRESHDESK_WEBHOOK_PATH"
+  category = "password"
+
+  password = random_password.yucca_freshdesk_webhook_path[0].result
+}
+
+# Substituted into the Flux tree (apps.yaml postBuild, optional Secret source):
+# the one config channel that bypasses the git-committed cluster-settings.
+resource "kubernetes_secret_v1" "cluster_secrets" {
+  count = local.provision_secrets ? 1 : 0
+  metadata {
+    name      = "cluster-secrets"
+    namespace = "flux-system"
+  }
+  data = {
+    FRESHDESK_WEBHOOK_PATH = random_password.yucca_freshdesk_webhook_path[0].result
+  }
+  depends_on = [helm_release.flux_operator]
+}
+
 # futo-backups-bot: Discord gateway token + the shared internal-API secret
 # + sietch RGW keys for ticket transcripts. Deliberately no precondition: the
 # token and S3 keys default empty so this Secret can land before their 1P
@@ -259,6 +306,15 @@ resource "kubernetes_secret_v1" "futo_backups_bot" {
     DISCORD_CUSTOMER_ROLE_ID        = var.yucca_discord_customer_role_id
     TRANSCRIPT_S3_ACCESS_KEY_ID     = var.sietch_transcripts_access_key
     TRANSCRIPT_S3_SECRET_ACCESS_KEY = var.sietch_transcripts_secret_key
+    # REPLACE_ME-guarded locals (freshdesk.tf) — an unfilled placeholder
+    # keeps the sync dormant.
+    FRESHDESK_URL            = local.freshdesk_url
+    FRESHDESK_API_KEY        = local.freshdesk_api_key
+    FRESHDESK_GROUP_ID       = try(tostring(freshdesk_group.discord[0].id), "")
+    FRESHDESK_WEBHOOK_SECRET = random_password.yucca_freshdesk_webhook_secret[0].result
+    # Staging shares the prod Freshdesk account; the tag keeps its tickets
+    # filterable in the agent view.
+    FRESHDESK_TAGS = "staging"
   }
 }
 

--- a/tf/deployment/staging/austin/talos/variables.tf
+++ b/tf/deployment/staging/austin/talos/variables.tf
@@ -241,6 +241,32 @@ variable "sietch_transcripts_secret_key" {
   default     = ""
 }
 
+variable "yucca_freshdesk_url" {
+  description = "Freshdesk base URL for the futo-backups-bot ticket sync (manual YUCCA_FRESHDESK_URL item). Empty = the sync stays dormant (placeholder items until filled)."
+  type        = string
+  default     = ""
+}
+
+variable "yucca_freshdesk_api_key" {
+  description = "Freshdesk API key of the dedicated bot agent (manual YUCCA_FRESHDESK_API_KEY item)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "yucca_freshdesk_admin_api_key" {
+  description = "Freshdesk API key of an ADMIN agent, used only by the freshdesk provider to manage the automation rule and group (manual YUCCA_FRESHDESK_ADMIN_API_KEY item; never lands in the cluster). Empty = the rules are unmanaged."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "yucca_app_domain" {
+  description = "Public app domain the Freshdesk webhook rule targets. Must match APP_DOMAIN in the cluster-settings.generated.yaml of this cluster."
+  type        = string
+  default     = "staging.backups.futo.cloud"
+}
+
 variable "yucca_discord_guild_id" {
   description = "Discord server id for futo-backups-bot (YUCCA_DISCORD_SUPPORT_IDS, written by core-infra-tf's discord apply). Empty = the bot idles."
   type        = string

--- a/tf/deployment/staging/austin/talos/versions.tf
+++ b/tf/deployment/staging/austin/talos/versions.tf
@@ -29,5 +29,10 @@ terraform {
       source  = "1Password/onepassword"
       version = "~> 2.1"
     }
+    # Freshdesk automation rule + agent group (freshdesk.tf).
+    freshdesk = {
+      source  = "registry.terraform.io/slop-place/freshdesk"
+      version = "~> 0.1"
+    }
   }
 }


### PR DESCRIPTION
Public /hooks/freshdesk HTTPRoute, envoy ingress allow, FRESHDESK\_\* secrets plumbing and docs.

- `main` <!-- branch-stack -->
  - \#576
    - \#577
      - \#578 :point\_left:
