### PR TITLE
fix(futo-backups-bot): fall back to a generic agent name when the profile read is forbidden

### DIFF
--- a/packages/futo-backups-bot/src/repositories/freshdesk.repository.ts
+++ b/packages/futo-backups-bot/src/repositories/freshdesk.repository.ts
@@ -139,8 +139,10 @@ export class FreshdeskRepository {
     if (cached) {
       return cached;
     }
-    const response = await this.request('GET', `/api/v2/agents/${agentId}`, undefined, [404]);
-    const name = response.status === 404 ? 'Support' : agentSchema.parse(await response.json()).contact.name;
+    // Reading other agents' profiles needs privileges the group-scoped bot
+    // key does not have — 403 falls back like 404 instead of failing ingest.
+    const response = await this.request('GET', `/api/v2/agents/${agentId}`, undefined, [403, 404]);
+    const name = response.ok ? agentSchema.parse(await response.json()).contact.name : 'Support';
     this.agentNames.set(agentId, name);
     return name;
   }


### PR DESCRIPTION
The group-scoped bot key 403s on GET /agents/:id, which aborted webhook ingest; treat it like 404 and post as Support.

- `main` <!-- branch-stack -->
  - \#584 :point\_left:
