### PR TITLE
test(yucca-admin-api): expect discordLink in the single-user response

### DIFF
--- a/packages/yucca-admin-api/test/user.integration-spec.ts
+++ b/packages/yucca-admin-api/test/user.integration-spec.ts
@@ -92,6 +92,7 @@ describe('UserController (e2e)', () => {
         .expect(200);
 
       expect(body).toEqual({
+        discordLink: null,
         user: {
           id: user.id,
           sub: user.sub,


### PR DESCRIPTION
GET /user/:id returns `discordLink` since #585 (`user.service.ts` builds `{ user, discordLink }`), but the integration spec still expects the bare `user` shape, so the suite fails on main and every open PR inherits the red check:

- expected shape -> `{ discordLink: null, user: {...} }`

* `main` <!-- branch-stack -->
  - \#590 :point\_left:
