### PR TITLE
ci: build changed app images on pull requests

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,73 @@
+name: Image Build Check
+
+# Deploy builds images only on merge to main, so a broken Dockerfile ships its
+# failure past review and surfaces post-merge (fail-fast is off there; the bad
+# app just never delivers). This builds changed apps' images on the PR, without
+# pushing, so the Dockerfile is exercised where the diff is still reviewable.
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - '.github/workflows/build-check.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed apps
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      apps: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # Filter names are app names; each app's Dockerfile lives at
+      # packages/<app>/Dockerfile, which is what the build job derives.
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            yucca-api: ["packages/yucca-api/**"]
+            yucca-admin-api: ["packages/yucca-admin-api/**"]
+            yucca-metrics-worker: ["packages/yucca-metrics-worker/**"]
+            futo-backups-bot: ["packages/futo-backups-bot/**"]
+            web: ["packages/web/**"]
+            michael: ["packages/michael/**"]
+            columbo: ["packages/columbo/**"]
+            monk: ["packages/monk/**"]
+
+  build:
+    name: Build ${{ matrix.app }}
+    needs: changes
+    if: needs.changes.outputs.apps != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        app: ${{ fromJSON(needs.changes.outputs.apps) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # cache-from only: reads the per-app cache Deploy maintains on main, and
+      # writes nothing back, so PR builds stay fast without polluting it.
+      - name: Build (no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: packages/${{ matrix.app }}/Dockerfile
+          push: false
+          cache-from: type=gha,scope=${{ matrix.app }}

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -57,9 +57,9 @@ jobs:
             yucca-metrics-worker: *node
             futo-backups-bot: *node
             web: *node
-            michael: ['packages/michael/**']
-            columbo: ['packages/columbo/**']
-            monk: ['packages/monk/**']
+            michael: ['packages/michael/**', '.dockerignore']
+            columbo: ['packages/columbo/**', '.dockerignore']
+            monk: ['packages/monk/**', '.dockerignore']
 
   build:
     name: Build ${{ matrix.app }}

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -59,7 +59,6 @@ jobs:
             web: *node
             michael: ['packages/michael/**', '.dockerignore']
             columbo: ['packages/columbo/**', '.dockerignore']
-            monk: ['packages/monk/**', '.dockerignore']
 
   build:
     name: Build ${{ matrix.app }}

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,6 +12,7 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.npmrc'
+      - '.dockerignore'
       - '.mise/**'
       - '.github/workflows/build-check.yml'
 
@@ -50,6 +51,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - '.npmrc'
+              - '.dockerignore'
               - '.mise/**'
             yucca-admin-api: *node
             yucca-metrics-worker: *node

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     paths:
       - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.npmrc'
+      - '.mise/**'
       - '.github/workflows/build-check.yml'
 
 concurrency:
@@ -30,18 +35,29 @@ jobs:
           persist-credentials: false
       # Filter names are app names; each app's Dockerfile lives at
       # packages/<app>/Dockerfile, which is what the build job derives.
+      #
+      # The node images build from `COPY . ./` plus the mise toolchain, so any
+      # package or root-manifest change is an input to all five and per-app
+      # precision would be fiction; only the Go images, which copy nothing but
+      # their own package, filter narrowly.
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
-            yucca-api: ["packages/yucca-api/**"]
-            yucca-admin-api: ["packages/yucca-admin-api/**"]
-            yucca-metrics-worker: ["packages/yucca-metrics-worker/**"]
-            futo-backups-bot: ["packages/futo-backups-bot/**"]
-            web: ["packages/web/**"]
-            michael: ["packages/michael/**"]
-            columbo: ["packages/columbo/**"]
-            monk: ["packages/monk/**"]
+            yucca-api: &node
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - '.mise/**'
+            yucca-admin-api: *node
+            yucca-metrics-worker: *node
+            futo-backups-bot: *node
+            web: *node
+            michael: ['packages/michael/**']
+            columbo: ['packages/columbo/**']
+            monk: ['packages/monk/**']
 
   build:
     name: Build ${{ matrix.app }}


### PR DESCRIPTION
Deploy builds images only on merge to main, so a broken Dockerfile surfaces post-merge with no PR signal. Changed apps' images now build (without pushing) on the PR itself: dorny/paths-filter turns per-package diffs into the build matrix, and cache-from reads the per-app cache Deploy maintains on main so PR builds stay fast without writing anything back. Apps whose packages did not change build nothing, and PRs outside packages/ skip the workflow entirely.

- `main` <!-- branch-stack -->
  - \#589 :point\_left:
