### PR TITLE
chore(tf): consume the freshdesk-stack webhook credentials in the talos stacks

### DIFF
--- a/tf/.env
+++ b/tf/.env
@@ -105,7 +105,7 @@ export TF_VAR_sietch_transcripts_secret_key="op://yucca_tf_staging/SIETCH_CEPH_S
 export TF_VAR_yucca_freshdesk_url="op://yucca_tf_staging/YUCCA_FRESHDESK_URL/password"
 export TF_VAR_yucca_freshdesk_api_key="op://yucca_tf_staging/YUCCA_FRESHDESK_API_KEY/password"
 export TF_VAR_yucca_freshdesk_admin_api_key="op://yucca_tf_staging/YUCCA_FRESHDESK_ADMIN_API_KEY/password"
-# Minted by the staging/global/freshdesk stack — uncomment after its first apply.
-# export TF_VAR_yucca_freshdesk_webhook_secret="op://yucca_tf_staging/YUCCA_FRESHDESK_WEBHOOK_SECRET/password"
-# export TF_VAR_yucca_freshdesk_webhook_path="op://yucca_tf_staging/YUCCA_FRESHDESK_WEBHOOK_PATH/password"
-# export TF_VAR_yucca_freshdesk_group_id="op://yucca_tf_staging/YUCCA_FRESHDESK_GROUP_ID/password"
+# Minted by the staging/global/freshdesk stack.
+export TF_VAR_yucca_freshdesk_webhook_secret="op://yucca_tf_staging/YUCCA_FRESHDESK_WEBHOOK_SECRET/password"
+export TF_VAR_yucca_freshdesk_webhook_path="op://yucca_tf_staging/YUCCA_FRESHDESK_WEBHOOK_PATH/password"
+export TF_VAR_yucca_freshdesk_group_id="op://yucca_tf_staging/YUCCA_FRESHDESK_GROUP_ID/password"

--- a/tf/.env.prod
+++ b/tf/.env.prod
@@ -105,7 +105,7 @@ export TF_VAR_vmauth_remote_write_password="op://shared_tf_prod/O11Y_VICTORIAMET
 export TF_VAR_yucca_freshdesk_url="op://yucca_tf_prod/YUCCA_FRESHDESK_URL/password"
 export TF_VAR_yucca_freshdesk_api_key="op://yucca_tf_prod/YUCCA_FRESHDESK_API_KEY/password"
 export TF_VAR_yucca_freshdesk_admin_api_key="op://yucca_tf_prod/YUCCA_FRESHDESK_ADMIN_API_KEY/password"
-# Minted by the prod/global/freshdesk stack — uncomment after its first apply.
-# export TF_VAR_yucca_freshdesk_webhook_secret="op://yucca_tf_prod/YUCCA_FRESHDESK_WEBHOOK_SECRET/password"
-# export TF_VAR_yucca_freshdesk_webhook_path="op://yucca_tf_prod/YUCCA_FRESHDESK_WEBHOOK_PATH/password"
-# export TF_VAR_yucca_freshdesk_group_id="op://yucca_tf_prod/YUCCA_FRESHDESK_GROUP_ID/password"
+# Minted by the prod/global/freshdesk stack.
+export TF_VAR_yucca_freshdesk_webhook_secret="op://yucca_tf_prod/YUCCA_FRESHDESK_WEBHOOK_SECRET/password"
+export TF_VAR_yucca_freshdesk_webhook_path="op://yucca_tf_prod/YUCCA_FRESHDESK_WEBHOOK_PATH/password"
+export TF_VAR_yucca_freshdesk_group_id="op://yucca_tf_prod/YUCCA_FRESHDESK_GROUP_ID/password"

--- a/tf/deployment/prod/htz-fsn1/talos/variables.tf
+++ b/tf/deployment/prod/htz-fsn1/talos/variables.tf
@@ -289,7 +289,7 @@ variable "yucca_freshdesk_admin_api_key" {
 }
 
 variable "yucca_freshdesk_webhook_secret" {
-  description = "Webhook header secret minted by the prod/global/freshdesk stack (YUCCA_FRESHDESK_WEBHOOK_SECRET); refs stay commented in tf/.env.prod until its first apply."
+  description = "Webhook header secret minted by the prod/global/freshdesk stack (YUCCA_FRESHDESK_WEBHOOK_SECRET)."
   type        = string
   sensitive   = true
   default     = ""

--- a/tf/deployment/staging/austin/talos/variables.tf
+++ b/tf/deployment/staging/austin/talos/variables.tf
@@ -262,7 +262,7 @@ variable "yucca_freshdesk_admin_api_key" {
 }
 
 variable "yucca_freshdesk_webhook_secret" {
-  description = "Webhook header secret minted by the staging/global/freshdesk stack (YUCCA_FRESHDESK_WEBHOOK_SECRET); refs stay commented in tf/.env until its first apply."
+  description = "Webhook header secret minted by the staging/global/freshdesk stack (YUCCA_FRESHDESK_WEBHOOK_SECRET)."
   type        = string
   sensitive   = true
   default     = ""


### PR DESCRIPTION
Uncomments the three op\:// refs; the global/freshdesk applies mint the items first.

- `main` <!-- branch-stack -->
  - \#582 :point\_left:
